### PR TITLE
Change wording for spectrum example, use hot colormap for spectrogram

### DIFF
--- a/examples/demo/advanced/spectrum.py
+++ b/examples/demo/advanced/spectrum.py
@@ -17,7 +17,7 @@ from numpy import zeros, linspace, short, fromstring, hstack, transpose
 from scipy import fft
 
 # Enthought library imports
-from chaco.default_colormaps import jet
+from chaco.default_colormaps import hot
 from enable.api import Component, ComponentEditor
 from traits.api import HasTraits, Instance
 from traitsui.api import Item, Group, View, Handler
@@ -79,7 +79,7 @@ def _create_plot_component(obj):
                               name='Spectrogram',
                               xbounds=(0, max_time),
                               ybounds=(0, max_freq),
-                              colormap=jet,
+                              colormap=hot,
                               )
     range_obj = spectrogram_plot.plots['Spectrogram'][0].value_mapper.range
     range_obj.high = 5


### PR DESCRIPTION
The `jet` colormap is for bipolar data (range of [−1, +1]), while spectrogram amplitude is unipolar (range of [0, +1]), so a sequential map like `hot` is a better choice.

http://www.jwave.vt.edu/~rkriz/Projects/create_color_table/color_07.pdf
