### PR TITLE
Version number bump for release of 4.4.1.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,7 +2,7 @@
 Chaco CHANGELOG
 ===============
 
-Release 4.4.0
+Release 4.4.1
 -------------
 This release contains a lot of enhancements and bug fixes mostly to the OOP API of Chaco but also its shell mode.
 

--- a/chaco/__init__.py
+++ b/chaco/__init__.py
@@ -3,7 +3,7 @@
 """ Two-dimensional plotting application toolkit.
     Part of the Chaco project of the Enthought Tool Suite.
 """
-__version__ = '4.4.0'
+__version__ = '4.4.1'
 
 __requires__ = [
    'enable',


### PR DESCRIPTION
Since a change to the MANIFEST.in file was made for the release on PyPI, a new release of chaco to 4.4.1 is needed.
