### PR TITLE
Python 2.6 with `system_site_packages: true` was broken.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: python
 python:
-  - 2.7
+  - "2.7_with_system_site_packages"
   - 2.6
-virtualenv:
-  # This allows installing PyQt using apt-get and being able to import it.
-  system_site_packages: true
 before_install:
   - sudo apt-get update
   - sudo apt-get install python-numpy swig


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/2219 for reference
