### PR TITLE
Add default position and tests for BetterZoom

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,11 @@
 Chaco CHANGELOG
 ===============
 
+Change summary since 4.5.0
+
+Fixes
+
+ * Fixed default position attribute in BetterZoom tool (PR#241)
 
 What's new in Chaco 4.5.0
 -------------------------
@@ -13,7 +18,7 @@ New features/Improvements
  * Added perceptual colormaps by Matteo Niccoli, Dave Green and Kenneth Moreland.
  * Added `asynchronous_updates.py` demo that shows a pattern for generating
    expensive plots while keeping the interface responsive (PR#170).
- * Speeded up by 10x the data mappers of the `GridMapper` class (mapping of 2D data 
+ * Speeded up by 10x the data mappers of the `GridMapper` class (mapping of 2D data
    to/from screen space).
 
 

--- a/chaco/tools/better_zoom.py
+++ b/chaco/tools/better_zoom.py
@@ -1,4 +1,13 @@
-import numpy
+# Copyright (c) 2005-2014, Enthought, Inc.
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+# Thanks for using Enthought open source!
+#
+# Author: Enthought, Inc.
 
 from chaco.grid_mapper import GridMapper
 from enable.api import BaseTool, KeySpec
@@ -43,13 +52,13 @@ class BetterZoom(BaseTool, ToolHistoryMixin):
     # only applies in 'range' mode.
     axis = Enum("both", "index", "value")
 
-    # The maximum ratio between the original data space bounds and the zoomed-in
-    # data space bounds.  If No limit is desired, set to inf
+    # The maximum ratio between the original data space bounds and the
+    # zoomed-in data space bounds.  If No limit is desired, set to inf
     x_max_zoom_factor = Float(1e5)
     y_max_zoom_factor = Float(1e5)
 
-    # The maximum ratio between the zoomed-out data space bounds and the original
-    # bounds.  If No limit is desired, set to -inf
+    # The maximum ratio between the zoomed-out data space bounds and the
+    # original bounds.  If No limit is desired, set to -inf
     x_min_zoom_factor = Float(1e-5)
     y_min_zoom_factor = Float(1e-5)
 
@@ -86,7 +95,7 @@ class BetterZoom(BaseTool, ToolHistoryMixin):
                 y = y_map.map_data(location[1])
                 nexty = y + (cy - y)*(self._value_factor/new_value_factor)
 
-            pan_state = PanState((cx,cy), (nextx, nexty))
+            pan_state = PanState((cx, cy), (nextx, nexty))
             zoom_state = ZoomState((self._index_factor, self._value_factor),
                                    (new_index_factor, new_value_factor))
 
@@ -187,7 +196,6 @@ class BetterZoom(BaseTool, ToolHistoryMixin):
             if self._zoom_limit_reached(new_value_factor, 'x'):
                 return
         self._do_zoom(new_index_factor, new_value_factor)
-
 
     def zoom_in_y(self, factor=0):
         if factor == 0:
@@ -290,13 +298,11 @@ class BetterZoom(BaseTool, ToolHistoryMixin):
         """
 
         if xy_axis == 'x':
-            if factor <= self.x_max_zoom_factor and factor >= self.x_min_zoom_factor:
-                return False
-            return True
+            return (factor > self.x_max_zoom_factor or
+                    factor < self.x_min_zoom_factor)
         else:
-            if factor <= self.y_max_zoom_factor and factor >= self.y_min_zoom_factor:
-                return False
-            return True
+            return (factor > self.y_max_zoom_factor or
+                    factor < self.y_min_zoom_factor)
 
     def _zoom_in_mapper(self, mapper, factor):
 

--- a/chaco/tools/better_zoom.py
+++ b/chaco/tools/better_zoom.py
@@ -2,7 +2,7 @@ import numpy
 
 from chaco.grid_mapper import GridMapper
 from enable.api import BaseTool, KeySpec
-from traits.api import Enum, Float, Instance, Bool, HasTraits, List
+from traits.api import Enum, Float, Instance, Bool, List, Tuple
 
 from tool_history_mixin import ToolHistoryMixin
 from tool_states import ZoomState, PanState, GroupedToolState, ToolState
@@ -55,6 +55,9 @@ class BetterZoom(BaseTool, ToolHistoryMixin):
 
     # The amount to zoom in by. The zoom out will be inversely proportional
     zoom_factor = Float(2.0)
+
+    #: the position to zoom on (usually the mouse location)
+    position = Tuple(Float, Float)
 
     # The zoom factor on each axis
     _index_factor = Float(1.0)
@@ -358,3 +361,11 @@ class BetterZoom(BaseTool, ToolHistoryMixin):
         for state in self._history[::-1]:
             state.revert(self)
         self._history = []
+
+    #--------------------------------------------------------------------------
+    #  Traits defaults
+    #--------------------------------------------------------------------------
+
+    def _position_default(self):
+        # center of the component is a sensible default
+        return self._center_screen()

--- a/chaco/tools/better_zoom.py
+++ b/chaco/tools/better_zoom.py
@@ -298,11 +298,11 @@ class BetterZoom(BaseTool, ToolHistoryMixin):
         """
 
         if xy_axis == 'x':
-            return (factor > self.x_max_zoom_factor or
-                    factor < self.x_min_zoom_factor)
+            return not (self.x_min_zoom_factor <=
+                        factor <= self.x_max_zoom_factor)
         else:
-            return (factor > self.y_max_zoom_factor or
-                    factor < self.y_min_zoom_factor)
+            return not (self.y_min_zoom_factor <=
+                        factor <= self.y_max_zoom_factor)
 
     def _zoom_in_mapper(self, mapper, factor):
 

--- a/chaco/tools/tests/better_zoom_test_case.py
+++ b/chaco/tools/tests/better_zoom_test_case.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2014, Enthought, Inc.
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+# Thanks for using Enthought open source!
+#
+# Author: Enthought, Inc.
+
+""" Tests for the BetterZoom Chaco tool """
+
 import unittest
 
 import numpy
@@ -5,10 +18,10 @@ import numpy
 from chaco.api import create_line_plot
 from chaco.tools.api import BetterZoom
 from enable.testing import EnableTestAssistant
-from traits.testing.api import UnittestTools
 
-class TestBetterZoomTool(EnableTestAssistant, UnittestTools, unittest.TestCase):
-    """ Tests for the TraversePolyLine enable tool """
+
+class TestBetterZoomTool(EnableTestAssistant, unittest.TestCase):
+    """ Tests for the BetterZoom Chaco tool """
 
     def setUp(self):
         values = numpy.arange(10)

--- a/chaco/tools/tests/better_zoom_test_case.py
+++ b/chaco/tools/tests/better_zoom_test_case.py
@@ -1,0 +1,37 @@
+import unittest
+
+import numpy
+
+from chaco.api import create_line_plot
+from chaco.tools.api import BetterZoom
+from enable.testing import EnableTestAssistant
+from traits.testing.api import UnittestTools
+
+class TestBetterZoomTool(EnableTestAssistant, UnittestTools, unittest.TestCase):
+    """ Tests for the TraversePolyLine enable tool """
+
+    def setUp(self):
+        values = numpy.arange(10)
+        self.plot = create_line_plot((values, values))
+        self.plot.bounds = [100, 100]
+        self.plot._window = self.create_mock_window()
+        self.tool = BetterZoom(component=self.plot)
+        self.plot.active_tool = self.tool
+        self.plot.do_layout()
+
+    def tearDown(self):
+        del self.tool
+        del self.plot
+
+    def test_default_position(self):
+        tool = self.tool
+
+        # this doesn't throw an exception
+        self.send_key(tool, '+')
+
+        self.assertEqual(tool.position, (50, 50))
+
+        # expected behaviour for a normal zoom in operation
+        self.assertNotEqual(tool._index_factor, 1.0)
+        self.assertNotEqual(tool._value_factor, 1.0)
+        self.assertEqual(len(tool._history), 2)


### PR DESCRIPTION
Fixes #240.

The problem occurred when the tool was added with keyboard focus on the component and the mouse in the region where the tool was working.  A keyboard interaction with the tool would then give a traceback because `position` was not defined.