### PR TITLE
DOCS: Change urls of examples to point to GitHub from svn.

### DIFF
--- a/docs/source/user_manual/annotated_examples.rst
+++ b/docs/source/user_manual/annotated_examples.rst
@@ -17,7 +17,7 @@ examples as starting points for their own applications.
 ---------------
 An example showing Chaco's BarPlot class.
 
-source: `bar_plot.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/bar_plot.py>`_
+source `bar_plot.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/bar_plot.py>`_
 
 .. image:: example_images/bar_plot.png
 
@@ -33,7 +33,7 @@ of the backbuffering built into chaco.
 Zooming with the mousewheel and the zoombox (as described in simple_line.py)
 is also available, but panning is not.
 
-source: `bigdata.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/bigdata.py>`_
+source `bigdata.py <https://github.com/enthought/chaco/tree/master/examples/demo/bigdata.py>`_
 
 .. image:: example_images/bigdata.png
 
@@ -44,7 +44,7 @@ A Demonstration of the CursorTool functionality
 Left-button drag to move the cursors round.
 Right-drag to pan the plots. 'z'-key to Zoom
 
-source: `cursor_tool_demo.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/cursor_tool_demo.py>`_
+source `cursor_tool_demo.py <https://github.com/enthought/chaco/tree/master/examples/demo/cursor_tool_demo.py>`_
 
 .. image:: example_images/cursor_tool_demo.png
 
@@ -53,7 +53,7 @@ source: `cursor_tool_demo.py <https://svn.enthought.com/enthought/browser/Chaco/
 Draws a line plot with several points labelled.  Demonstrates how to annotate
 plots.
 
-source: `data_labels.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/data_labels.py>`_
+source `data_labels.py <https://github.com/enthought/chaco/tree/master/examples/demo/data_labels.py>`_
 
 .. image:: example_images/data_labels.png
 
@@ -61,7 +61,7 @@ source: `data_labels.py <https://svn.enthought.com/enthought/browser/Chaco/trunk
 ----------------
 Example of how to use a DataView and bare renderers to create plots.
 
-source: `data_view.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/data_view.py>`_
+source `data_view.py <https://github.com/enthought/chaco/tree/master/examples/demo/data_view.py>`_
 
 .. image:: example_images/data_view.png
 
@@ -69,7 +69,7 @@ source: `data_view.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/e
 ----------------
 Allows editing of a line plot.
 
-source: `edit_line.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/edit_line.py>`_
+source `edit_line.py <https://github.com/enthought/chaco/tree/master/examples/demo/edit_line.py>`_
 
 .. image:: example_images/edit_line.png
 
@@ -79,7 +79,7 @@ Implementation of a standard financial plot visualization using Chaco renderers
 and scales. Right-clicking and selecting an area in the top window zooms in
 the corresponding area in the lower window.
 
-source: `financial_plot.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/financial_plot.py>`_
+source `financial_plot.py <https://github.com/enthought/chaco/tree/master/examples/demo/financial_plot.py>`_
 
 .. image:: example_images/financial_plot.png
 
@@ -91,7 +91,7 @@ the corresopnding area in the lower window.
 This differs from the financial_plot.py example in that it uses a date-oriented
 axis.
 
-source: `financial_plot_dates.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/financial_plot_dates.py>`_
+source `financial_plot_dates.py <https://github.com/enthought/chaco/tree/master/examples/demo/financial_plot_dates.py>`_
 
 .. image:: example_images/financial_plot_dates.png
 
@@ -101,7 +101,7 @@ Draws several overlapping line plots like simple_line.py, but uses a separate
 Y range for each plot.  Also has a second Y-axis on the right hand side.
 Demonstrates use of the BroadcasterTool.
 
-source: `multiaxis.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/multiaxis.py>`_
+source `multiaxis.py <https://github.com/enthought/chaco/tree/master/examples/demo/multiaxis.py>`_
 
 .. image:: example_images/multiaxis.png
 
@@ -115,7 +115,7 @@ Draws some x-y line and scatter plots. On the left hand plot:
    and alt-right-arrow moves you forwards and backwards through the "zoom 
    history".
 
-source: `multiaxis_using_Plot.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/multiaxis_using_Plot.py>`_
+source `multiaxis_using_Plot.py <https://github.com/enthought/chaco/tree/master/examples/demo/multiaxis_using_Plot.py>`_
 
 .. image:: example_images/multiaxis_using_Plot.png
 
@@ -124,7 +124,7 @@ source: `multiaxis_using_Plot.py <https://svn.enthought.com/enthought/browser/Ch
 This demonstrates how to create a plot offscreen and save it to an image file
 on disk. The image is what is saved.
 
-source: `noninteractive.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/noninteractive.py>`_
+source `noninteractive.py <https://github.com/enthought/chaco/tree/master/examples/demo/noninteractive.py>`_
 
 .. image:: example_images/noninteractive.png
 
@@ -134,7 +134,7 @@ Demo of the RangeSelection on a line plot.  Left-click and drag creates a
 horizontal range selection; this selection can then be dragged around, or
 resized by dragging its edges.
 
-source: `range_selection_demo.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/range_selection_demo.py>`_
+source `range_selection_demo.py <https://github.com/enthought/chaco/tree/master/examples/demo/range_selection_demo.py>`_
 
 .. image:: example_images/range_selection_demo.png
 
@@ -144,7 +144,7 @@ Draws several overlapping line plots.
 
 Double-clicking on line or scatter plots opens a Traits editor for the plot.
 
-source: `scales_test.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/scales_test.py>`_
+source `scales_test.py <https://github.com/enthought/chaco/tree/master/examples/demo/scales_test.py>`_
 
 .. image:: example_images/scales_test.png
 
@@ -154,7 +154,7 @@ Draws several overlapping line plots.
 
 Double-clicking on line or scatter plots opens a Traits editor for the plot.
 
-source: `simple_line.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/simple_line.py>`_
+source `simple_line.py <https://github.com/enthought/chaco/tree/master/examples/demo/simple_line.py>`_
 
 .. image:: example_images/simple_line.png
 
@@ -172,7 +172,7 @@ source: `simple_line.py <https://svn.enthought.com/enthought/browser/Chaco/trunk
 --------------
 Tornado plot example from Brennan Williams.
 
-source: `tornado.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/tornado.py>`_
+source `tornado.py <https://github.com/enthought/chaco/tree/master/examples/demo/tornado.py>`_
 
 .. image:: example_images/tornado.png
 
@@ -180,7 +180,7 @@ source: `tornado.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/exa
 ----------------
 Demonstrates plots sharing datasources, ranges, etc...
 
-source: `two_plots.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/two_plots.py>`_
+source `two_plots.py <https://github.com/enthought/chaco/tree/master/examples/demo/two_plots.py>`_
 
 .. image:: example_images/two_plots.png
 
@@ -191,7 +191,7 @@ Draws a static plot of bessel functions, oriented vertically, side-by-side.
 You can experiment with using different containers (uncomment lines 32-33)
 or different orientations on the plots (comment out line 43 and uncomment 44).
 
-source: `vertical_plot.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/vertical_plot.py>`_
+source `vertical_plot.py <https://github.com/enthought/chaco/tree/master/examples/demo/vertical_plot.py>`_
 
 .. image:: example_images/vertical_plot.png
 
@@ -199,7 +199,7 @@ source: `vertical_plot.py <https://svn.enthought.com/enthought/browser/Chaco/tru
 ----------------
 Allows isometric viewing of a 3-D data cube (downloads the necessary data, about 7.8 MB)
 
-source: `data_cube.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/advanced/data_cube.py>`_
+source `data_cube.py <https://github.com/enthought/chaco/tree/master/examples/demo/advanced/data_cube.py>`_
 
 .. image:: example_images/data_cube.png
 
@@ -214,7 +214,7 @@ device from which the data is being acquired; in this case, it is a mockup
 random number generator whose mean and standard deviation can be controlled
 by the user.
 
-source: `data_stream.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/advanced/data_stream.py>`_
+source `data_stream.py <https://github.com/enthought/chaco/tree/master/examples/demo/advanced/data_stream.py>`_
 
 .. image:: example_images/data_stream.png
 
@@ -223,7 +223,7 @@ source: `data_stream.py <https://svn.enthought.com/enthought/browser/Chaco/trunk
 Renders a colormapped image of a scalar value field, and a cross section
 chosen by a line interactor.
 
-source: `scalar_image_function_inspector.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/advanced/scalar_image_function_inspector.py>`_
+source `scalar_image_function_inspector.py <https://github.com/enthought/chaco/tree/master/examples/demo/advanced/scalar_image_function_inspector.py>`_
 
 .. image:: example_images/scalar_image_function_inspector.png
 
@@ -231,7 +231,7 @@ source: `scalar_image_function_inspector.py <https://svn.enthought.com/enthought
 --------------------------------------
 This plot displays the audio spectrum from the microphone.
 
-source: `spectrum.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/advanced/spectrum.py>`_
+source `spectrum.py <https://github.com/enthought/chaco/tree/master/examples/demo/vtk/spectrum.py>`_
 
 .. image:: example_images/spectrum.png
 
@@ -239,7 +239,7 @@ source: `spectrum.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/ex
 ----------------------
 Draws a colormapped image plot.
 
-source: `cmap_image_plot.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/cmap_image_plot.py>`_
+source `cmap_image_plot.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/cmap_image_plot.py>`_
 
 .. image:: example_images/cmap_image_plot.png
 
@@ -248,7 +248,7 @@ source: `cmap_image_plot.py <https://svn.enthought.com/enthought/browser/Chaco/t
 Draws a colormapped image plot. Selecting colors in the spectrum on the right
 highlights the corresponding colors in the color map.
 
-source: `cmap_image_select.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/cmap_image_select.py>`_
+source `cmap_image_select.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/cmap_image_select.py>`_
 
 .. image:: example_images/cmap_image_select.png
 
@@ -256,7 +256,7 @@ source: `cmap_image_select.py <https://svn.enthought.com/enthought/browser/Chaco
 -------------------
 Draws a colormapped scatterplot of some random data. Selection works the same as in cmap_image_select.py.
 
-source: `cmap_scatter.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/cmap_scatter.py>`_
+source `cmap_scatter.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/cmap_scatter.py>`_
 
 .. image:: example_images/cmap_scatter.png
 
@@ -264,7 +264,7 @@ source: `cmap_scatter.py <https://svn.enthought.com/enthought/browser/Chaco/trun
 --------------------------
 Renders some contoured and colormapped images of a scalar value field.
 
-source: `countour_cmap_plot.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/contour_cmap_plot.py>`_
+source `contour_cmap_plot.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/contour_cmap_plot.py>`_
 
 .. image:: example_images/contour_cmap_plot.png
 
@@ -272,7 +272,7 @@ source: `countour_cmap_plot.py <https://svn.enthought.com/enthought/browser/Chac
 -------------------
 Draws an contour polygon plot with a contour line plot on top.
 
-source: `countour_plot.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/contour_plot.py>`_
+source `contour_plot.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/contour_plot.py>`_
 
 .. image:: example_images/contour_plot.png
 
@@ -280,7 +280,7 @@ source: `countour_plot.py <https://svn.enthought.com/enthought/browser/Chaco/tru
 ---------------------
 Draws several overlapping line plots.
 
-source: `grid_container.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/grid_container.py>`_
+source `grid_container.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/grid_container.py>`_
 
 .. image:: example_images/grid_container.png
 
@@ -289,7 +289,7 @@ source: `grid_container.py <https://svn.enthought.com/enthought/browser/Chaco/tr
 Similar to grid_container.py, but demonstrates Chaco's capability to used a
 fixed screen space aspect ratio for plot components.
 
-source: `grid_container_aspect_ratio.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/grid_container_aspect_ratio.py>`_
+source `grid_container_aspect_ratio.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/grid_container_aspect_ratio.py>`_
 
 .. image:: example_images/grid_container_aspect_ratio.png
 
@@ -297,7 +297,7 @@ source: `grid_container_aspect_ratio.py <https://svn.enthought.com/enthought/bro
 ----------------------
 Loads and saves RGB images from disk.
 
-source: `image_from_file.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/image_from_file.py>`_
+source `image_from_file.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/image_from_file.py>`_
 
 .. image:: example_images/image_from_file.png
 
@@ -306,7 +306,7 @@ source: `image_from_file.py <https://svn.enthought.com/enthought/browser/Chaco/t
 Demonstrates the ImageInspectorTool and overlay on a colormapped image plot.
 The underlying plot is similar to the one in cmap_image_plot.py.
 
-source: `image_inspector.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/image_inspector.py>`_
+source `image_inspector.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/image_inspector.py>`_
 
 .. image:: example_images/image_inspector.png
 
@@ -314,7 +314,7 @@ source: `image_inspector.py <https://svn.enthought.com/enthought/browser/Chaco/t
 -----------------
 Draws a simple RGB image
 
-source: `image_plot.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/image_plot.py>`_
+source `image_plot.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/image_plot.py>`_
 
 .. image:: example_images/image_plot.png
 
@@ -324,7 +324,7 @@ A modification of line_plot1.py that shows the second plot as a subwindow of
 the first.  You can pan and zoom the second plot just like the first, and you
 can move it around my right-click and dragging in the smaller plot.
 
-source: `inset_plot.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/inset_plot.py>`_
+source `inset_plot.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/inset_plot.py>`_
 
 .. image:: example_images/inset_plot.png
 
@@ -333,7 +333,7 @@ source: `inset_plot.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/
 Demonstrates using a line segment drawing tool on top of the scatter plot from
 simple_scatter.py.
 
-source: `line_drawing.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/line_drawing.py>`_
+source `line_drawing.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/line_drawing.py>`_
 
 .. image:: example_images/line_drawing.png
 
@@ -341,7 +341,7 @@ source: `line_drawing.py <https://svn.enthought.com/enthought/browser/Chaco/trun
 -----------------
 Draws some x-y line and scatter plots.
 
-source: `line_plot1.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/line_plot1.py>`_
+source `line_plot1.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/line_plot1.py>`_
 
 .. image:: example_images/line_plot1.png
 
@@ -349,7 +349,7 @@ source: `line_plot1.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/
 ---------------------
 Demonstrates the different 'hold' styles of LinePlot.
 
-source: `line_plot_hold.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/line_plot_hold.py>`_
+source `line_plot_hold.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/line_plot_hold.py>`_
 
 .. image:: example_images/line_plot_hold.png
 
@@ -357,7 +357,7 @@ source: `line_plot_hold.py <https://svn.enthought.com/enthought/browser/Chaco/tr
 -----------------
 Draws some x-y log plots. (No Tools).
 
-source: `log_plot.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/log_plot.py>`_
+source `log_plot.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/log_plot.py>`_
 
 .. image:: example_images/log_plot.png
 
@@ -365,7 +365,7 @@ source: `log_plot.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/ex
 ----------------
 This plot displays chaco's ability to handle data interlaced with NaNs.
 
-source: `nans_plot.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/nans_plot.py>`_
+source `nans_plot.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/nans_plot.py>`_
 
 .. image:: example_images/nans_plot.png
 
@@ -373,7 +373,7 @@ source: `nans_plot.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/e
 -------------------
 Draws some different polygons.
 
-source: `polygon_plot.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/polygon_plot.py>`_
+source: `polygon_plot.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/polygon_plot_demo.py>`_
 
 .. image:: example_images/polygon_plot.png
 
@@ -382,7 +382,7 @@ source: `polygon_plot.py <https://svn.enthought.com/enthought/browser/Chaco/trun
 Shares same basic interactions as polygon_plot.py, but adds a new one: 
 right-click and drag to move a polygon around.
 
-source: `polygon_move.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/polygon_move.py>`_
+source `polygon_move.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/polygon_move.py>`_
 
 .. image:: example_images/polygon_move.png
 
@@ -395,7 +395,7 @@ around some points, and a line fit is drawn through the center of the points.
 The parameters of the line are displayed at the bottom of the plot region.  You
 can do this repeatedly to draw different regions.
 
-source: `regression.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/regression.py>`_
+source `regression.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/regression.py>`_
 
 .. image:: example_images/regression.png
 
@@ -403,7 +403,7 @@ source: `regression.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/
 -------------------
 Draws a simple scatterplot of a set of random points.
 
-source: `scatter.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/scatter.py>`_
+source `scatter.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/scatter.py>`_
 
 .. image:: example_images/scatter.png
 
@@ -411,7 +411,7 @@ source: `scatter.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/exa
 ------------------------
 Example of using tooltips on Chaco plots.
 
-source: `scatter_inspector.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/scatter_inspector.py>`_
+source `scatter_inspector.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/scatter_inspector.py>`_
 
 .. image:: example_images/scatter_inspector.png
 
@@ -422,7 +422,7 @@ the lasso selector, which allows you to circle a set of points.  Upon
 completion of the lasso operation, the indices of the selected points are
 printed to the console.
 
-source: `scatter_select.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/scatter_select.py>`_
+source `scatter_select.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/scatter_select.py>`_
 
 .. image:: example_images/scatter_select.png
 
@@ -437,7 +437,7 @@ console output::
 -------------------
 Draws some x-y line and scatter plots.
 
-source: `scrollbar.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/scrollbar.py>`_
+source `scrollbar.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/scrollbar.py>`_
 
 .. image:: example_images/scrollbar.png
 
@@ -445,7 +445,7 @@ source: `scrollbar.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/e
 -------------------
 Draws some x-y line and scatter plots.
 
-source: `tabbed_plots.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/tabbed_plots.py>`_
+source `tabbed_plots.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/tabbed_plots.py>`_
 
 .. image:: example_images/tabbed_plots1.png
 .. image:: example_images/tabbed_plots2.png
@@ -457,7 +457,7 @@ ChacoPlotEditors for displaying simple plot relations, as well as Traits UI
 integration. Any 1-D numpy/scipy.special function works in the function
 text box.
 
-source: `traits_editor.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/traits_editor.py>`_
+source `traits_editor.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/traits_editor.py>`_
 
 .. image:: example_images/traits_editor.png
 
@@ -472,7 +472,7 @@ Left-click pans the colorbar's data region.  Right-click-drag
 selects a zoom range.  Mousewheel up and down zoom in and out on
 the data bounds of the color bar.
 
-source: `zoomable_colorbar.py <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/basic/zoomable_colorbar.py>`_
+source `zoomable_colorbar.py <https://github.com/enthought/chaco/tree/master/examples/demo/basic/zoomable_colorbar.py>`_
 
 .. image:: example_images/zoomable_colorbar.png
 
@@ -484,6 +484,6 @@ Right-click and drag on the upper plot to select a region to view in detail
 in the lower plot.  The selected region can be moved around by dragging,
 or resized by clicking on one of its edges and dragging.
 
-source: `zoomed_plot <https://svn.enthought.com/enthought/browser/Chaco/trunk/examples/zoomed_plot/>`_
+source: `zoomed_plot <https://github.com/enthought/chaco/tree/master/examples/demo/zoomed_plot/>`_
 
 .. image:: example_images/zoomed_plot.png

--- a/examples/demo/basic/bar_plot.py
+++ b/examples/demo/basic/bar_plot.py
@@ -1,0 +1,135 @@
+"""
+Simple example of a stacked bar chart, using the BarPlot class.
+"""
+
+# Major library imports
+from numpy import cos, linspace, pi, sin
+
+from chaco.example_support import COLOR_PALETTE
+from enable.example_support import DemoFrame, demo_main
+
+# Enthought library imports
+from enable.api import Component, ComponentEditor, Window
+from traits.api import HasTraits, Instance
+from traitsui.api import Item, Group, View
+
+# Chaco imports
+from chaco.api import ArrayDataSource, BarPlot, DataRange1D, LabelAxis, \
+                                 LinearMapper, OverlayPlotContainer, PlotAxis
+
+
+def get_points():
+    index = linspace(pi/4, 3*pi/2, 9)
+    data = sin(index) + 2
+    return (range(1, 10), data)
+    
+def make_curves():
+    (index_points, value_points) = get_points()
+    size = len(index_points)
+
+    # Create our data sources
+    idx = ArrayDataSource(index_points[:(size/2)])
+    vals = ArrayDataSource(value_points[:(size/2)], sort_order="none")
+
+    idx2 = ArrayDataSource(index_points[(size/2):])
+    vals2 = ArrayDataSource(value_points[(size/2):], sort_order="none")
+
+    idx3 = ArrayDataSource(index_points)
+    starting_vals = ArrayDataSource(value_points, sort_order="none")
+    vals3 = ArrayDataSource(2 * cos(value_points) + 2, sort_order="none")
+
+    # Create the index range
+    index_range = DataRange1D(idx, low=0.5, high=9.5)
+    index_mapper = LinearMapper(range=index_range)
+
+    # Create the value range
+    value_range = DataRange1D(low=0, high=4.25)
+    value_mapper = LinearMapper(range=value_range)
+
+    # Create the plot
+    plot1 = BarPlot(index=idx, value=vals,
+                    value_mapper=value_mapper,
+                    index_mapper=index_mapper,
+                    line_color='black',
+                    fill_color=tuple(COLOR_PALETTE[6]),
+                    bar_width=0.8, antialias=False)
+    
+    plot2 = BarPlot(index=idx2, value=vals2,
+                    value_mapper=value_mapper,
+                    index_mapper=index_mapper,
+                    line_color='blue',
+                    fill_color=tuple(COLOR_PALETTE[3]),
+                    bar_width=0.8, antialias=False)
+    
+    plot3 = BarPlot(index=idx3, value=vals3,
+                    value_mapper=value_mapper,
+                    index_mapper=index_mapper,
+                    starting_value=starting_vals,
+                    line_color='black',
+                    fill_color=tuple(COLOR_PALETTE[1]),
+                    bar_width=0.8, antialias=False)
+
+    return [plot1, plot2, plot3]
+
+#===============================================================================
+# # Create the Chaco plot.
+#===============================================================================
+def _create_plot_component():
+    
+    container = OverlayPlotContainer(bgcolor = "white")
+    plots = make_curves()
+    for plot in plots:
+        plot.padding = 50
+        container.add(plot)
+
+    left_axis = PlotAxis(plot, orientation='left')
+
+    bottom_axis = LabelAxis(plot, orientation='bottom',
+                           title='Categories',
+                           positions = range(1, 10),
+                           labels = ['a', 'b', 'c', 'd', 'e',
+                                     'f', 'g', 'h', 'i'],
+                           small_haxis_style=True)
+
+    plot.underlays.append(left_axis)
+    plot.underlays.append(bottom_axis)
+        
+    return container
+
+#===============================================================================
+# Attributes to use for the plot view.
+size = (800, 600)
+title = "Bar Plot"
+        
+#===============================================================================
+# # Demo class that is used by the demo.py application.
+#===============================================================================
+class Demo(HasTraits):
+    plot = Instance(Component)
+    
+    traits_view = View(
+                    Group(
+                        Item('plot', editor=ComponentEditor(size=size), 
+                             show_label=False),
+                        orientation = "vertical"),
+                    resizable=True, title=title
+                    )
+    
+    def _plot_default(self):
+        return _create_plot_component()
+    
+demo = Demo()
+
+#===============================================================================
+# Stand-alone frame to display the plot.
+#===============================================================================
+class PlotFrame(DemoFrame):
+
+    def _create_window(self):
+        # Return a window containing our plots
+        return Window(self, -1, component=_create_plot_component())
+    
+if __name__ == "__main__":
+    demo_main(PlotFrame, size=size, title=title)
+
+#--EOF---


### PR DESCRIPTION
Just make changes to annotated_examples.rst, so that all examples have links to code examples that run, and produce the same plot as shown in the figures.
