### PR TITLE
use column_stack to speed up gather_points

### DIFF
--- a/chaco/lineplot.py
+++ b/chaco/lineplot.py
@@ -316,7 +316,6 @@ class LinePlot(BaseXYPlot):
                         run_data = ( block_index[start:end],
                                      block_value[start:end] )
                         run_data = column_stack(run_data)
-                        run_data = array(run_data)
 
                         points.append(run_data)
 


### PR DESCRIPTION
`gather_points` function in `lineplot` uses `transpose(array( (xs,ys) ))` instead of the much faster `column_stack( (xs,ys) )`.

There are a number of other places in the code where array() is also used, like in the render_hold functions, which presumably could also be sped up like this, but I haven't tried.
