### PR TITLE
Rename the line style and width attributes of the CoordinateLineOverlay

### DIFF
--- a/chaco/overlays/coordinate_line_overlay.py
+++ b/chaco/overlays/coordinate_line_overlay.py
@@ -20,13 +20,13 @@ class CoordinateLineOverlay(AbstractOverlay):
     value_data = Array
 
     # Width of the lines.
-    width = Float(1.0)
+    line_width = Float(1.0)
 
     # Color of the lines.
     color = black_color_trait
 
     # Style of the lines ('solid', 'dash' or 'dot').
-    style = LineStyle
+    line_style = LineStyle
 
     # The component that this tool overlays.  This must be a Component with
     # the following attributes:
@@ -57,8 +57,8 @@ class CoordinateLineOverlay(AbstractOverlay):
         with gc:
             # Set the line color and style parameters.
             gc.set_stroke_color(self.color_)
-            gc.set_line_width(self.width)
-            gc.set_line_dash(self.style_)
+            gc.set_line_width(self.line_width)
+            gc.set_line_dash(self.line_style_)
 
             # Draw the vertical lines.
             for screen_x in x_pts:

--- a/examples/demo/coordinate_line_overlay_demo.py
+++ b/examples/demo/coordinate_line_overlay_demo.py
@@ -101,7 +101,7 @@ class PlotExample(HasTraits):
                     index_data=self.x1,
                     value_data=self.y1,
                     color=(0.75, 0.25, 0.25, 0.75),
-                    style='dash', width=1)
+                    line_style='dash', line_width=1)
         time_plot.underlays.append(lines1)
         self.line_overlay1 = lines1
 
@@ -109,7 +109,7 @@ class PlotExample(HasTraits):
                     index_data=self.x2,
                     value_data=self.y2,
                     color=(0.2, 0.5, 1.0, 0.75),
-                    width=3)
+                    line_width=3)
         time_plot.underlays.append(lines2)
         self.line_overlay2 = lines2
 


### PR DESCRIPTION
A small change to the recently added CoordinateLineOverlay.  This change renames the line width and style attributes to 'line_width' and 'line_style' (but leaves the color attribute as 'color').  This is consistent with LineInspector, LinePlot, MultiLinePlot and PolarLineRenderer.
