### PR TITLE
FIX: The _render_icon method of the PolygonPlot

### DIFF
--- a/chaco/polygon_plot.py
+++ b/chaco/polygon_plot.py
@@ -113,7 +113,7 @@ class PolygonPlot(BaseXYPlot):
         """
         with gc:
             gc.set_stroke_color(self.effective_edge_color)
-            gc.set_line_width(self.line_width)
+            gc.set_line_width(self.edge_width)
             gc.set_fill_color(self.effective_face_color)
             if hasattr(self, 'line_style_'):
                 gc.set_line_dash(self.line_style_)


### PR DESCRIPTION
This commit fixes the _render_icon function of the PolygonPlot. The method was trying to access the self.line_width attribute which does not exist. As a result when trying to render the icons it raises an exception and the proper icon is not shown in the legend.

This fix effects also the FilledLinePlot which now produces the right icon in the Plot legend.
