### PR TITLE
Fixed `image_from_file` demo

### DIFF
--- a/examples/demo/basic/image_from_file.py
+++ b/examples/demo/basic/image_from_file.py
@@ -46,10 +46,13 @@ class DemoView(HasTraits):
     ### Private Traits #########################################################
 
     # File name to load image from
-    resource_path = os.path.join('examples','basic','capitol.jpg')
-    alt_path = 'capitol.jpg'
-    image_path = find_resource('Chaco', resource_path, alt_path=alt_path,
-        return_path=True)
+#    resource_path = os.path.join('examples','basic','capitol.jpg')
+#    alt_path = 'capitol.jpg'
+#    image_path = find_resource('Chaco', resource_path, alt_path=alt_path,
+#        return_path=True)
+#    _load_file = File(image_path)
+
+    image_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),'capitol.jpg')
     _load_file = File(image_path)
 
     # File name to save image to


### PR DESCRIPTION
running demo.py or basic/image_from_file.py from outside basic/ gives the following output
```
Traceback (most recent call last):
  File "examples/demo/basic/image_from_file.py", line 203, in <module>
    popup = DemoView()
  File "examples/demo/basic/image_from_file.py", line 102, in __init__
    self.plot.img_plot("imagedata")
  File "/Users/rahul/Library/canopyr/osx-64/runtimes/jigna/lib/python2.7/site-packages/chaco/plot.py", line 524, in img_plot
    value = self._get_or_create_datasource(data)
  File "/Users/rahul/Library/canopyr/osx-64/runtimes/jigna/lib/python2.7/site-packages/chaco/plot.py", line 1020, in _get_or_create_datasource
    "type %s" % type(data))
ValueError: Couldn't create datasource for data of type <type 'NoneType'>
```
On, the other hand, running image_from_file from inside basic/ works because alt_path ='capitol.jpg' preset.

A fix was to directly set image_path to the absolute path of the image file using os.path.join, os.path.dirname and os.path.abspath.