### PR TITLE
Documentation update for tutorial2_ipython.py , how to call ipython with GUI thread.

### DIFF
--- a/examples/tutorials/tutorial2_ipython.py
+++ b/examples/tutorials/tutorial2_ipython.py
@@ -6,7 +6,7 @@ components in Chaco.
 To run this tutorial, change to the directory where this file is located,
 then invoke IPython:
 
-  ipython -wthread
+  ipython --gui=wx
 
 Then just run this tutorial:
 


### PR DESCRIPTION
changed ipython command for new format for GUI thread: --gui=wx instead of -wthread
