### PR TITLE
Fix MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,9 @@ include chaco/tools/toolbars/images*.png
 include chaco/tools/toolbars/images*.svg
 include chaco/tools/toolbars/images*.txt
 include chaco/layers/data/*.svg
+graft examples
+recursive-exclude examples *.pyc
+include README.rst
 include CHANGES.txt
 include LICENSE.txt
 include image_LICENSE.txt


### PR DESCRIPTION
The project MANIFEST.in file was missing several icon files from various subdirectories.  This meant that they were not included when using setup.py to build a source distribution.
