### PR TITLE
For rgb or rgba plots, forcing value_depth to type int.

### DIFF
--- a/chaco/plot.py
+++ b/chaco/plot.py
@@ -929,7 +929,7 @@ class Plot(DataView):
                     ds = ImageData(data=data, value_depth=1)
                 elif len(data.shape) == 3:
                     if data.shape[2] in (3,4):
-                        ds = ImageData(data=data, value_depth=data.shape[2])
+                        ds = ImageData(data=data, value_depth=int(data.shape[2]))
                     else:
                         raise ValueError("Unhandled array shape in creating new plot: " \
                                          + str(data.shape))


### PR DESCRIPTION
FIX: In Plot._get_or_create_datasource(), for rgb or rgba plots, forcing value_depth to type int. In some cases, the depth may be type long instead, but still 3 or 4, which caused a crash.
