### PR TITLE
Qt clipboard access for `ToolbarPlot` data 

### DIFF
--- a/chaco/tools/toolbars/toolbar_buttons.py
+++ b/chaco/tools/toolbars/toolbar_buttons.py
@@ -198,6 +198,8 @@ class ExportDataToClipboardButton(ToolbarButton):
     def perform(self, event):
         if ETSConfig.toolkit == 'wx':
             self._perform_wx()
+        elif ETSConfig.toolkit == 'qt4':
+            self._perform_qt()
         else:
             pass
 
@@ -241,3 +243,11 @@ class ExportDataToClipboardButton(ToolbarButton):
             wx.TheClipboard.Close()
         else:
             wx.MessageBox("Unable to open the clipboard.", "Error")
+
+    def _perform_qt(self):
+        from pyface.qt import QtGui
+
+        indices, values = self._get_data_from_plots()
+        data_str = self._serialize_data(indices, values)
+
+        QtGui.QApplication.clipboard().setText(data_str)


### PR DESCRIPTION
Add support for copying plot data to the clipboard using the Qt GUI. Tested using PySide 1.0.4 on Win 7 64 bit w/ Python 2.7.0 and ETS 4.0.0.
