### PR TITLE
Add shorter summary-line to module docstring.

### DIFF
--- a/examples/demo/basic/inset_plot.py
+++ b/examples/demo/basic/inset_plot.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-"""
+""" Overlaid inset plots.
+
 A modification of line_plot1.py that shows the second plot as a subwindow
 of the first.  You can pan and zoom the second plot just like the first,
 and you can move it around my right-click and dragging in the smaller plot.

--- a/examples/demo/basic/log_plot.py
+++ b/examples/demo/basic/log_plot.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
-"""
+""" Basic x-y log plots.
+
 Draws some x-y log plots. (No Tools)
+
 """
 
 # Major library imports

--- a/examples/demo/basic/nans_plot.py
+++ b/examples/demo/basic/nans_plot.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-"""
+""" Plot data with NaNs.
+
 This plot displays chaco's ability to handle data interlaced with NaNs.
  - Left-drag pans the plot.
  - Mousewheel up and down zooms the plot in and out.

--- a/examples/demo/basic/polygon_move.py
+++ b/examples/demo/basic/polygon_move.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-"""
+""" Polygon plot with drag-move.
+
 Shares same basic interactions as polygon_plot.py, but adds a new one:
  - Right click and drag to move a polygon around.
 """

--- a/examples/demo/basic/polygon_plot_demo.py
+++ b/examples/demo/basic/polygon_plot_demo.py
@@ -1,5 +1,7 @@
-"""Demonstrate a simple polygon plot.  The UI allows you to change
-some of the attributes of the plot.
+""" Simple polygon plot.
+
+The UI allows you to change some of the attributes of the plot.
+
 """
 
 import numpy as np

--- a/examples/demo/basic/scrollbar.py
+++ b/examples/demo/basic/scrollbar.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-"""
+""" Plot with pan-zoom interaction.
+
 Draws some x-y line and scatter plots. On the left hand plot:
  - Left-drag pans the plot.
  - Mousewheel up and down zooms the plot in and out.

--- a/examples/demo/basic/traits_editor.py
+++ b/examples/demo/basic/traits_editor.py
@@ -1,4 +1,5 @@
-"""
+""" 1D Function plotter.
+
 This example creates a simple 1D function examiner, illustrating the use of
 ChacoPlotEditors for displaying simple plot relations, as well as TraitsUI
 integration. Any 1D numpy/scipy.special function should work in the function


### PR DESCRIPTION
This aids in displaying the first line as a summary of the example
and the rest as the description, as per PEP 257
