### PR TITLE
DataLabel tweaks

### DIFF
--- a/chaco/data_label.py
+++ b/chaco/data_label.py
@@ -126,6 +126,13 @@ class DataLabel(ToolTip):
     # data space values.
     label_format = Str("(%(x)f, %(y)f)")
 
+    # The text to show on the label, or above the coordinates for the label, if
+    # show_label_coords is True
+    label_text = Str
+
+    # Flag whether to show coordinates with the label or not.
+    show_label_coords = Bool(True)
+
     # Does the label clip itself against the main plot area?  If not, then
     # the label draws into the padding area (where axes typically reside).
     clip_to_plot = Bool(True)
@@ -172,7 +179,8 @@ class DataLabel(ToolTip):
     # is 'auto', then the label uses **label_position**.  Otherwise, it treats
     # the label as if it were at the label position indicated by this attribute.
     arrow_root = Trait("auto", "auto", "top left", "top right", "bottom left",
-                       "bottom right", "center")
+                       "bottom right", "top center", "bottom center",
+                       "left center", "right center")
 
     # The minimum length of the arrow before it will be drawn.  By default,
     # the arrow will be drawn regardless of how short it is.
@@ -199,6 +207,10 @@ class DataLabel(ToolTip):
         "top right": "bottom left",
         "bottom left": "top right",
         "bottom right": "top left",
+        "top center": "bottom center",
+        "bottom center": "top center",
+        "left center": "right center",
+        "right center": "left center"
         }
 
     _root_positions = {
@@ -206,6 +218,10 @@ class DataLabel(ToolTip):
         "bottom left": ("x", "y"),
         "top right": ("x2", "y2"),
         "top left": ("x", "y2"),
+        "top center": ("x", "y"),
+        "bottom center": ("x", "y2"),
+        "left center": ("x", "y"),
+        "right center": ("x2", "y2"),
         }
 
 
@@ -294,9 +310,13 @@ class DataLabel(ToolTip):
                     self.outer_y = sy - self.outer_height - 1
                 elif "top" in orientation:
                     self.outer_y = sy
-            if orientation == "center":
-                self.x = sx - (self.width/2)
-                self.y = sy - (self.height/2)
+            if "center" in orientation:
+                if " " not in orientation:
+                    self.x = sx - (self.width/2)
+                    self.y = sy - (self.height/2)
+                else:
+                    self.x = sx - (self.outer_width/2) - 1
+                    self.y = sy - (self.outer_height/2) - 1
         else:
             self.x = sx + self.label_position[0]
             self.y = sy + self.label_position[1]
@@ -311,10 +331,19 @@ class DataLabel(ToolTip):
     def _label_format_changed(self, old, new):
         self._create_new_labels()
 
+    def _label_text_changed(self, old, new):
+        self._create_new_labels()
+
+    def _show_label_coords_changed(self, old, new):
+        self._create_new_labels()
+
     def _create_new_labels(self):
         pt = self.data_point
         if pt is not None:
-            self.lines = [self.label_format % {"x": pt[0], "y": pt[1]}]
+            if self.show_label_coords:
+                self.lines = [self.label_text, self.label_format % {"x": pt[0], "y": pt[1]}]
+            else:
+                self.lines = [self.label_text]
 
     def _component_changed(self, old, new):
         for comp, attach in ((old, False), (new, True)):

--- a/chaco/tools/data_label_tool.py
+++ b/chaco/tools/data_label_tool.py
@@ -27,7 +27,7 @@ class DataLabelTool(DragTool):
 
     # This is used in the auto_arrow_root = 'corners' case.
     _corner_names = ("bottom left", "bottom right", "top right", "top left",
-                     "center", "center", "center", "center")
+                     "top center", "bottom center", "left center", "right center")
 
     def is_draggable(self, x, y):
         """ Returns whether the (x,y) position is in a region that is OK to


### PR DESCRIPTION
Tweaks to DataLabel to allow arbitrary text in data labels, and a hack to get arrow bases to behave better.  Still needs work on arrow root "centering," but it works better for my purposes.

Arrow bases were being centered completely (at the center of the text of the label) rather than beginning at the "top center," "right center," etc. of the label bounds.  For now it just snaps to a corner.

Also added arbitrary text abilities to data labels.  

Seems like the api is showing some artifacts of its evolution:
One can choose:
- coordinates only: label_text=""
- text only: show_label_coords=False
- both coordinates and text: show_label_coords=True, and any string for label_text

This approach does have the advantage of being backward compatible, though.
