### PR TITLE
Bug fix for shell/plot_maker.py

### DIFF
--- a/chaco/shell/plot_maker.py
+++ b/chaco/shell/plot_maker.py
@@ -327,7 +327,7 @@ def do_imshow(plotdata, active_plot, *data, **kwargs):
     x = None
     y = None
     try:
-        z = _get_or_create_plot_data(data[0])
+        z = _get_or_create_plot_data(data[0], plotdata)
     except ValueError:
         # z is the name of the file
         # create plot data
@@ -348,7 +348,7 @@ def do_pcolor(plotdata, colormap, active_plot, *data, **kwargs ):
     if len(data) == 1:
         x = None
         y = None
-        z = _get_or_create_plot_data(data[0])
+        z = _get_or_create_plot_data(data[0], plotdata)
 
     # three data sources means we got x-y grid data of some sort, too
     elif len(data) == 3:
@@ -372,7 +372,7 @@ def do_contour(plotdata, colormap, active_plot, type, *data, **kwargs ):
     if len(data) == 1:
         x = None
         y = None
-        z = _get_or_create_plot_data(data[0])
+        z = _get_or_create_plot_data(data[0], plotdata)
 
     # three data sources means we got x-y grid data of some sort, too
     elif len(data) == 3:


### PR DESCRIPTION
Per EPD-Users discussion on 4/11/12 between Todd Rovito rovitotv@gmail.com and myself, this patch fixes some minor bugs where the _get_or_create_plot_data function was getting called with one argument.

Traceback for the error encountered by the user is below:
## In [9]: %run imshow.py

TypeError                                 Traceback (most recent call last)
/Library/Frameworks/Python.framework/Versions/7.2/lib/python2.7/site-packages/IPython/utils/py3compat.py
in execfile(fname, *where)
   173             else:
   174                 filename = fname
--> 175             **builtin**.execfile(filename, *where)

/Library/Frameworks/Python.framework/Versions/7.2/Examples/chaco-4.1.0/demo/shell/imshow.py
in <module>()
    21
    22 # Create the plot

---> 23 imshow(image, origin="top left")
    24
    25 # Alternatively, you can call imshow using the path to the image file

/Library/Frameworks/Python.framework/Versions/7.2/lib/python2.7/site-packages/chaco/shell/commands.py
in imshow(_data, *_kwargs)
   400         kwargs["colormap"] = session.colormap
   401     plots = plot_maker.do_imshow(session.data, cont,
--> 402                                  _data, *_kwargs)
   403     cont.request_redraw()
   404     return

/Library/Frameworks/Python.framework/Versions/7.2/lib/python2.7/site-packages/chaco/shell/plot_maker.py
in do_imshow(plotdata, active_plot, _data, *_kwargs)
   328     y = None
   329     try:
--> 330         z = _get_or_create_plot_data(data[0])
   331     except ValueError:
   332         # z is the name of the file

TypeError: _get_or_create_plot_data() takes exactly 2 arguments (1 given)
