### PR TITLE
Small fix for RangeSelection:

### DIFF
--- a/chaco/tools/range_selection.py
+++ b/chaco/tools/range_selection.py
@@ -201,7 +201,7 @@ class RangeSelection(AbstractController):
         low = min(screen_bounds)
         high = max(screen_bounds)
         tmp = (event.x, event.y)
-        ndx = self._determine_axis()
+        ndx = self.axis_index
         mouse_coord = tmp[ndx]
 
         if self.enable_resize:
@@ -209,11 +209,11 @@ class RangeSelection(AbstractController):
                             (abs(mouse_coord - low) <= self.resize_margin):
                 return self.selected_right_down(event)
 
-        if tmp[self.axis_index] >= low and tmp[self.axis_index] <= high:
+        if low <= tmp[ndx] <= high:
             self.event_state = "moving"
             self._down_point = array([event.x, event.y])
             self._down_data_coord = \
-                self.mapper.map_data(self._down_point)[self.axis_index]
+                self.mapper.map_data(self._down_point)[ndx]
             self._original_selection = array(self.selection)
         elif self.allow_deselection:
             self.deselect(event)
@@ -240,7 +240,7 @@ class RangeSelection(AbstractController):
             if coords is not None:
                 start, end = coords
                 tmp = (event.x, event.y)
-                ndx = self._determine_axis()
+                ndx = self.axis_index
                 mouse_coord = tmp[ndx]
                 # We have to do a little swapping; the "end" point
                 # is always what gets updated, so if the user
@@ -283,7 +283,7 @@ class RangeSelection(AbstractController):
             if coords is not None:
                 start, end = coords
                 tmp = (event.x, event.y)
-                ndx = self._determine_axis()
+                ndx = self.axis_index
                 mouse_coord = tmp[ndx]
                 if abs(mouse_coord - end) <= self.resize_margin or \
                         abs(mouse_coord - start) <= self.resize_margin:


### PR DESCRIPTION
While parts of the code refer to `self.axis_index`, other parts refer
to `self._determine_axis()`. According to the doc, `self._determine_axis`
is only ever used, when `self._axis_index` is not set. In fact, the
property getter for `self.axis_index` handles this case, so `self.axis_index`
should be used in all cases.

It will only affect the behaviour if indeed `axis_index` is being assigned
to something different than the usual value, which will hardly every be.
Nonetheless, I guess we prefer correctness.
