### PR TITLE
Broken/outdated links in user docs

### DIFF
--- a/docs/source/api/renderers.rst
+++ b/docs/source/api/renderers.rst
@@ -109,7 +109,7 @@ Renderers
     :show-inheritance:
 
 :class:`ScatterPlot1D`
-====================
+======================
 .. autoclass:: ScatterPlot
     :members:
     :show-inheritance:
@@ -130,7 +130,7 @@ Renderers
 ..===================
 .... autoclass:: TextPlot1D
 ..    :members:
- ..   :show-inheritance:
+..    :show-inheritance:
 
 :class:`VariableSizeScatterPlot`
 ================================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,11 +39,12 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'chaco'
-copyright = '2008-2014, Enthought, Inc.'
+copyright = '2008-2016, Enthought, Inc.'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
-version = release = __version__
+release = __version__
+version = '.'.join(release.split('.',3)[:3])
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -86,7 +87,7 @@ html_style = 'default.css'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+html_title = "Chaco {}".format(version)
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,9 +17,6 @@ import sys, os
 # is relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 sys.path.append(os.path.abspath('sphinxext'))
-sys.path.append(os.path.abspath(os.path.join('..','..')))
-
-from chaco import __version__
 
 # General configuration
 # ---------------------
@@ -43,8 +40,10 @@ copyright = '2008-2016, Enthought, Inc.'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
-release = __version__
-version = '.'.join(release.split('.',3)[:3])
+d = {}
+execfile(os.path.join('..', '..', 'chaco', '_version.py'), d)
+release = d['version']
+version = '.'.join(release.split('.',2)[:2])
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,9 @@ import sys, os
 # is relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 sys.path.append(os.path.abspath('sphinxext'))
+sys.path.append(os.path.abspath(os.path.join('..','..')))
+
+from chaco import __version__
 
 # General configuration
 # ---------------------
@@ -40,9 +43,7 @@ copyright = '2008-2014, Enthought, Inc.'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
-d = {}
-execfile(os.path.join('..', '..', 'chaco', '__init__.py'), d)
-version = release = d['__version__']
+version = release = __version__
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -142,6 +143,7 @@ html_use_index = False
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'Chacodoc'
 
+html_theme='classic'
 
 # Options for LaTeX output
 # ------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-Chaco |release|
+Chaco |version|
 ===============
 
 Chaco is a Python package for building interactive and custom 2-D plots and

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,4 +44,6 @@ Documentation
    :width: 800 px
    :align: center
 
+------------
+
 * :ref:`search`

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -79,14 +79,9 @@ installed.
 To do this, you can either
 
 1. Install Chaco and its :ref:`dependencies` from `PyPI
-   <http://pypi.python.org/pypi>`_ using `easy_install
-   <https://pythonhosted.org/setuptools/easy_install.html>`_ (part of
-   setuptools) or using `pip <http://www.pip-installer.org/en/latest/>`_. For
+   <http://pypi.python.org/pypi>`_ using
+    `pip <http://www.pip-installer.org/en/latest/>`_. For
    example
-
-   :command:`easy_install chaco`
-
-   or
 
    :command:`pip install chaco`
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -21,7 +21,7 @@ which is available for Windows, Linux and Mac OSX and also provides many other
 useful packages. Chaco may also be available through a package manager on your
 platform, such as apt on Ubuntu, yum on Redhat or
 `MacPorts <http://www.macports.org/>`_ on OS X.  You can also build Chaco from
-it's `source code <https://github.com/enthought/chaco>`_, but because of the
+its `source code <https://github.com/enthought/chaco>`_, but because of the
 dependencies, the easiest way by far is to install Canopy.
 
 .. _dependencies:
@@ -39,8 +39,7 @@ Dependencies
 
 * `Enable <https://github.com/enthought/enable/>`_, a framework for writing
   interactive visual components, and for abstracting away GUI-toolkit-specific
-  details of mouse and keyboard handling. This currently still depends on the
-  Python Image Library (PIL).
+  details of mouse and keyboard handling.
 
 * `NumPy <http://numpy.scipy.org/>`_, for dealing efficiently with large
   datasets
@@ -54,7 +53,7 @@ Installing Chaco with Canopy
 ----------------------------
 
 Chaco, the rest of the `Enthought Tool Suite <http://code.enthought.com/>`_,
-and a lot more are bundled with enthought Canopy (formerly EPD).  Getting
+and a lot more are bundled with Enthought Canopy (formerly EPD).  Getting
 Canopy gives you a one-click install of Chaco
 and all its dependencies at once; however, these packages will be linked to a
 new instance of Python. Canopy Express is free for all users and
@@ -94,15 +93,9 @@ To do this, you can either:
 
         :command:`pip install --upgrade chaco`
 
-.. note::
-   Because Chaco depends on Enable, which depends on PIL, certain plarforms
-   cannot install PIL from PyPI without these options:
-
-        :command:`pip install --allow-external PIL --allow-unverified PIL chaco`
-
 2. Or, download the source from the `Chaco GitHub repository
-   <https://github.com/enthought/chaco>`_ or alternatively as a part of
-   `Enthought Tool Suite <http://code.enthought.com/source/>`_.
+   <https://github.com/enthought/chaco>`_ or alternatively as a part of the
+   full `Enthought Tool Suite <https://github.com/enthought/ets>`_.
 
 .. Please refer to the :ref:`installation` section for more detailed
 .. instructions.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -83,10 +83,6 @@ To do this, you can either:
 
    :command:`pip install chaco`
 
-   or
-
-   :command:`easy_install chaco`
-
 .. note::
    If you have already installed Chaco and just want to update to the newest
    version, use
@@ -373,7 +369,7 @@ free and open source under the BSD license.
 Reporting bugs and contributing
 ===============================
 
-since Chaco is open source and hosted on
+Since Chaco is open source and hosted on
 `Github <https://github.com/enthought/chaco>`_, the development version can
 always be checked out from Github, forked, and modified at will. When a bug is
 found, please submit an issue in the

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -48,27 +48,26 @@ Dependencies
   interactive plots. As an alternative to PyQt, Chaco is being tested more and
   more with the `PySide <http://www.pyside.org/>`_ toolkit (LGPL license).
 
-.. .. note
-.. ::
-.. In addition to wxPython or PyQt a cross-platform OpenGL backend (using
-.. Pyglet) is in the works, and it will not require WX or Qt.
+.. Note::
+   In addition to wxPython or PyQt a cross-platform OpenGL backend (using
+   Pyglet) is in the works, and it will not require WX or Qt.
 
-Installing Chaco with EPD
--------------------------
+Installing Chaco with Canopy
+-----------------------------
 
 Chaco, the rest of the `Enthought Tool Suite <http://code.enthought.com/>`_,
-and a lot more are bundled with EPD.  Getting EPD allows you to install Chaco
+and a lot more are bundled with Canopy.  Getting Canopy allows you to install Chaco
 and all its dependencies at once; however, these packages will be linked to a
-new instance of Python.  The EPD Free distribution is free for all users and
+new instance of Python. Canopy Express is free for all users and
 contains all that you need to use Chaco.
 
-To get EPD, go to the `EPD download page
-<http://www.enthought.com/products/getepd.php>`_ and get the appropriate
+To get Canopy, go to the `Canopy download page
+<http://www.enthought.com/products/canopy>`_ and get the appropriate
 version for your platform.  After running the installer, you will have a
 working version of Chaco and several examples.
 
 Building Chaco
---------------
+---------------
 
 Building Chaco on your machine requires you to build Chaco and each of its
 dependencies, but it has the advantage of installing Chaco on top of the Python
@@ -79,9 +78,7 @@ installed.
 To do this, you can either
 
 1. Install Chaco and its :ref:`dependencies` from `PyPI
-   <http://pypi.python.org/pypi>`_ using
-    `pip <http://www.pip-installer.org/en/latest/>`_. For
-   example
+   <http://pypi.python.org/pypi>`_ using `pip <http://www.pip-installer.org/en/latest/>`_. For example
 
    :command:`pip install chaco`
 
@@ -105,7 +102,7 @@ you may or may not have the examples already.
 Location
 --------
 
-1. If you installed Chaco as part of EPD, the location of the examples depends
+1. If you installed Chaco as part of Canopy, the location of the examples depends
    on your platform:
 
    * On Windows, they are in the Examples\\ subdirectory of your installation

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -48,10 +48,6 @@ Dependencies
   interactive plots. As an alternative to PyQt, Chaco is being tested more and
   more with the `PySide <http://www.pyside.org/>`_ toolkit (LGPL license).
 
-.. Note::
-   In addition to wxPython or PyQt a cross-platform OpenGL backend (using
-   Pyglet) is in the works, and it will not require WX or Qt.
-
 Installing Chaco with Canopy
 -----------------------------
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -10,22 +10,18 @@ Quickstart
 +----------------------------------------+--------------------------------------+
 
 This section is meant to help users on well-supported platforms and common
-Python environments get started using Chaco as quickly as possible. Chaco users
-can subscribe to the `enthought-dev
-<https://mail.enthought.com/mailman/listinfo/enthought-dev>`_  mailing list to
-post questions, consult archives, and share tips.
-
+Python environments get started using Chaco as quickly as possible.
 
 Installation
 ============
 
-There are several ways to get Chaco. The easiest way is through the `Enthought
-Python Distribution (EPD) <http://www.enthought.com/epd>`_, which is available
-for several platforms and also provides many other useful packages.  Chaco may
+There are several ways to get Chaco. The easiest way is through `Enthought
+Canopy (Canopy) <https://www.enthought.com/products/canopy>`_, which is available
+for several platforms and also provides many other useful packages. Chaco may
 also be available through a package manager on your platform, such as apt on
 Ubuntu or `MacPorts <http://www.macports.org/>`_ on OS X.  You can also build
 Chaco yourself, but because of the number of packages required, we highly
-recommend you install EPD.
+recommend you install Canopy
 
 .. _dependencies:
 
@@ -84,7 +80,7 @@ To do this, you can either
 
 1. Install Chaco and its :ref:`dependencies` from `PyPI
    <http://pypi.python.org/pypi>`_ using `easy_install
-   <http://packages.python.org/distribute/easy_install.html>`_ (part of
+   <https://pythonhosted.org/setuptools/easy_install.html>`_ (part of
    setuptools) or using `pip <http://www.pip-installer.org/en/latest/>`_. For
    example
 
@@ -139,14 +135,6 @@ Location
 
      https://github.com/enthought/chaco/tree/master/examples
 
-   For ETS 3.0 or Chaco 3.0, you can check out the examples with Subversion:
-
-     :command:`svn co https://svn.enthought.com/svn/enthought/Chaco/tags/3.0.0/examples`
-
-   For ETS 2.8 or Chaco 2.0.x:
-
-     :command:`svn co https://svn.enthought.com/svn/enthought/Chaco/tags/enthought.chaco2_2.0.5/examples`
-
 Chaco examples can be found in the :file:`examples/demo/` and
 :file:`examples/tutorials/` directories. Some are classified by themes and
 located in separate directories.  Almost all of the Chaco examples are
@@ -172,6 +160,7 @@ This opens a plot of several Bessel functions with a legend.
   .. image:: images/simple_line.png
 
 You can interact with the plot in several ways:
+
 .. Ctrl-Left and Ctrl-Right don't work in OS X?
 
 * To pan the plot, hold down the left mouse button inside the plot area (but

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -16,19 +16,20 @@ Installation
 ============
 
 There are several ways to get Chaco. The easiest way is through `Enthought
-Canopy (Canopy) <https://www.enthought.com/products/canopy>`_, which is available
-for several platforms and also provides many other useful packages. Chaco may
-also be available through a package manager on your platform, such as apt on
-Ubuntu or `MacPorts <http://www.macports.org/>`_ on OS X.  You can also build
-Chaco yourself, but because of the number of packages required, we highly
-recommend you install Canopy
+Canopy (Canopy) <https://www.enthought.com/products/canopy>`_ (formerly EPD)
+which is available for Windows, Linux and Mac OSX and also provides many other
+useful packages. Chaco may also be available through a package manager on your
+platform, such as apt on Ubuntu, yum on Redhat or
+`MacPorts <http://www.macports.org/>`_ on OS X.  You can also build Chaco from
+it's `source code <https://github.com/enthought/chaco>`_, but because of the
+dependencies, the easiest way by far is to install Canopy.
 
 .. _dependencies:
 
 Dependencies
 ------------
 
-* `Python <https://www.python.org>`_ 2.5 or later
+* `Python <https://www.python.org>`_ 2.7 or later
 
 * `Traits <https://github.com/enthought/traits>`_, an event notification
   framework
@@ -38,29 +39,31 @@ Dependencies
 
 * `Enable <https://github.com/enthought/enable/>`_, a framework for writing
   interactive visual components, and for abstracting away GUI-toolkit-specific
-  details of mouse and keyboard handling
+  details of mouse and keyboard handling. This currently still depends on the
+  Python Image Library (PIL).
 
 * `NumPy <http://numpy.scipy.org/>`_, for dealing efficiently with large
   datasets
 
-* Either `wxPython <http://www.wxpython.org/>`_ or  `PyQt
-  <http://www.riverbankcomputing.co.uk/software/pyqt/intro>`_ to display
-  interactive plots. As an alternative to PyQt, Chaco is being tested more and
-  more with the `PySide <http://www.pyside.org/>`_ toolkit (LGPL license).
+* Either `wxPython <http://www.wxpython.org/>`_, `PyQt
+  <http://www.riverbankcomputing.co.uk/software/pyqt/intro>`_ (GPL or
+  Commercial license) or `PySide <http://www.pyside.org/>`_ (LGPL license) to
+  display interactive plots.
 
 Installing Chaco with Canopy
------------------------------
+----------------------------
 
 Chaco, the rest of the `Enthought Tool Suite <http://code.enthought.com/>`_,
-and a lot more are bundled with Canopy.  Getting Canopy allows you to install Chaco
+and a lot more are bundled with enthought Canopy (formerly EPD).  Getting
+Canopy gives you a one-click install of Chaco
 and all its dependencies at once; however, these packages will be linked to a
 new instance of Python. Canopy Express is free for all users and
 contains all that you need to use Chaco.
 
 To get Canopy, go to the `Canopy download page
-<http://www.enthought.com/products/canopy>`_ and get the appropriate
-version for your platform.  After running the installer, you will have a
-working version of Chaco and several examples.
+<http://store.enthought.com/>`_, select the desired bundle (Express, Full,
+TriplePlay) and get the appropriate version for your platform.  After running
+the installer, you will have a working version of Chaco and several examples.
 
 Building Chaco
 ---------------
@@ -68,19 +71,38 @@ Building Chaco
 Building Chaco on your machine requires you to build Chaco and each of its
 dependencies, but it has the advantage of installing Chaco on top of the Python
 instance you already have installed.  The build process may be challenging and
-will require you to have SWIG, Cython and several development libraries
-installed.
+will require you to have a C compiler, SWIG, Cython and several development
+libraries installed.
 
-To do this, you can either
+To do this, you can either:
 
 1. Install Chaco and its :ref:`dependencies` from `PyPI
-   <http://pypi.python.org/pypi>`_ using `pip <http://www.pip-installer.org/en/latest/>`_. For example
+   <http://pypi.python.org/pypi>`_ using
+   `pip <http://www.pip-installer.org/en/latest/>`_ or using `easy_install
+   <http://packages.python.org/distribute/easy_install.html>`_ (part of
+   setuptools). For example
 
    :command:`pip install chaco`
 
+   or
+
+   :command:`easy_install chaco`
+
+.. note::
+   If you have already installed Chaco and just want to update to the newest
+   version, use
+
+        :command:`pip install --upgrade chaco`
+
+.. note::
+   Because Chaco depends on Enable, which depends on PIL, certain plarforms
+   cannot install PIL from PyPI without these options:
+
+        :command:`pip install --allow-external PIL --allow-unverified PIL chaco`
+
 2. Or, download the source from the `Chaco GitHub repository
-   <https://github.com/enthought/chaco>`_ or alternatively as a part of `ETS
-   <http://code.enthought.com/source/>`_.
+   <https://github.com/enthought/chaco>`_ or alternatively as a part of
+   `Enthought Tool Suite <http://code.enthought.com/source/>`_.
 
 .. Please refer to the :ref:`installation` section for more detailed
 .. instructions.
@@ -102,21 +124,23 @@ Location
    on your platform:
 
    * On Windows, they are in the Examples\\ subdirectory of your installation
-     location.  This is typically
-     :file:`C:\\Python27\\Examples\\Chaco-<version>`.  On MS Windows these
-     examples can be browsed from the start menu, by clicking
-     :menuselection:`Start --> Applications --> Enthought --> Examples`.
+     location. This is typically
+     :file:`C:\\Users\\<username>\\AppData\\Local\\Enthought\\Canopy\\User\\Examples\\Chaco-<version>`.
+     These examples can be browsed from the start menu, by clicking
+     :menuselection:`Start --> Applications --> Enthought Canopy --> Example Browser`.
 
-   * On Linux, they are in the :file:`Examples/Chaco-<version>` subdirectory of
-     your installation location.
+   * On Linux, they are in the
+     :file:`Enthought/Canopy_XXbit/User/Examples/Chaco-<version>`
+     subdirectory of your installation location.
 
    * On Mac OS X, they are in the
-     :file:`/Applications/Enthought/Examples/chaco-<version>` directory.
+     :file:`/Library/Enthought/Canopy_XXbit/User/Examples/chaco-<version>`
+     directory.
 
 2. If you downloaded and installed Chaco from source (from GitHub or via the
    PyPI tar.gz file), the examples are located in the :file:`examples/`
    subdirectory inside the root of the Chaco source tree, next to :file:`docs/`
-   and the :file:`enthought/` directories.
+   and the :file:`chaco/` directories.
 
 3. If you don't know how Chaco was installed, you can download the latest
    versions of examples individually from github:
@@ -216,11 +240,12 @@ This shows two overlapping line plots.
 
 You can interact with this plot just as in the previous section.
 
-Now exit the plot, and start IPython with the ``--gui=wx`` option [#guiqt]_:
+Now close the plot, and start IPython with the ``--gui=qt`` [#guiqt]_ or
+``--gui=wx`` option:
 
-    :command:`ipython --gui=wx`
+    :command:`ipython --gui=qt`
 
-This tells IPython to start a wxPython mainloop in a background thread.  Now
+This tells IPython to start a Qt or Wx mainloop in a background thread.  Now
 run the previous example again::
 
     In [1]: run lines.py
@@ -257,8 +282,13 @@ information on all you can do with Chaco from within IPython.
 Chaco plot embedded in a Traits application
 ===========================================
 
-Let's create, from scratch, the simplest possible Chaco plot (embedded inside a
-`Traits`_ application).
+The previous section showed how Chaco can be used interactively similarly to
+`Matlab` or Matplotlib's `pyplot` package
+
+Now, let's create, from scratch, the simplest possible Chaco plot which is
+embedded inside a `Traits`_ application. This will require more work but will
+represent the basis for a potential large-scale, custom and powerful rich
+client application. this is really what Chaco has been written for.
 
 First, some imports to bring in necessary components::
 
@@ -323,8 +353,8 @@ relatively simple basis on top of which we can build full-featured applications
 with custom UIs and custom tools. For example, the Traits object allows you to
 create controls for your plot at a very high level, add these controls to the
 UI with very little work, and add listeners to update the plot when the data
-changes.  Chaco also allows you to create tools to interact with the plot and
-overlays that make these tools intuitive and visually appealing.
+changes.  Chaco also allows you to create custom tools to interact with the
+plot and overlays that make these tools intuitive and visually appealing.
 
 
 .. rubric:: Footnotes
@@ -334,9 +364,29 @@ overlays that make these tools intuitive and visually appealing.
     is set correctly, as described `here
     <http://ipython.org/ipython-doc/dev/interactive/reference.html?highlight=qt_api#pyqt-and-pyside>`_
 
+Where to learn more?
+====================
+
+To learn more about the power of Chaco and to build powerful rich client
+applications with custom visualizations, consider going over the
+:ref:`tutorials` section or learning from the :ref:`user_guide`.
 
 License
 =======
 
 As part of the `Enthought Tool Suite <http://code.enthought.com/>`_, Chaco is
 free and open source under the BSD license.
+
+Reporting bugs and contributing
+===============================
+
+since Chaco is open source and hosted on
+`Github <https://github.com/enthought/chaco>`_, the development version can
+always be checked out from Github, forked, and modified at will. When a bug is
+found, please submit an issue in the
+`issue page <https://github.com/enthought/chaco/issues>`_. If you would like to
+share a bug fix or a new feature, simply submit a Pull Request from your fork.
+Don't forget to specify very clearly what code to run to reproduce the issue,
+what the logic of the fix is and to add one or more unit tests to ensure future
+stability. The Pull Request description can and often needs to contain
+screenshots of the issue or the fix.

--- a/docs/source/user_manual/basic_elements/plot_renderers.rst
+++ b/docs/source/user_manual/basic_elements/plot_renderers.rst
@@ -27,7 +27,7 @@ for :ref:`X-vs-Y plots <xy_plots>`,
 :ref:`contour plots <contour_plot>`) and
 :class:`~chaco.base_1d_plot.Base1DPlot`, which is the interface for
 :ref:`1D plots <1d_plots>` (e.g., :ref:`jitter plots <jitter_plot>` or
-:ref:`1D scatter plots <scatter_plot_1d>`).
+:ref:`1D scatter plots <scatter_plot>`).
 
 The base interface inherits from a deep hierarchy of classes generating
 from the :mod:`enable` package, starting with
@@ -258,20 +258,31 @@ All :class:`~chaco.abstract_plot_renderer.AbstractPlotRenderer` subclasses are
 expected to provide three methods for mapping to and from screen space and
 data space:
 
-    :attr:`map_screen`
+    .. :py:method:: map_screen(data_array)
+
+    :map_screen:
 
         This is expected to take an array of points (as columns) in
         the appropriate data coordinates, and return the corresponding points
         in screen pixel coordinates (measured from the bottom left of the
         plot component).
 
-    :attr:`map_data`
-        This is the reverse of :attr:`map_screen`, and takes an array of
+    .. :py:method: map_data(screen_pt)
+
+    :map_data:
+
+        This is the reverse of map_screen, and takes an array of
         points (as columns) screen pixel coordinates relative to the renderer
         component and return the corresponding points in screen data
         coordinates.
 
-    :attr:`map_index`
+    .. :py:method:map_index(screen_pt,
+                            threshold=0.0,
+                            outside_returns_none=True,
+                            index_only=False)
+
+    :map_index:
+
         This method takes a point in screen pixel coordinates and returns an
         appropriate index value that can be used to index into data.  This can
         be used by hit-testing methods (see below), and provides optional

--- a/docs/source/user_manual/basic_elements/plot_renderers.rst
+++ b/docs/source/user_manual/basic_elements/plot_renderers.rst
@@ -258,20 +258,20 @@ All :class:`~chaco.abstract_plot_renderer.AbstractPlotRenderer` subclasses are
 expected to provide three methods for mapping to and from screen space and
 data space:
 
-    :method:`map_screen`
+    :attr:`map_screen`
 
         This is expected to take an array of points (as columns) in
         the appropriate data coordinates, and return the corresponding points
         in screen pixel coordinates (measured from the bottom left of the
         plot component).
 
-    :method:`map_data`
-        This is the reverse of :method:`map_screen`, and takes an array of
+    :attr:`map_data`
+        This is the reverse of :attr:`map_screen`, and takes an array of
         points (as columns) screen pixel coordinates relative to the renderer
         component and return the corresponding points in screen data
         coordinates.
 
-    :method:`map_index`
+    :attr:`map_index`
         This method takes a point in screen pixel coordinates and returns an
         appropriate index value that can be used to index into data.  This can
         be used by hit-testing methods (see below), and provides optional
@@ -457,7 +457,7 @@ The attribute :attr:`~chaco.base_2d_plot.Base2DPlot.alpha` defines the
 global transparency value for the whole plot.
 It ranges from 0.0 for transparent to 1.0 (default) for full intensity.
 
-.. _oned_plots:
+.. _1d_plots:
 
 1D Plots Interface
 ==================

--- a/docs/source/user_manual/chaco_tutorial.rst
+++ b/docs/source/user_manual/chaco_tutorial.rst
@@ -1191,6 +1191,8 @@ Other event callbacks correspond to mouse gestures (``mouse_enter``,
 ``mouse_leave``, ``mouse_wheel``), mouse clicks (``left_down``, ``left_up``,
 ``right_down``, ``right_up``), and key presses (``key_pressed``).
 
+.. _Tool_States:
+
 Stateful tools
 ==============
 

--- a/docs/source/user_manual/containers.rst
+++ b/docs/source/user_manual/containers.rst
@@ -496,7 +496,7 @@ In summary, when a component gets an event, it dispatches it to:
 On each of these elements, Chaco looks for a method of the form
 ``{component_state}_{event_name}``. For example,
 in response to the user pressing the left mouse button
-on a tool in state ``normal`` (the default state, see :ref:`Tool states`),
+on a tool in state ``normal`` (the default state, see :ref:`Tool_States`),
 Chaco would look for a method called ``normal_left_down``.
 
 If this exists, the event is

--- a/docs/source/user_manual/faq.rst
+++ b/docs/source/user_manual/faq.rst
@@ -24,7 +24,7 @@ the capabilities and feature sets of the two projects.
 
 
 Here is an `excerpt from a thread about this question
-<https://mail.enthought.com/pipermail/enthought-dev/2007-May/005363.html>`_ on
+<http://thread.gmane.org/gmane.comp.python.enthought.devel/5220/focus=5221>`_ on
 the enthought-dev mailing list.
 
 Gael Varoquaux's response::

--- a/docs/source/user_manual/plot_types.rst
+++ b/docs/source/user_manual/plot_types.rst
@@ -682,6 +682,7 @@ The aspect of the polar plot can be controlled with these parameters:
 .. image:: images/user_guide/polar_plot.png
   :width: 350px
 
+.. _jitter_plot:
 
 Jitter Plot
 ===========

--- a/docs/source/user_manual/tutorials_and_examples.rst
+++ b/docs/source/user_manual/tutorials_and_examples.rst
@@ -21,20 +21,12 @@ Tutorials
   command-line plotting interface to build plots, in
   a Matlab or gnuplot-like style.
 
-Webinars
---------
+.. the webinars section here has been removed as the hyperlinks 
+    dont exist and/or are broken. it will be readded once we 
+    figure out how and where to host the webinars.
 
-* `Step-by-step Chaco - 2D plotting with Python <http://enthought.com/training/SCPwebinar.php#w2009-07-17>`_
 
-  Webinar recorded on, July 17, 2009, available as Windows Media Player (.wmv) video,
-  Matroska (.mkv) video, and as a slideshare slide show.
-
-* `EPDLab & Chaco <http://enthought.com/training/SCPwebinar.php#w2009-07-17>`_
-
-  Webinar recorded on, June 19, 2009, available as Windows Media Player (.wmv) video,
-  Matroska (.mkv) video, and as a slideshare slide show.
-
-.. tutorial_wx
+..  tutorial_wx
 
 Examples
 --------


### PR DESCRIPTION
ref : issue #291 

As mentioned there, the following need to be fixed : 

- [x] mailing-list info in [quick_start](http://docs.enthought.com/chaco/quickstart.html)
- [x] installing chaco with EPD [info and link](http://docs.enthought.com/chaco/quickstart.html#installing-chaco-with-epd)
- [x] easy_install [broken link](http://docs.enthought.com/chaco/quickstart.html#building-chaco)
- [x] outdated [svn example links](http://docs.enthought.com/chaco/quickstart.html#location)
- [x] broken webinar links [in tutorials](http://docs.enthought.com/chaco/user_manual/tutorials_and_examples.html#webinars)
- [x] broken link to mailing-list on [FAQ page](http://docs.enthought.com/chaco/user_manual/faq.html#what-are-the-pros-and-cons-of-chaco-vs-matplotlib)

Can someone clarify two things for me.
What was the original intent of the [Tools and Overlays](http://docs.enthought.com/chaco/user_manual/tools.html) and [Common Usages](http://docs.enthought.com/chaco/user_manual/common_patterns.html) pages in the user docs? As in, what was the content that these two pages were/are expected to have.