### PR TITLE
Fix a bug which was causing axis objects to draw upside down.

### DIFF
--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -532,10 +532,10 @@ class PlotAxis(AbstractOverlay):
             self._title_orientation = array([0.,1.])
             self.title_angle = 0.0
             if self.orientation == 'top':
-                self._origin_point = array(self.position)
+                self._origin_point = array(self.position) + self._major_axis * screenlow
                 self._inside_vector = array([0.,-1.])
             else: #self.oriention == 'bottom'
-                self._origin_point = array(self.position) + array([0., self.bounds[1]])
+                self._origin_point = array(self.position) + array([0., self.bounds[1]]) + self._major_axis * screenlow
                 self._inside_vector = array([0., 1.])
 
         elif self.orientation in ('left', 'right'):
@@ -544,11 +544,11 @@ class PlotAxis(AbstractOverlay):
             self._major_axis = array([0., 1.])
             self._title_orientation = array([-1., 0])
             if self.orientation == 'left':
-                self._origin_point = array(self.position) + array([self.bounds[0], 0.])
+                self._origin_point = array(self.position) + array([self.bounds[0], 0.]) + self._major_axis * screenlow
                 self._inside_vector = array([1., 0.])
                 self.title_angle = 90.0
             else: #self.orientation == 'right'
-                self._origin_point = array(self.position)
+                self._origin_point = array(self.position) + self._major_axis * screenlow
                 self._inside_vector = array([-1., 0.])
                 self.title_angle = 270.0
 


### PR DESCRIPTION
When an axis mapper's high position is smaller than the mapper's low position, and axis will have the correct origin, but a wildly incorrect end point due to its vector pointing 180º off from where it should be pointing. A well-placed abs() fixes the problem.
