### PR TITLE
Fix zoom mode when drag_button set to None.

### DIFF
--- a/chaco/tools/better_selecting_zoom.py
+++ b/chaco/tools/better_selecting_zoom.py
@@ -7,7 +7,7 @@ from enable.api import ColorTrait, KeySpec
 from traits.api import Bool, Enum, Trait, Int, Float, Tuple, Instance, Property
 from traits.util.deprecated import deprecated
 
-from better_zoom import BetterZoom 
+from better_zoom import BetterZoom
 from tool_states import SelectedZoomState
 
 class BetterSelectingZoom(AbstractOverlay, BetterZoom):
@@ -171,7 +171,7 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
         return
 
     def pre_selecting_left_down(self, event):
-        """ the use pressed the key to turn on the zoom mode,
+        """ The user pressed the key to turn on the zoom mode,
             now handle the click to start the select mode
         """
         self._start_select(event)
@@ -230,7 +230,7 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
 
         Finishes selecting and does the zoom.
         """
-        if self.drag_button == "left":
+        if self.drag_button in ("left", None):
             self._end_select(event)
         return
 


### PR DESCRIPTION
When the user set `drag_button=None` on the `ZoomTool` and entered zoom mode (by pressing 'z'), the left-button would start the zoom-box, but releasing the left-button did not end the selection.

Try running [edit_line.py](https://github.com/enthought/chaco/blob/master/examples/demo/edit_line.py), pressing 'z', then pressing the left-mouse-button, and releasing. (This assumes PR #93 hasn't been merged, since it removes the `drag_button=None` line.)

This might not be the right fix (depending on the intended behavior). Alternatively, `normal_key_pressed` should check for `drag_button == None`, so that the left-mouse-button doesn't start the 'pre_selecting' mode.
