### PR TITLE
Reset mapper range settings when zoom is reset

### DIFF
--- a/examples/demo/updating_plot/updating_plot1.py
+++ b/examples/demo/updating_plot/updating_plot1.py
@@ -49,13 +49,7 @@ class PlotFrame(DemoFrame):
         x = self.x_values[:self.current_index]
         y = self.y_values[:self.current_index]
 
-        value_range = None
-        index_range = None
         plot = create_line_plot((x,y), color="red", width=2.0)
-        value_range = plot.value_mapper.range
-        index_range = plot.index_mapper.range
-        index_range.low = -5
-        index_range.high = 15
         plot.padding = 50
         plot.fill_padding = True
         plot.bgcolor = "white"


### PR DESCRIPTION
I've modified BetterSelectingZoom so that the mapper range settings are reset to the original values when the zoom state is reset or pushed back to the start. This fixes a bug (feature?) where adding a ZoomTool to a plot with auto-resizing ranges (or some other non-static range) would make the ranges static even when resetting the zoom state. This fix is nearly copied from SimpleZoom.

I've also modified examples/demo/updating_plot/updating_plot1.py, which according to the module documentation, was intended to demonstrate this feature.
