### PR TITLE
Quiver plot addition

### DIFF
--- a/chaco/plot.py
+++ b/chaco/plot.py
@@ -895,7 +895,6 @@ class Plot(DataView):
         self.add(plot)
         self.plots[name] = [plot]
         return [plot]        
-        
 
     def delplot(self, *names):
         """ Removes the named sub-plots. """

--- a/examples/demo/quiver.py
+++ b/examples/demo/quiver.py
@@ -48,9 +48,6 @@ class PlotExample(HasTraits):
         quiverplot = Plot(data)
         quiverplot.quiverplot(('index', 'value', 'vectors'))
 
-        add_default_axes(quiverplot)
-        add_default_grids(quiverplot)
-
         # Attach some tools to the plot
         quiverplot.tools.append(PanTool(quiverplot, constrain_key="shift"))
         zoom = ZoomTool(quiverplot)


### PR DESCRIPTION
This adds a quiverplot method to the Plot class, so that the API common to most other plots (e.g. plot = Plot(); plot.plot) can be used with QuiverPlots.  Updated the examples to use the new method.
