### PR TITLE
DOC: Improve field-name appearance

### DIFF
--- a/docs/source/_static/default.css
+++ b/docs/source/_static/default.css
@@ -679,7 +679,7 @@ table.footnote td, table.footnote th {
     border-color: whitesmoke;
     border-top: 0;
     border-bottom: 0;
-    min-width: 7em;
+    white-space: nowrap;
 }
 
 .field-list ul {


### PR DESCRIPTION
In the "Programmer's Reference" section of the Sphinx-generated HTML documentation for Chaco, the appearance of field-names (such as 'Parameters :' and 'Traits :') could use improvement.  In particular, the trailing ':' often gets wrapped to the next line.  In this patch to the .css file, I add the whitespace:nowrap property to fieldnames and also add a light background color (as in the default Sphinx stylesheet but matching the Enthought color scheme).

Before:
![field-names-before](https://f.cloud.github.com/assets/624123/60738/8e97d898-5c1e-11e2-92f2-4ae7e2b0fbc3.png)

After:
![field-names-after](https://f.cloud.github.com/assets/624123/60739/920788e8-5c1e-11e2-911f-750de6b4dbe2.png)
