### PR TITLE
Fix resizing bug in range_selection tool

### DIFF
--- a/chaco/tools/range_selection.py
+++ b/chaco/tools/range_selection.py
@@ -207,10 +207,6 @@ class RangeSelection(AbstractController):
         if self.enable_resize:
             if (abs(mouse_coord - high) <= self.resize_margin) or \
                             (abs(mouse_coord - low) <= self.resize_margin):
-                # HACK: Choose down point that is far enough away from the
-                # boundaries that resizing will never be deselected.
-                x_out = low - self.resize_margin - self.minimum_selection
-                self._down_point = array([x_out, x_out])
                 return self.selected_right_down(event)
 
         if tmp[self.axis_index] >= low and tmp[self.axis_index] <= high:
@@ -321,6 +317,7 @@ class RangeSelection(AbstractController):
 
         self.event_state = "selected"
         self.selection_completed = self.selection
+        self._down_point = []
         event.handled = True
         return
 
@@ -457,9 +454,17 @@ class RangeSelection(AbstractController):
     def selecting_button_up(self, event):
         # Check to see if the selection region is bigger than the minimum
         event.window.set_pointer("arrow")
-        start = self._down_point[self.axis_index]
+
         end = self._get_axis_coord(event)
-        if self.minimum_selection > abs(start - end):
+
+        if len(self._down_point) == 0:
+            cancel_selection = False
+        else:
+            start = self._down_point[self.axis_index]
+            self._down_point = []
+            cancel_selection = self.minimum_selection > abs(start - end)
+
+        if cancel_selection:
             self.deselect(event)
             event.handled = True
         else:


### PR DESCRIPTION
Resizing didn't save a mouse-down point. This, combined with that fact that selections below the `minimum_selection` size get deselected resulted in strange errors. For example, open up the [range selection demo](https://github.com/enthought/chaco/blob/master/examples/demo/range_selection_demo.py) and make a selection. Then save a mouse-down point by moving the selection a little bit (click within selection at x0 and drag to x0 + eps). Now, try to resize one of the edges to x0. The selection disappears because the difference between the _saved_ mouse-down point and the mouse-release point is small.

Also, since resizing doesn't save a mouse-down point, you could end up accessing the down point before its ever initialized. (I think this requires manually setting the event state to "selected"). For example, if you open the [trait editor demo](https://github.com/enthought/chaco/blob/master/examples/demo/chaco_trait_editor.py), and try to resize it, it will throw exceptions (and causes a crash of the IPython kernel in the IDE). Note the resize must be the first operation you try since moving the selection actually saves a down point.
