### PR TITLE
Fix for Aspect Ratio Support in ZoomTool

### DIFF
--- a/chaco/tools/better_selecting_zoom.py
+++ b/chaco/tools/better_selecting_zoom.py
@@ -327,8 +327,6 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
         """ Ends selection of the zoom region, adds the new zoom range to
         the zoom stack, and does the zoom.
         """
-        self._screen_end = (event.x, event.y)
-
         start = numpy.array(self._screen_start)
         end = numpy.array(self._screen_end)
 


### PR DESCRIPTION
Aspect ratio was not honored if mouse pointer moved away from the square selection corner.  The removed line allowed any ROI to be selected outside of the region that was highlighted.

Now, the zoom is set to the highlighted region no matter where the mouse is unclicked.
