### PR TITLE
define a PlotGraphicsContext when saving as .bmp / .png / .jpg

### DIFF
--- a/chaco/shell/commands.py
+++ b/chaco/shell/commands.py
@@ -793,7 +793,7 @@ def save(filename="chacoplot.png", dpi=72, pagesize="letter", dest_box=None, uni
 
     elif ext in [".bmp", ".png", ".jpg"]:
         from chaco.api import PlotGraphicsContext
-        gc = PlotGraphicsContext(tuple(p.outer_bounds), **{'dpi': dpi})
+        gc = PlotGraphicsContext(tuple(p.outer_bounds), dpi=dpi)
 
         # temporarily turn off the backbuffer for offscreen rendering
         use_backbuffer = p.use_backbuffer


### PR DESCRIPTION
no graphics context was defined in that case, causing an error. I'm using PlotGraphicsContext now.
