### PR TITLE
DOC: Fix docstring description of zoom-history keyboard shortcuts.

### DIFF
--- a/examples/demo/data_labels.py
+++ b/examples/demo/data_labels.py
@@ -9,8 +9,8 @@ Mousewheel up and down zooms the plot in and out.
 
 Pressing "z" brings up the Zoom Box, and you can click-drag a rectangular
 region to zoom.  If you use a sequence of zoom boxes, pressing control-y
-and control-z moves you forwards and backwards through the
-"zoom history".
+and control-z (Meta-y and Meta-z on Mac) moves you forwards and backwards
+through the "zoom history".
 
 Right-drag is enabled on some of the labels.
 """

--- a/examples/demo/edit_line.py
+++ b/examples/demo/edit_line.py
@@ -10,7 +10,8 @@ Mousewheel up and down zooms the plot in and out.
 
 Pressing "z" brings up the Zoom Box, and you can click-drag a rectangular
 region to zoom.  If you use a sequence of zoom boxes, pressing control-y and
-control-z moves you forwards and backwards through the "zoom history".
+control-z  (use Meta-y and Meta-z on Mac) moves you forwards and backwards
+through the "zoom history".
 """
 
 # Major library imports

--- a/examples/demo/scales_test.py
+++ b/examples/demo/scales_test.py
@@ -8,7 +8,8 @@ Mousewheel up and down zooms the plot in and out.
 
 Pressing "z" brings up the Zoom Box, and you can click-drag a rectangular
 region to zoom. If you use a sequence of zoom boxes, pressing control-y and
-control-z moves you forwards and backwards through the "zoom history".
+control-z (Meta-y and Meta-z on Mac) moves you forwards and backwards
+through the "zoom history".
 
 Right-click and dragging on the legend allows you to reposition the legend.
 


### PR DESCRIPTION
A few of the examples stated that you could scroll through the zoom history using alt-left-arrow and alt-right-arrow. The `ZoomTool`, however, responds to `control-z` and `control-y`.

Also, one of the examples turned off zoom-box selection (by setting `drag_button=None`). Since the docstring refers to the zoom box and zoom history, this limitation was also removed.

Closes #15 
