### PR TITLE
text_box_overlay supports a rotate_angle trait

### DIFF
--- a/chaco/label.py
+++ b/chaco/label.py
@@ -4,7 +4,7 @@
 from __future__ import with_statement
 
 # Major library imports
-from math import cos, sin, pi
+from math import cos, sin, pi, radians
 from numpy import array, dot
 
 # Enthought library imports
@@ -133,14 +133,7 @@ class Label(HasTraits):
         """ Returns a rectangular bounding box for the Label as (width,height).
         """
         width, height = self.get_width_height(gc)
-        if self.rotate_angle in (90.0, 270.0):
-            return (height, width)
-        elif self.rotate_angle in (0.0, 180.0):
-            return (width, height)
-        else:
-            angle = self.rotate_angle
-            return (abs(width*cos(angle))+abs(height*sin(angle)),
-                    abs(height*sin(angle))+abs(width*cos(angle)))
+        return dot(self.get_rotation_matrix(), array([width, height])).T
 
     def get_bounding_poly(self, gc):
         """
@@ -163,8 +156,13 @@ class Label(HasTraits):
         return points
 
     def get_rotation_matrix(self):
-        return array([[cos(self.rotate_angle), -sin(self.rotate_angle)],
-            [sin(self.rotate_angle), cos(self.rotate_angle)]])
+        angle = radians(self.rotate_angle)
+        return array(
+            [
+                [cos(angle), -sin(angle)],
+                [sin(angle), cos(angle)]
+            ]
+        )
 
     def draw(self, gc):
         """ Draws the label.

--- a/examples/demo/text_box_overlay.py
+++ b/examples/demo/text_box_overlay.py
@@ -1,0 +1,50 @@
+import math
+
+from chaco.api import Plot
+from chaco.text_box_overlay import TextBoxOverlay
+from enable.api import ComponentEditor
+from traits.api import HasTraits, DelegatesTo, Instance, on_trait_change
+from traitsui.api import View, Item, HGroup, RangeEditor
+
+class TextBoxOverlayExample(HasTraits):
+
+    text_label = DelegatesTo('_overlay', 'text')
+    rotate_angle = DelegatesTo('_overlay', 'rotate_angle')
+
+    _plot = Instance(Plot)
+    _overlay = Instance(TextBoxOverlay)
+
+    def __overlay_default(self):
+
+        overlay = TextBoxOverlay(text='Hello World!')
+
+        return overlay
+
+    def __plot_default(self):
+
+        plot = Plot()
+
+        plot.overlays.append(self._overlay)
+
+        return plot
+
+    traits_view = View(
+        Item('_plot', editor=ComponentEditor(), show_label=False),
+        HGroup(
+            Item('text_label'),
+            Item('rotate_angle', editor=RangeEditor(low=0, high=360))
+        ),
+        title = 'Example of TextBoxOverlay'
+    )
+
+    @on_trait_change('text_label,rotate_angle')
+    def _refresh_overlay(self):
+        print ' Updates'
+        self._overlay.request_redraw()
+        self._plot.request_redraw()
+
+if __name__ == '__main__':
+    
+    example = TextBoxOverlayExample(rotate_angle=0.)
+    example.configure_traits()
+


### PR DESCRIPTION
The Chaco label supports a rotate_angle trait that worked fine but was not exposed when using a TextBoxOverlay. This pull request exposes the rotate_angle trait on the TextBoxOverlay and fixes some issues in the way the Label was playing with angles. It was implicitely using degrees but not converting to radians in part of the api.

I have added text_box_overlay demo where one can play with the text and the angle to see how it works.

The change to the get_bounding_box method of the Label class might have an impact as it is used by the Axis, Legen, Tooltip and PlotLabel. We need to be cautious when merging the pull request
