### PR TITLE
Adding a 'list of polygons' capability

### DIFF
--- a/chaco/polygon_plot.py
+++ b/chaco/polygon_plot.py
@@ -100,7 +100,7 @@ class PolygonPlot(BaseXYPlot):
             gc.set_line_dash(self.edge_style_)
             gc.set_fill_color(self.effective_face_color)
 
-            # bnds is True where where polygons are separated, last is also True
+            # bnds is True where polygons are separated + ensures last is True
             # indx contains the list of indices that separates the polygons
             # lines contains a list of lines that represents all polygons
             bnds = [np.isnan(point[0]) for point in points]
@@ -146,7 +146,7 @@ class PolygonPlot(BaseXYPlot):
         value = self.value.get_data()
         points = zip(index,value)
 
-        # bnds is True where where polygons are separated, last is also True
+        # bnds is True where polygons are separated + ensures last is True
         # indx contains the list of indices that separates the polygons
         # lines contains a list of lines that represents all polygons
         bnds = [np.isnan(point[0]) for point in points]


### PR DESCRIPTION
Hi,

I'm using the PolygonPlot function of chaco for a personal project. Unfortunately it becomes really slow when the number of polygons starts to increase and eventually becomes unusable. While googling I found that with matplotlib there is a simple way to plot a list of polygons in one single call (see http://exnumerus.blogspot.com/2011/02/how-to-quickly-plot-polygons-in.html) by simple sending a list of coordinates separated by None to identify the different polygons.

So, I implemented the same idea in chaco to speed-up the plot of a list of polygons. I used numpy.nan instead of None because it needed 'float'. The modification of polygon_plot is trivial, I just receive the list of polygons and cut it in a list of polygons according to the numpy.nan before doing the plot of each polygon within a loop. (I tried several ways of creating the list, from the most trivial to the one currently implemented. The latter is 1.5 times faster than the trivial way of doing it, so I kept it.)

I also modified the hittest to work with the list of polygons. Of course a list of polygons is seen as only one object and it has been coded such that if you send only one polygon the way it is originally done, it also works as expected.

The only restriction for now, is that this allows to send a list of polygons that must have the same properties: face_color, edge_color, line width... but this is nonetheless very useful I think.

I wrote 3 basic scripts to test that:

1) https://github.com/SDiot/chaco_troubles/blob/master/FastPolygonPlot.py : creates a list of 1000 random polygons and plot it with the original technique and with the new one and measure the computational times. On my machine the original method takes 3.8s while the new one 0.007s for 1000 polygons. Moreover for 2000 polygons, the original takes 14.8s and the new one 0.008s... thus being almost independent of the number of polygons!

2) https://github.com/SDiot/chaco_troubles/blob/master/polygon_move.py : a simplified version of "Polygon plot with drag-move" where 4 polygons are plotted and can be dragged using the left click. This is only to show that the behavior didn't change with the modification of hittest.

3) https://github.com/SDiot/chaco_troubles/blob/master/polygon_move_list.py : a simplified version of "Polygon plot with drag-move" where 4 lists of polygons are plotted and can be dragged using the left click. This intends to show that the modification of hittest works as expected, i.e. each list of polygons is seen as an object and any click in one of the polygons of the list allows to drag the whole list.

This simple modification allowed me to use PolygonPlot for my application, I hope it will be interested for some of you!

S.

PS: I'm currently thinking about an extension where a list of face_colors/edge_colors/line_width/... could be send at the same time as the list of polygons to make it even more general.
