### PR TITLE
Fix initialization of `Label._text_needs_fitting.`

### DIFF
--- a/chaco/label.py
+++ b/chaco/label.py
@@ -75,7 +75,7 @@ class Label(HasTraits):
 
     _bounding_box = List()
     _position_cache_valid = Bool(False)
-    _text_needs_fitting = Bool(True)
+    _text_needs_fitting = Bool(False)
     _line_xpos = Any()
     _line_ypos = Any()
     _rot_matrix = Any()
@@ -190,8 +190,7 @@ class Label(HasTraits):
     #------------------------------------------------------------------------
 
     def _text_changed(self):
-        if self.max_width > 0.0:
-            self._text_needs_fitting = True
+        self._text_needs_fitting = (self.max_width > 0.0)
 
     @on_trait_change("font,margin,text,rotate_angle")
     def _invalidate_position_cache(self):


### PR DESCRIPTION
`_text_needs_fitting` was always initialized to True, even when `max_width` was set to zero. As a result, labels (e.g. plot titles, as shown below) wrap by default:

![chaco_label_bug](https://f.cloud.github.com/assets/133031/1502077/bae6000a-4895-11e3-9f30-a3babc4af8f6.png)

PR Note: The default value for `_text_needs_fitting` doesn't really matter (the change in the conditional does), but it was changed for consistency with the default `max_width`.

Example script:

``` python
from enable.api import Component, ComponentEditor
from traits.api import HasTraits, Instance
from traitsui.api import UItem, View

from chaco.api import ArrayPlotData, Plot


class Demo(HasTraits):

    plot = Instance(Component)

    traits_view = View(UItem('plot', editor=ComponentEditor(size=(600, 600))))

    def _plot_default(self):
        pd = ArrayPlotData(x=[0, 1])
        plot = Plot(pd)
        plot.plot('x')
        # Uncomment to trigger text wrapping
        # plot._title._label.max_width = 1
        plot.title = 'multi word title'
        return plot


demo = Demo()


if __name__ == "__main__":
    demo.configure_traits()
```
