### PR TITLE
Speed-ups for chaco.base

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Chaco CHANGELOG
 
 Change summary since 4.5.0
 
+New features/Improvements
+
+ * Replaced bin_search by numpy.searchsorted-based routine for 5x speedup. (PR #263)
+
 Fixes
 
  * Workaround RuntimeWarnings from nanmin and nanmax in ImageData.get_bounds

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,7 +6,9 @@ Change summary since 4.5.0
 
 New features/Improvements
 
- * Replaced bin_search by numpy.searchsorted-based routine for 5x speedup. (PR #263)
+ * Replaced chaco.base.bin_search by numpy.searchsorted-based routine for
+   5x speedup and remove use of zip in chaco.base.arg_find_runs in favour of
+   column_stack for 10x speedup in bad cases. (PR #263)
 
 Fixes
 

--- a/chaco/base.py
+++ b/chaco/base.py
@@ -61,12 +61,28 @@ def n_gon(center, r, nsides, rot_degrees=0):
 
 
 def bin_search(values, value, ascending):
-    """
-    Performs a binary search of a sorted array looking for a specified value.
+    """ Performs a binary search of a sorted array for a specified value.
+
+    Parameters
+    ----------
+
+    values : array
+        The values being searched.
+
+    value : float
+        The value being searched for.
+
+    ascending : -1 or 1
+        This value should be 1 if the values array is ascending, or -1 if
+        the values array is descending.
+
+    Returns
+    -------
 
     Returns the lowest position where the value can be found or where the
     array value is the last value less (greater) than the desired value.
     Returns -1 if `value` is beyond the minimum or maximum of `values`.
+
     """
     if ascending > 0:
         if (value < values[0]) or (value > values[-1]):

--- a/chaco/base.py
+++ b/chaco/base.py
@@ -60,34 +60,25 @@ def n_gon(center, r, nsides, rot_degrees=0):
     return [poly_point(center, r, i*theta+rotation) for i in range(nsides)]
 
 
-# Ripped from Chaco 1.0's plot_base.py
 def bin_search(values, value, ascending):
     """
     Performs a binary search of a sorted array looking for a specified value.
 
     Returns the lowest position where the value can be found or where the
     array value is the last value less (greater) than the desired value.
-    Returns -1 if *value* is beyond the minimum or maximum of *values*.
+    Returns -1 if `value` is beyond the minimum or maximum of `values`.
     """
     if ascending > 0:
         if (value < values[0]) or (value > values[-1]):
             return -1
+        index = values.searchsorted(value, 'right') - 1
     else:
         if (value < values[-1]) or (value > values[0]):
             return -1
-    lo = 0
-    hi = len( values )
-    while True:
-        mid  = (hi + lo) / 2
-        test = cmp( values[ mid ], value ) * ascending
-        if test == 0:
-            return mid
-        if test > 0:
-            hi = mid
-        else:
-            lo = mid
-        if lo >= (hi - 1):
-            return lo
+        ascending_values = values[::-1]
+        index = len(values) - ascending_values.searchsorted(value, 'left') - 1
+    return index
+
 
 def reverse_map_1d(data, pt, sort_order, floor_only=False):
     """Returns the index of *pt* in the array *data*.

--- a/chaco/base.py
+++ b/chaco/base.py
@@ -6,8 +6,8 @@ Defines basic traits and functions for the data model.
 from math import radians, sqrt
 
 # Major library imports
-from numpy import (array, argsort, concatenate, cos, dot, empty, nonzero,
-    pi, sin, take, ndarray)
+from numpy import (array, argsort, concatenate, column_stack, cos, dot, empty,
+                   nonzero, pi, searchsorted, sin, take, ndarray)
 
 # Enthought library imports
 from traits.api import CArray, Enum, Trait
@@ -71,12 +71,12 @@ def bin_search(values, value, ascending):
     if ascending > 0:
         if (value < values[0]) or (value > values[-1]):
             return -1
-        index = values.searchsorted(value, 'right') - 1
+        index = searchsorted(values, value, 'right') - 1
     else:
         if (value < values[-1]) or (value > values[0]):
             return -1
         ascending_values = values[::-1]
-        index = len(values) - ascending_values.searchsorted(value, 'left') - 1
+        index = len(values) - searchsorted(ascending_values, value, 'left') - 1
     return index
 
 
@@ -177,10 +177,7 @@ def find_runs(int_array, order='ascending'):
     return [ [0,0,0], [1,1,1,1], [0,0,0,0] ]
     """
     ranges = arg_find_runs(int_array, order)
-    if ranges:
-        return [int_array[i:j] for (i,j) in ranges]
-    else:
-        return []
+    return [int_array[i:j] for (i,j) in ranges]
 
 def arg_find_runs(int_array, order='ascending'):
     """
@@ -199,7 +196,7 @@ def arg_find_runs(int_array, order='ascending'):
     rshifted = right_shift(int_array, int_array[0]-increment).view(ndarray)
     start_indices = concatenate([[0], nonzero(int_array - (rshifted+increment))[0]])
     end_indices = left_shift(start_indices, len(int_array))
-    return zip(start_indices, end_indices)
+    return column_stack((start_indices, end_indices))
 
 
 def point_line_distance(pt, p1, p2):

--- a/chaco/tests/base_utils_test_case.py
+++ b/chaco/tests/base_utils_test_case.py
@@ -7,7 +7,8 @@ from math import sqrt
 from numpy import arange, array
 from numpy.testing import assert_equal, assert_almost_equal
 
-from chaco.api import bin_search, find_runs, reverse_map_1d, point_line_distance
+from chaco.api import (arg_find_runs, bin_search, find_runs, reverse_map_1d,
+                       point_line_distance)
 
 class BinSearchTestCase(unittest.TestCase):
     def test_ascending_data(self):
@@ -132,6 +133,49 @@ class FindRunsTestCase(unittest.TestCase):
         x = array([30,41,40,39,38,37,12])
         assert_equal(find_runs(x, order='descending') , \
                             [[30], [41,40,39,38,37], [12]])
+
+    def test_find_runs_flat(self):
+        x = array([0,0,0,1,1,1,1,0,0,0,0])
+        assert_equal(find_runs(x, order='flat') , \
+                            [[0,0,0], [1,1,1,1], [0,0,0,0]])
+
+
+class ArgFindRunsTestCase(unittest.TestCase):
+    def test_arg_find_runs_middle(self):
+        x = array([0,8,7,8,9,2,3,4,10])
+        assert_equal(arg_find_runs(x) , [[0, 1], [1, 2], [2, 5], [5, 8], [8, 9]])
+
+    def test_arg_find_runs_start(self):
+        x = array([3,4,5,12,9,17])
+        assert_equal(arg_find_runs(x) , [[0, 3], [3, 4], [4, 5], [5, 6]])
+
+    def test_arg_find_runs_end(self):
+        x = array([18,23,24,25])
+        assert_equal(arg_find_runs(x) , [[0, 1], [1, 4]])
+
+    def test_arg_find_runs_offset(self):
+        # because of the nature of the find_runs algorithm, there may be
+        # fencepost errors with runs that start at x[1] or x[-2]
+        x = array([10,12,13,14,28,16])
+        assert_equal(arg_find_runs(x) , [[0, 1], [1, 4], [4, 5], [5, 6]])
+        x = array([10,15,16,17,34])
+        assert_equal(arg_find_runs(x) , [[0, 1],[1, 4],[4, 5]])
+
+    def test_arg_find_runs_none(self):
+        x = array([])
+        assert_equal(arg_find_runs(x) , [])
+        x = array([12,15,27])
+        assert_equal(arg_find_runs(x) , [[0, 1],[1, 2],[2, 3]])
+
+    def test_arg_find_runs_descending(self):
+        x = array([30,41,40,39,38,37,12])
+        assert_equal(arg_find_runs(x, order='descending') , \
+                            [[0, 1], [1, 6], [6, 7]])
+
+    def test_arg_find_runs_flat(self):
+        x = array([0,0,0,1,1,1,1,0,0,0,0])
+        assert_equal(arg_find_runs(x, order='flat') , \
+                            [[0, 3], [3, 7], [7, 11]])
 
 
 class PointLineDistanceTestCase(unittest.TestCase):

--- a/chaco/tests/base_utils_test_case.py
+++ b/chaco/tests/base_utils_test_case.py
@@ -13,33 +13,37 @@ from chaco.api import (arg_find_runs, bin_search, find_runs, reverse_map_1d,
 class BinSearchTestCase(unittest.TestCase):
     def test_ascending_data(self):
         ary = arange(10.0)
+
         # inside bounds
-        self.assert_(bin_search(ary, 0.0, 1) == 0)
-        self.assert_(bin_search(ary, 5.0, 1) == 5)
-        self.assert_(bin_search(ary, 9.0, 1) == 9)
+        self.assertEqual(bin_search(ary, 0.0, 1), 0)
+        self.assertEqual(bin_search(ary, 5.0, 1), 5)
+        self.assertEqual(bin_search(ary, 9.0, 1), 9)
+
         # out of bounds
-        self.assert_(bin_search(ary, 10.0, 1) == -1)
-        self.assert_(bin_search(ary, -1.0, 1) == -1)
-        self.assert_(bin_search(ary, 9.00001, 1) == -1)
-        self.assert_(bin_search(ary, -0.00001, 1) == -1)
+        self.assertEqual(bin_search(ary, 10.0, 1), -1)
+        self.assertEqual(bin_search(ary, -1.0, 1), -1)
+        self.assertEqual(bin_search(ary, 9.00001, 1), -1)
+        self.assertEqual(bin_search(ary, -0.00001, 1), -1)
+
         # rounding
-        self.assert_(bin_search(ary, 5.1, 1) == 5)
-        self.assert_(bin_search(ary, 4.9, 1) == 4)
-        return
+        self.assertEqual(bin_search(ary, 5.1, 1), 5)
+        self.assertEqual(bin_search(ary, 4.9, 1), 4)
 
     def test_descending_data(self):
         ary = arange(10.0, 0.0, -1.0)
+
         # inside bounds
-        self.assert_(bin_search(ary, 10.0, -1) == 0)
-        self.assert_(bin_search(ary, 5.0, -1) == 5)
-        self.assert_(bin_search(ary, 1.0, -1) == 9)
+        self.assertEqual(bin_search(ary, 10.0, -1), 0)
+        self.assertEqual(bin_search(ary, 5.0, -1), 5)
+        self.assertEqual(bin_search(ary, 1.0, -1), 9)
+
         # out of bounds
-        self.assert_(bin_search(ary, 10.1, -1) == -1)
-        self.assert_(bin_search(ary, 0.9, -1) == -1)
+        self.assertEqual(bin_search(ary, 10.1, -1), -1)
+        self.assertEqual(bin_search(ary, 0.9, -1), -1)
+
         # rounding
-        self.assert_(bin_search(ary, 5.1, -1) == 4)
-        self.assert_(bin_search(ary, 4.9, -1) == 5)
-        return
+        self.assertEqual(bin_search(ary, 5.1, -1), 4)
+        self.assertEqual(bin_search(ary, 4.9, -1), 5)
 
 class ReverseMap1DTestCase(unittest.TestCase):
 
@@ -104,78 +108,79 @@ class ReverseMap1DTestCase(unittest.TestCase):
 
 class FindRunsTestCase(unittest.TestCase):
     def test_find_runs_middle(self):
-        x = array([0,8,7,8,9,2,3,4,10])
-        assert_equal(find_runs(x) , [[0], [8], [7,8,9], [2,3,4], [10]])
+        x = array([0, 8, 7, 8, 9, 2, 3, 4, 10])
+        assert_equal(find_runs(x), [[0], [8], [7, 8, 9], [2, 3, 4], [10]])
 
     def test_find_runs_start(self):
-        x = array([3,4,5,12,9,17])
-        assert_equal(find_runs(x) , [[3,4,5],[12],[9],[17]])
+        x = array([3, 4, 5, 12, 9, 17])
+        assert_equal(find_runs(x), [[3, 4, 5], [12], [9], [17]])
 
     def test_find_runs_end(self):
-        x = array([18,23,24,25])
-        assert_equal(find_runs(x) , [[18],[23,24,25]])
+        x = array([18, 23, 24, 25])
+        assert_equal(find_runs(x) , [[18], [23, 24, 25]])
 
     def test_find_runs_offset(self):
         # because of the nature of the find_runs algorithm, there may be
         # fencepost errors with runs that start at x[1] or x[-2]
-        x = array([10,12,13,14,28,16])
-        assert_equal(find_runs(x) , [[10],[12,13,14],[28],[16]])
-        x = array([10,15,16,17,34])
-        assert_equal(find_runs(x) , [[10],[15,16,17],[34]])
+        x = array([10, 12, 13, 14, 28, 16])
+        assert_equal(find_runs(x), [[10], [12, 13, 14], [28], [16]])
+        x = array([10, 15, 16, 17, 34])
+        assert_equal(find_runs(x), [[10], [15, 16, 17], [34]])
 
     def test_find_runs_none(self):
         x = array([])
-        assert_equal(find_runs(x) , [])
-        x = array([12,15,27])
-        assert_equal(find_runs(x) , [[12],[15],[27]])
+        assert_equal(find_runs(x), [])
+        x = array([12, 15, 27])
+        assert_equal(find_runs(x), [[12], [15], [27]])
 
     def test_find_runs_descending(self):
-        x = array([30,41,40,39,38,37,12])
-        assert_equal(find_runs(x, order='descending') , \
-                            [[30], [41,40,39,38,37], [12]])
+        x = array([30, 41, 40, 39, 38, 37, 12])
+        assert_equal(find_runs(x, order='descending'), \
+                    [[30], [41, 40, 39, 38, 37], [12]])
 
     def test_find_runs_flat(self):
-        x = array([0,0,0,1,1,1,1,0,0,0,0])
-        assert_equal(find_runs(x, order='flat') , \
-                            [[0,0,0], [1,1,1,1], [0,0,0,0]])
+        x = array([0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0])
+        assert_equal(find_runs(x, order='flat'), \
+                     [[0, 0, 0], [1, 1, 1, 1], [0, 0, 0, 0]])
 
 
 class ArgFindRunsTestCase(unittest.TestCase):
     def test_arg_find_runs_middle(self):
-        x = array([0,8,7,8,9,2,3,4,10])
-        assert_equal(arg_find_runs(x) , [[0, 1], [1, 2], [2, 5], [5, 8], [8, 9]])
+        x = array([0, 8, 7, 8, 9, 2, 3, 4, 10])
+        assert_equal(arg_find_runs(x),
+                     [[0, 1], [1, 2], [2, 5], [5, 8], [8, 9]])
 
     def test_arg_find_runs_start(self):
-        x = array([3,4,5,12,9,17])
+        x = array([3, 4, 5, 12, 9, 17])
         assert_equal(arg_find_runs(x) , [[0, 3], [3, 4], [4, 5], [5, 6]])
 
     def test_arg_find_runs_end(self):
-        x = array([18,23,24,25])
+        x = array([18, 23, 24, 25])
         assert_equal(arg_find_runs(x) , [[0, 1], [1, 4]])
 
     def test_arg_find_runs_offset(self):
         # because of the nature of the find_runs algorithm, there may be
         # fencepost errors with runs that start at x[1] or x[-2]
-        x = array([10,12,13,14,28,16])
+        x = array([10, 12, 13, 14, 28, 16])
         assert_equal(arg_find_runs(x) , [[0, 1], [1, 4], [4, 5], [5, 6]])
-        x = array([10,15,16,17,34])
-        assert_equal(arg_find_runs(x) , [[0, 1],[1, 4],[4, 5]])
+        x = array([10, 15, 16, 17, 34])
+        assert_equal(arg_find_runs(x) , [[0, 1], [1, 4], [4, 5]])
 
     def test_arg_find_runs_none(self):
         x = array([])
         assert_equal(arg_find_runs(x) , [])
-        x = array([12,15,27])
-        assert_equal(arg_find_runs(x) , [[0, 1],[1, 2],[2, 3]])
+        x = array([12, 15, 27])
+        assert_equal(arg_find_runs(x) , [[0, 1], [1, 2], [2, 3]])
 
     def test_arg_find_runs_descending(self):
-        x = array([30,41,40,39,38,37,12])
-        assert_equal(arg_find_runs(x, order='descending') , \
-                            [[0, 1], [1, 6], [6, 7]])
+        x = array([30, 41, 40, 39, 38, 37, 12])
+        assert_equal(arg_find_runs(x, order='descending'), \
+                     [[0, 1], [1, 6], [6, 7]])
 
     def test_arg_find_runs_flat(self):
-        x = array([0,0,0,1,1,1,1,0,0,0,0])
-        assert_equal(arg_find_runs(x, order='flat') , \
-                            [[0, 3], [3, 7], [7, 11]])
+        x = array([0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0])
+        assert_equal(arg_find_runs(x, order='flat'), \
+                     [[0, 3], [3, 7], [7, 11]])
 
 
 class PointLineDistanceTestCase(unittest.TestCase):


### PR DESCRIPTION
Replace `bin_search` with a `numpy.searchsorted`-based algorithm. This gives a 5x speedup, but keeps the results the same (unit tests should all pass).

Also use `column_stack` instead of `zip` in `arg_find_runs`.  This is slightly slower in typical use cases, but up to 10x faster in bad cases (large arrays with many separate runs).  As part of this, added tests for `arg_find_runs` and the `flat` argument, since this is what is actually used in practice in a lot of chaco code.