### PR TITLE
Refactor image plot

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ New features/Improvements
  * Replaced chaco.base.bin_search by numpy.searchsorted-based routine for
    5x speedup and remove use of zip in chaco.base.arg_find_runs in favour of
    column_stack for 10x speedup in bad cases. (PR #263)
+ * `ImagePlot` refactored to clarify transformation applied to images and allow
+   easier reuse of transformations in subclasses.
 
 Fixes
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,7 +10,7 @@ New features/Improvements
    5x speedup and remove use of zip in chaco.base.arg_find_runs in favour of
    column_stack for 10x speedup in bad cases. (PR #263)
  * `ImagePlot` refactored to clarify transformation applied to images and allow
-   easier reuse of transformations in subclasses.
+   easier reuse of transformations in subclasses. (PR #147)
 
 Fixes
 

--- a/chaco/image_plot.py
+++ b/chaco/image_plot.py
@@ -24,6 +24,7 @@ from kiva.agg import GraphicsContextArray
 
 # Local relative imports
 from base_2d_plot import Base2DPlot
+from image_utils import trim_screen_rect
 
 try:
     # InterpolationQuality required for Quartz backend only (requires OSX).
@@ -241,8 +242,12 @@ class ImagePlot(Base2DPlot):
 
         virtual_rect = self._calc_virtual_screen_bbox()
         index_bounds, screen_rect = self._calc_zoom_coords(virtual_rect)
-
         col_min, col_max, row_min, row_max = index_bounds
+
+        view_rect = self.position + self.bounds
+        sub_array_size = (col_max - col_min, row_max - row_min)
+        screen_rect = trim_screen_rect(screen_rect, view_rect, sub_array_size)
+
         data = data[row_min:row_max, col_min:col_max]
 
         if mapper is not None:

--- a/chaco/image_plot.py
+++ b/chaco/image_plot.py
@@ -122,6 +122,9 @@ class ImagePlot(Base2DPlot):
         scale_y = 1 if self.y_axis_is_flipped else -1
 
         x, y, w, h = self._cached_dest_rect
+        if w <= 0 or h <= 0:
+            return
+
         x_center = x + w / 2
         y_center = y + h / 2
         with gc:

--- a/chaco/image_plot.py
+++ b/chaco/image_plot.py
@@ -26,13 +26,14 @@ from kiva.agg import GraphicsContextArray
 from base_2d_plot import Base2DPlot
 
 try:
+    # InterpolationQuality required for Quartz backend only (requires OSX).
     from kiva.quartz.ABCGI import InterpolationQuality
 except ImportError:
     pass
 else:
-    KIVA_INTERP_QUALITY = {"nearest": InterpolationQuality.none,
-                           "bilinear": InterpolationQuality.low,
-                           "bicubic": InterpolationQuality.high}
+    QUARTZ_INTERP_QUALITY = {"nearest": InterpolationQuality.none,
+                             "bilinear": InterpolationQuality.low,
+                             "bicubic": InterpolationQuality.high}
 
 
 KIVA_DEPTH_MAP = {3: "rgb24", 4: "rgba32"}
@@ -183,7 +184,7 @@ class ImagePlot(Base2DPlot):
     def _temporary_interp_setting(self, gc):
         if hasattr(gc, "set_interpolation_quality"):
             # Quartz uses interpolation setting on the destination GC.
-            interp_quality = KIVA_INTERP_QUALITY[self.interpolation]
+            interp_quality = QUARTZ_INTERP_QUALITY[self.interpolation]
             gc.set_interpolation_quality(interp_quality)
             yield
         elif hasattr(gc, "set_image_interpolation"):
@@ -250,7 +251,7 @@ class ImagePlot(Base2DPlot):
         if len(data.shape) != 3:
             raise RuntimeError("`ImagePlot` requires color images.")
         elif data.shape[2] not in KIVA_DEPTH_MAP:
-            msg = "Unknown colormap depth value: {}"
+            msg = "Unknown colormap depth value: {0}"
             raise RuntimeError(msg.format(data.shape[2]))
         kiva_depth = KIVA_DEPTH_MAP[data.shape[2]]
 

--- a/chaco/image_plot.py
+++ b/chaco/image_plot.py
@@ -18,7 +18,8 @@ from contextlib import contextmanager
 import numpy as np
 
 # Enthought library imports.
-from traits.api import Bool, Either, Enum, Instance, List, Range, Trait, Tuple
+from traits.api import (Bool, Either, Enum, Instance, List, Range, Trait,
+                        Tuple, Property, cached_property)
 from kiva.agg import GraphicsContextArray
 
 # Local relative imports
@@ -51,6 +52,12 @@ class ImagePlot(Base2DPlot):
     # The interpolation method to use when rendering an image onto the GC.
     interpolation = Enum("nearest", "bilinear", "bicubic")
 
+    # Bool indicating whether x-axis is flipped.
+    x_axis_is_flipped = Property(depends_on=['orientation', 'origin'])
+
+    # Bool indicating whether y-axis is flipped.
+    y_axis_is_flipped = Property(depends_on=['orientation', 'origin'])
+
     #------------------------------------------------------------------------
     # Private traits
     #------------------------------------------------------------------------
@@ -65,17 +72,21 @@ class ImagePlot(Base2DPlot):
     # **_cached_image** is to be drawn.
     _cached_dest_rect = Either(Tuple, List)
 
+    # Bool indicating whether the origin is top-left or bottom-right.
+    # The name "principal diagonal" is borrowed from linear algebra.
+    _origin_on_principal_diagonal = Property(depends_on='origin')
+
     #------------------------------------------------------------------------
     # Properties
     #------------------------------------------------------------------------
 
-    @property
-    def x_axis_is_flipped(self):
+    @cached_property
+    def _get_x_axis_is_flipped(self):
         return ((self.orientation == 'h' and 'right' in self.origin) or
                 (self.orientation == 'v' and 'top' in self.origin))
 
-    @property
-    def y_axis_is_flipped(self):
+    @cached_property
+    def _get_y_axis_is_flipped(self):
         return ((self.orientation == 'h' and 'top' in self.origin) or
                 (self.orientation == 'v' and 'right' in self.origin))
 
@@ -152,9 +163,8 @@ class ImagePlot(Base2DPlot):
     # Private methods
     #------------------------------------------------------------------------
 
-    @property
-    def _origin_on_principal_diagonal(self):
-        # The name "principal diagonal" comes from linear algebra.
+    @cached_property
+    def _get__origin_on_principal_diagonal(self):
         bottom_right = 'bottom' in self.origin and 'right' in self.origin
         top_left = 'top' in self.origin and 'left' in self.origin
         return bottom_right or top_left

--- a/chaco/image_utils.py
+++ b/chaco/image_utils.py
@@ -1,0 +1,36 @@
+
+X_PARAMS = (0, 2)  # index for x-position and width
+Y_PARAMS = (1, 3)  # index for y-position and height
+
+
+def trim_screen_rect(screen_rect, view_rect, sub_array_size):
+    """ Trim sub-image screen rectangle for highly zoomed in states.
+
+    When zoomed into one or two pixels (in any dimension), the screen rectangle
+    for those pixels can extend without bound outside of the plot area. This
+    function will return altered bounds to remove unnecessary rendering.
+    """
+    screen_rect = list(screen_rect)  # Copy values that we'll be modifying.
+
+    for n_px, (i_pos, i_length) in zip(sub_array_size, (X_PARAMS, Y_PARAMS)):
+        if n_px == 1:
+            screen_max = screen_rect[i_pos] + screen_rect[i_length]
+            view_max = view_rect[i_pos] + view_rect[i_length]
+            # Viewer bounds shows single pixel, so we can clip the actual pixel
+            # bounds to the viewer bounds.
+            new_min = max(screen_rect[i_pos], view_rect[i_pos])
+            new_max = min(screen_max, view_max)
+            screen_rect[i_pos] = new_min
+            screen_rect[i_length] = new_max - new_min
+        elif n_px == 2:
+            image_length = screen_rect[i_length]
+            # Viewer displays 2 pixels; if we scale down the sub-image's screen
+            # size to twice the viewer size, we can be sure that any offset
+            # will cover the entire screen.
+            scale = 2 * view_rect[i_length] / float(image_length)
+            if scale < 1:
+                # Sub-image is two pixels wide, so pixel size is half the image
+                pixel_length = image_length/2
+                screen_rect[i_length] *= scale
+                screen_rect[i_pos] += (1-scale) * pixel_length
+    return screen_rect

--- a/chaco/tests/test_image_plot.py
+++ b/chaco/tests/test_image_plot.py
@@ -1,0 +1,164 @@
+import os
+import tempfile
+from contextlib import contextmanager
+
+import numpy as np
+from skimage import io
+from skimage.data import coins
+from skimage.color import gray2rgb
+
+from traits.etsconfig.api import ETSConfig
+from chaco.api import (PlotGraphicsContext, GridDataSource, GridMapper,
+                       DataRange2D, ImageData, ImagePlot)
+
+
+# The Quartz backend rescales pixel values, so use a higher threshold.
+MAX_RMS_ERROR = 16 if ETSConfig.kiva_backend == 'quartz' else 1
+
+IMAGE = coins()
+RGB = gray2rgb(IMAGE)
+# Rendering adds rows and columns for some reason.
+TRIM_RENDERED = (slice(2, None), slice(0, -2), 0)
+
+
+@contextmanager
+def temp_image_file(suffix='.png', prefix='test', dir=None):
+    fd, filename = tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=dir)
+    try:
+        yield filename
+    finally:
+        os.close(fd)
+        os.remove(filename)
+
+
+def get_image_index_and_mapper(image):
+    h, w = image.shape[:2]
+    index = GridDataSource(np.arange(h), np.arange(w))
+    index_mapper = GridMapper(range=DataRange2D(low=(0, 0), high=(h-1, w-1)))
+    return index, index_mapper
+
+
+def save_renderer_result(renderer, filename):
+    renderer.padding = 0
+    gc = PlotGraphicsContext(renderer.outer_bounds)
+    with gc:
+        gc.render_component(renderer)
+        gc.save(filename)
+
+
+def image_from_renderer(renderer, orientation):
+    data = renderer.value
+    # Set bounding box size and origin to align rendered image with array
+    renderer.bounds = (data.get_width() + 1, data.get_height() + 1)
+    if orientation == 'v':
+        renderer.bounds = renderer.bounds[::-1]
+    renderer.position = 0.5, 0.5
+
+    with temp_image_file() as filename:
+        save_renderer_result(renderer, filename)
+        rendered_image = io.imread(filename)[TRIM_RENDERED]
+    return rendered_image
+
+
+def rendered_image_result(image, filename=None, **plot_kwargs):
+    data_source = ImageData(data=image)
+    index, index_mapper = get_image_index_and_mapper(image)
+    renderer = ImagePlot(value=data_source, index=index,
+                         index_mapper=index_mapper,
+                         **plot_kwargs)
+    orientation = plot_kwargs.get('orientation', 'h')
+    return image_from_renderer(renderer, orientation)
+
+
+def calculate_rms(image_result, expected_image):
+    """Return root-mean-square error.
+
+    Implementation taken from matplotlib.
+    """
+    # calculate the per-pixel errors, then compute the root mean square error
+    num_values = np.prod(expected_image.shape)
+    # Cast to int64 to reduce likelihood of over-/under-flow.
+    abs_diff_image = abs(np.int64(expected_image) - np.int64(image_result))
+
+    histogram = np.bincount(abs_diff_image.ravel(), minlength=256)
+    sum_of_squares = np.sum(histogram * np.arange(len(histogram))**2)
+    rms = np.sqrt(float(sum_of_squares) / num_values)
+    return rms
+
+
+def verify_result_image(input_image, expected_image, **plot_kwargs):
+    # These tests were written assuming uint8 inputs.
+    assert input_image.dtype == np.uint8
+    assert expected_image.dtype == np.uint8
+    image_result = rendered_image_result(input_image, **plot_kwargs)
+    rms = calculate_rms(image_result, expected_image)
+    print "RMS =", rms
+    assert rms < MAX_RMS_ERROR
+
+
+def plot_comparison(input_image, expected_image, **plot_kwargs):
+    import matplotlib.pyplot as plt
+
+    image_result = rendered_image_result(input_image, **plot_kwargs)
+    diff = np.int64(expected_image) - np.int64(image_result)
+    max_diff = max(abs(diff.min()), abs(diff.max()), 1)
+
+    fig, (ax0, ax1, ax2) = plt.subplots(ncols=3, sharex='all', sharey='all')
+    ax0.imshow(expected_image)
+    ax1.imshow(image_result)
+    im_plot = ax2.imshow(diff, vmin=-max_diff, vmax=max_diff, cmap=plt.cm.bwr)
+    fig.colorbar(im_plot)
+    plt.show()
+
+
+def test_horizontal_top_left():
+    # Horizontal orientation with top left origin renders original image.
+    verify_result_image(RGB, IMAGE, origin='top left')
+
+
+def test_horizontal_bottom_left():
+    # Horizontal orientation with bottom left origin renders a vertically
+    # flipped image.
+    verify_result_image(RGB, IMAGE[::-1], origin='bottom left')
+
+
+def test_horizontal_top_right():
+    # Horizontal orientation with top right origin renders a horizontally
+    # flipped image.
+    verify_result_image(RGB, IMAGE[:, ::-1], origin='top right')
+
+
+def test_horizontal_bottom_right():
+    # Horizontal orientation with top right origin renders an image flipped
+    # horizontally and vertically.
+    verify_result_image(RGB, IMAGE[::-1, ::-1], origin='bottom right')
+
+
+def test_vertical_top_left():
+    # Vertical orientation with top left origin renders transposed image.
+    verify_result_image(RGB, IMAGE.T, origin='top left', orientation='v')
+
+
+def test_vertical_bottom_left():
+    # Vertical orientation with bottom left origin renders transposed image
+    # that is vertically flipped.
+    verify_result_image(RGB, (IMAGE.T)[::-1],
+                        origin='bottom left', orientation='v')
+
+
+def test_vertical_top_right():
+    # Vertical orientation with top right origin renders transposed image
+    # that is horizontally flipped.
+    verify_result_image(RGB, (IMAGE.T)[:, ::-1],
+                        origin='top right', orientation='v')
+
+
+def test_vertical_bottom_right():
+    # Vertical orientation with bottom right origin renders transposed image
+    # that is flipped vertically and horizontally.
+    verify_result_image(RGB, (IMAGE.T)[::-1, ::-1],
+                        origin='bottom right', orientation='v')
+
+
+if __name__ == "__main__":
+    np.testing.run_module_suite()

--- a/chaco/tests/test_image_plot.py
+++ b/chaco/tests/test_image_plot.py
@@ -15,7 +15,7 @@ MAX_RMS_ERROR = 16 if ETSConfig.kiva_backend == 'quartz' else 1
 IMAGE = np.random.random_integers(0, 255, size=(100, 200)).astype(np.uint8)
 RGB = np.dstack([IMAGE] * 3)
 # Rendering adds rows and columns for some reason.
-TRIM_RENDERED = (slice(2, None), slice(0, -2), 0)
+TRIM_RENDERED = (slice(1, -1), slice(1, -1), 0)
 
 
 @contextmanager
@@ -49,7 +49,7 @@ def image_from_renderer(renderer, orientation):
     renderer.bounds = (data.get_width() + 1, data.get_height() + 1)
     if orientation == 'v':
         renderer.bounds = renderer.bounds[::-1]
-    renderer.position = 0.5, 0.5
+    renderer.position = 0, 0
 
     with temp_image_file() as filename:
         save_renderer_result(renderer, filename)

--- a/chaco/tests/test_image_plot.py
+++ b/chaco/tests/test_image_plot.py
@@ -3,7 +3,6 @@ import tempfile
 from contextlib import contextmanager
 
 import numpy as np
-from scipy.misc import lena
 
 from traits.etsconfig.api import ETSConfig
 from chaco.api import (PlotGraphicsContext, GridDataSource, GridMapper,
@@ -13,7 +12,7 @@ from chaco.api import (PlotGraphicsContext, GridDataSource, GridMapper,
 # The Quartz backend rescales pixel values, so use a higher threshold.
 MAX_RMS_ERROR = 16 if ETSConfig.kiva_backend == 'quartz' else 1
 
-IMAGE = lena().astype(np.uint8)
+IMAGE = np.random.random_integers(0, 255, size=(100, 200)).astype(np.uint8)
 RGB = np.dstack([IMAGE] * 3)
 # Rendering adds rows and columns for some reason.
 TRIM_RENDERED = (slice(2, None), slice(0, -2), 0)

--- a/chaco/tests/test_image_plot.py
+++ b/chaco/tests/test_image_plot.py
@@ -3,9 +3,7 @@ import tempfile
 from contextlib import contextmanager
 
 import numpy as np
-from skimage import io
-from skimage.data import coins
-from skimage.color import gray2rgb
+from scipy.misc import lena
 
 from traits.etsconfig.api import ETSConfig
 from chaco.api import (PlotGraphicsContext, GridDataSource, GridMapper,
@@ -15,8 +13,8 @@ from chaco.api import (PlotGraphicsContext, GridDataSource, GridMapper,
 # The Quartz backend rescales pixel values, so use a higher threshold.
 MAX_RMS_ERROR = 16 if ETSConfig.kiva_backend == 'quartz' else 1
 
-IMAGE = coins()
-RGB = gray2rgb(IMAGE)
+IMAGE = lena().astype(np.uint8)
+RGB = np.dstack([IMAGE] * 3)
 # Rendering adds rows and columns for some reason.
 TRIM_RENDERED = (slice(2, None), slice(0, -2), 0)
 
@@ -56,7 +54,7 @@ def image_from_renderer(renderer, orientation):
 
     with temp_image_file() as filename:
         save_renderer_result(renderer, filename)
-        rendered_image = io.imread(filename)[TRIM_RENDERED]
+        rendered_image = ImageData.fromfile(filename).data[TRIM_RENDERED]
     return rendered_image
 
 

--- a/chaco/tests/test_image_plot.py
+++ b/chaco/tests/test_image_plot.py
@@ -19,7 +19,7 @@ TRIM_RENDERED = (slice(2, None), slice(0, -2), 0)
 
 
 @contextmanager
-def temp_image_file(suffix='.png', prefix='test', dir=None):
+def temp_image_file(suffix='.tif', prefix='test', dir=None):
     fd, filename = tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=dir)
     try:
         yield filename

--- a/chaco/tests/test_image_utils.py
+++ b/chaco/tests/test_image_utils.py
@@ -1,0 +1,61 @@
+from numpy.testing import assert_allclose, assert_equal
+
+from chaco.image_utils import trim_screen_rect, X_PARAMS, Y_PARAMS
+
+
+SINGLE_PIXEL = (1, 1)
+FOUR_PIXELS = (2, 2)
+
+
+def midpoint(x, length):
+    return x + length / 2.0
+
+
+def assert_midpoints_equal(bounds_list):
+
+    for i_pos, i_length in (X_PARAMS, Y_PARAMS):
+        x_mid = [midpoint(bnd[i_pos], bnd[i_length]) for bnd in bounds_list]
+        assert_equal(x_mid[0], x_mid[1])
+
+
+def test_viewer_zoomed_into_single_pixel():
+    screen_rect = [0, 0, 100, 100]
+    view_rect = [10, 11, 1, 2]
+    new_rect = trim_screen_rect(screen_rect, view_rect, SINGLE_PIXEL)
+    assert_allclose(new_rect, view_rect)
+
+
+def test_viewer_at_corner_of_single_image():
+    offset = 0.2
+    screen_rect = [1, 1, 1, 1]
+    new_size = [1-offset, 1-offset]
+
+    down_right = [1+offset, 1+offset, 1, 1]
+    new_rect = trim_screen_rect(screen_rect, down_right, SINGLE_PIXEL)
+    expected_rect = down_right[:2] + new_size
+    assert_midpoints_equal((new_rect, expected_rect))
+
+    up_left = [1-offset, 1-offset, 1, 1]
+    new_rect = trim_screen_rect(screen_rect, up_left, SINGLE_PIXEL)
+    expected_rect = [1, 1] + new_size
+    assert_midpoints_equal((new_rect, expected_rect))
+
+
+def test_viewer_zoomed_into_four_pixel_intersection():
+    screen_rect = [0, 0, 100, 100]  # 4-pixel intersection at (50, 50)
+    view_rectangles = ([49, 49, 2, 2],  # Centered pixel intersection
+                       [49, 49, 3, 3],  # Intersection at 1/3 of view
+                       [49, 49, 2, 3])  # Intersection at 1/2, 1/3 of view
+    for view_rect in view_rectangles:
+        new_rect = trim_screen_rect(screen_rect, view_rect, FOUR_PIXELS)
+        yield assert_midpoints_equal, (new_rect, screen_rect)
+
+
+def test_viewer_at_corner_of_four_pixel_image():
+    offset = 0.2
+    screen_rect = [1, 1, 1, 1]
+    view_rectangles = ([1+offset, 1+offset, 1, 1],  # Shifted down and right
+                       [1-offset, 1-offset, 1, 1])  # Shifted up and left
+    for view_rect in view_rectangles:
+        new_rect = trim_screen_rect(screen_rect, view_rect, FOUR_PIXELS)
+        yield assert_equal, new_rect, screen_rect

--- a/examples/demo/image_plot_origin_and_orientation.py
+++ b/examples/demo/image_plot_origin_and_orientation.py
@@ -1,0 +1,79 @@
+"""
+Demonstration of altering a plot's origin and orientation.
+
+The origin parameter sets a plot's default origin to the specified corner
+of the plot window. These positions has the following behavior:
+    * 'left' : index increases left to right
+    * 'right' : index increases right to left
+    * 'top' : index increases top to bottom
+    * 'bottom' : index increases bottom to top
+
+The orientation parameter switches the x- and y-axes. Alternatively, you can
+think of this as a transpose about the origin.
+"""
+
+# Major library imports
+from scipy.misc import lena
+
+# Enthought library imports
+from enable.api import Component, ComponentEditor
+from traits.api import HasTraits, Instance
+from traitsui.api import UItem, Group, View
+
+# Chaco imports
+from chaco.api import ArrayPlotData, GridContainer, Plot
+from chaco.tools.api import PanTool, ZoomTool
+
+
+class Demo(HasTraits):
+    plot = Instance(Component)
+
+    traits_view = View(
+        Group(
+            UItem('plot', editor=ComponentEditor(size=(1000, 500))),
+            orientation = "vertical"
+        ),
+        resizable=True, title="Demo of image origin and orientation"
+    )
+
+    def _plot_default(self):
+        # Create a GridContainer to hold all of our plots: 2 rows, 4 columns:
+        container = GridContainer(fill_padding=True,
+                                  bgcolor="lightgray", use_backbuffer=True,
+                                  shape=(2, 4))
+
+        arrangements = [('top left', 'h'),
+                        ('top right', 'h'),
+                        ('top left', 'v'),
+                        ('top right', 'v'),
+                        ('bottom left', 'h'),
+                        ('bottom right', 'h'),
+                        ('bottom left', 'v'),
+                        ('bottom right', 'v')]
+        orientation_name = {'h': 'horizontal', 'v': 'vertical'}
+
+        pd = ArrayPlotData(image=lena())
+        # Plot some bessel functions and add the plots to our container
+        for origin, orientation in arrangements:
+            plot = Plot(pd, default_origin=origin, orientation=orientation)
+            plot.img_plot('image')
+
+            # Attach some tools to the plot
+            plot.tools.append(PanTool(plot))
+            zoom = ZoomTool(plot, tool_mode="box", always_on=False)
+            plot.overlays.append(zoom)
+
+            title = '{}, {}'
+            plot.title = title.format(orientation_name[orientation],
+                                      origin.replace(' ', '-'))
+
+            # Add to the grid container
+            container.add(plot)
+
+        return container
+
+
+demo = Demo()
+
+if __name__ == "__main__":
+    demo.configure_traits()

--- a/examples/demo/image_plot_origin_and_orientation.py
+++ b/examples/demo/image_plot_origin_and_orientation.py
@@ -31,7 +31,7 @@ class Demo(HasTraits):
     traits_view = View(
         Group(
             UItem('plot', editor=ComponentEditor(size=(1000, 500))),
-            orientation = "vertical"
+            orientation="vertical"
         ),
         resizable=True, title="Demo of image origin and orientation"
     )
@@ -63,7 +63,7 @@ class Demo(HasTraits):
             zoom = ZoomTool(plot, tool_mode="box", always_on=False)
             plot.overlays.append(zoom)
 
-            title = '{}, {}'
+            title = '{0}, {1}'
             plot.title = title.format(orientation_name[orientation],
                                       origin.replace(' ', '-'))
 
@@ -74,6 +74,7 @@ class Demo(HasTraits):
 
 
 demo = Demo()
+
 
 if __name__ == "__main__":
     demo.configure_traits()


### PR DESCRIPTION
While adding some plotting capabilities to an `ImagePlot` subclass (see https://github.com/enthought/geolibs/pull/43), I ended up having to refactor `ImagePlot` quite a bit.

This PR cleans up some of the coordinate transforms in `ImagePlot` and fixes an issue with negative screen sizes (see https://github.com/enthought/enable/issues/109). I've also added tests, but I'm not sure how robust this testing is: It requires precise pixel positions in the rendered image. (This positioning is achieved using a tweaked index grid, tweaked plot bounds, and slicing some "extra" rows/columns off the rendered image. Probably a bit fragile :P)