### PR TITLE
Consistently treat the data like a numpy array

### DIFF
--- a/chaco/array_data_source.py
+++ b/chaco/array_data_source.py
@@ -219,6 +219,7 @@ class ArrayDataSource(AbstractDataSource):
             # to do anyway... right?
             #data = self._data
             data = self.get_data()
+        data = data.view(ndarray)
 
         data_len = 0
         try:
@@ -250,15 +251,15 @@ class ArrayDataSource(AbstractDataSource):
                     # the data may be in a subclass of numpy.array, viewing
                     # the data as a ndarray will remove side effects of
                     # the subclasses, such as different operator behaviors
-                    self._min_index = bounded_nanargmin(data.view(ndarray))
-                    self._max_index = bounded_nanargmax(data.view(ndarray))
+                    self._min_index = bounded_nanargmin(data)
+                    self._max_index = bounded_nanargmax(data)
                 except (TypeError, IndexError, NotImplementedError):
                     # For strings and objects, we punt...  These show up in
                     # label-ish data sources.
                     self._cached_bounds = (0.0, 0.0)
 
-            self._cached_bounds = (data.view(ndarray)[self._min_index],
-                               data.view(ndarray)[self._max_index])
+            self._cached_bounds = (data[self._min_index],
+                               data[self._max_index])
         return
 
     #------------------------------------------------------------------------


### PR DESCRIPTION
For example, when the underlying data source is a pandas array, indexing a subview uses the original index values.
