### PR TITLE
Add inspector formatters to overlays.api

### DIFF
--- a/chaco/overlays/api.py
+++ b/chaco/overlays/api.py
@@ -2,4 +2,5 @@ from databox import DataBox
 from container_overlay import ContainerOverlay
 from aligned_container_overlay import AlignedContainerOverlay
 from text_grid_overlay import TextGridOverlay
-from simple_inspector_overlay import SimpleInspectorOverlay
+from simple_inspector_overlay import SimpleInspectorOverlay, basic_formatter, \
+    datetime_formatter, date_formatter, time_formatter


### PR DESCRIPTION
This just makes some formatters for the inspector overlays more convenient to access for user code.

This is a minor change and shouldn't break any existing code, as it is just adding to the formal api.
