### PR TITLE
Overlay should not force a border to be drawn.

### DIFF
--- a/chaco/text_box_overlay.py
+++ b/chaco/text_box_overlay.py
@@ -5,7 +5,7 @@ from __future__ import with_statement
 # Enthought library imports
 from enable.api import ColorTrait
 from kiva.trait_defs.kiva_font_trait import KivaFont
-from traits.api import Any, Enum, Int, Str, Float, Trait
+from traits.api import Any, Enum, Int, Str, Float, Trait, Bool
 
 # Local, relative imports
 from abstract_overlay import AbstractOverlay
@@ -35,6 +35,9 @@ class TextBoxOverlay(AbstractOverlay):
 
     # The thickness of box border.
     border_size = Int(1)
+    
+    # The border visibility. Defaults to true to duplicate previous behavior.
+    border_visible = Bool(True)
 
     # Number of pixels of padding around the text within the box.
     padding = Int(5)
@@ -122,24 +125,25 @@ class TextBoxOverlay(AbstractOverlay):
             gc.set_stroke_color(self.border_color_)
             gc.set_fill_color(color)
 
-            # draw a rounded rectangle
-            x = y = 0
-            end_radius = 8.0
-            gc.begin_path()
-            gc.move_to(x + end_radius, y)
-            gc.arc_to(x + width, y,
-                    x + width,
-                    y + end_radius, end_radius)
-            gc.arc_to(x + width,
-                    y + height,
-                    x + width - end_radius,
-                    y + height, end_radius)
-            gc.arc_to(x, y + height,
-                    x, y,
-                    end_radius)
-            gc.arc_to(x, y,
-                    x + width + end_radius,
-                    y, end_radius)
-            gc.draw_path()
+            if self.border_visible:
+                # draw a rounded rectangle.
+                x = y = 0
+                end_radius = 8.0
+                gc.begin_path()
+                gc.move_to(x + end_radius, y)
+                gc.arc_to(x + width, y,
+                        x + width,
+                        y + end_radius, end_radius)
+                gc.arc_to(x + width,
+                        y + height,
+                        x + width - end_radius,
+                        y + height, end_radius)
+                gc.arc_to(x, y + height,
+                        x, y,
+                        end_radius)
+                gc.arc_to(x, y,
+                        x + width + end_radius,
+                        y, end_radius)
+                gc.draw_path()
 
             label.draw(gc)


### PR DESCRIPTION
Despite the typo in the commit message, this change allows control over the drawing of the border. 

Added border_visible trait as condition for drawing the border. Default is to draw the border to maintain previous behavior.
