### PR TITLE
BUG: include _isnan.h to fix cython speedup compilation.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include chaco/*.h


### PR DESCRIPTION
This is necessary for the release as the sdist-produced tarball cannot be compiled without it.
