### PR TITLE
add 'metadata_name' trait to LassoSelection

### DIFF
--- a/chaco/tools/lasso_selection.py
+++ b/chaco/tools/lasso_selection.py
@@ -198,8 +198,8 @@ class LassoSelection(AbstractController):
 
         Ends the selection operation.
         """
-        print event
-        return
+        # Treat this as if it were a selecting_mouse_up event
+        return self.selecting_mouse_up(event)
 
     def normal_key_pressed(self, event):
         """ Handles the user pressing a key in the 'normal' state.


### PR DESCRIPTION
Tested against the relevant examples, and this is a pretty straightforward change that should not break downstream code (unless someone has a subclass of LassoSelection where they use metadata_name for some other purpose).
