### PR TITLE
Fix timescale tests and calendar timescales

### DIFF
--- a/chaco/scales/tests/test_time_scale.py
+++ b/chaco/scales/tests/test_time_scale.py
@@ -13,7 +13,7 @@ from chaco.scales.api import TimeFormatter
 
 # Note on testing:
 # Chaco assumes times are in UTC seconds since Posix Epoch but does ticking
-# in whatever the local time is on the host maschine.  This is problematic for
+# in whatever the local time is on the host machine.  This is problematic for
 # testing, because correct responses depend on current state of the test
 # machine, and will vary by location and time of year.  For hour/day/year
 # testing, where TZ matter, we select 3 timezones to test in:

--- a/chaco/scales/tests/test_time_scale.py
+++ b/chaco/scales/tests/test_time_scale.py
@@ -1,6 +1,5 @@
 
 
-import time
 import datetime
 import os
 import contextlib

--- a/chaco/scales/tests/test_time_scale.py
+++ b/chaco/scales/tests/test_time_scale.py
@@ -25,11 +25,8 @@ from chaco.scales.api import TimeFormatter
 #   shifts, which should hopefully reveal bugs with previous-day or -year
 #   baselines.
 #
-# Note that this isn't quite bullet-proof, as things will break if Hawaii or
-# the Northern Territory ever change their timezones (eg. by introducing
-# daylight savings).  We also rely on os.environ['TZ'] working to run the
-# tests, but at the time of writing it remains to be seen if this works for
-# Windows.
+# Note that we don't actually change the timezone for the process, but this is
+# good enough to test the logic for the tfrac and trange functions.
 
 #----------------------------------------------------------------
 # Utilities
@@ -43,7 +40,10 @@ HONOLULU = -10.0*3600
 
 @contextlib.contextmanager
 def set_timezone(tz):
-    """ Temporarily select the timezone to use
+    """ Temporarily select the timezone to use.
+
+    This works by temporarily replacing the EPOCH module variable with a
+    different value.
 
     Parameters
     ----------

--- a/chaco/scales/time_scale.py
+++ b/chaco/scales/time_scale.py
@@ -297,8 +297,8 @@ class TimeScale(AbstractScale):
 
         # get range of years of interest
         # add 2 because of python ranges + guard against timezone shifts
-        # eg. 20000101 -> 19991231 because of local timezone, so end is 1999+2
-        years = range(start_dt.year, end_dt.year+2)
+        # eg. if 20000101 -> 19991231 because of local timezone, end is 1999+2
+        years = range(start_dt.year, min(end_dt.year+2, MAXYEAR))
         if self.unit == "day_of_month":
             # get naive datetimes for start of each day of each month
             # in range of years.  Excess will be discarded later.
@@ -309,7 +309,7 @@ class TimeScale(AbstractScale):
         elif self.unit == "month_of_year":
             # get naive datetimes for start of each month in range of years
             dates = [datetime(year, month, 1)
-                      for year in years for month in self.vals]
+                     for year in years for month in self.vals]
         else:
             raise ValueError("Unknown calendar unit '%s'" % self.unit)
 

--- a/chaco/scales/time_scale.py
+++ b/chaco/scales/time_scale.py
@@ -298,7 +298,7 @@ class TimeScale(AbstractScale):
         # get range of years of interest
         # add 2 because of python ranges + guard against timezone shifts
         # eg. if 20000101 -> 19991231 because of local timezone, end is 1999+2
-        years = range(start_dt.year, min(end_dt.year+2, MAXYEAR))
+        years = range(start_dt.year, min(end_dt.year+2, MAXYEAR+1))
         if self.unit == "day_of_month":
             # get naive datetimes for start of each day of each month
             # in range of years.  Excess will be discarded later.

--- a/chaco/scales/time_scale.py
+++ b/chaco/scales/time_scale.py
@@ -285,48 +285,41 @@ class TimeScale(AbstractScale):
     def cal_ticks(self, start, end):
         """ ticks() method for calendar-based intervals """
 
+        # start and end are in seconds since Epoch, get naive datetimes
         try:
-            start = datetime.fromtimestamp(start)
+            start_dt = datetime.fromtimestamp(start)
         except ValueError:
-            start = datetime(MINYEAR, 1, 1, 0, 0, 0)
+            start_dt = datetime(MINYEAR, 1, 1, 0, 0, 0)
         try:
-            end = datetime.fromtimestamp(end)
+            end_dt = datetime.fromtimestamp(end)
         except ValueError:
-            end = datetime(MAXYEAR, 1, 1, 0, 0, 0)
+            end_dt = datetime(MAXYEAR, 1, 1, 0, 0, 0)
 
+        # get range of years of interest
+        # add 2 because of python ranges + guard against timezone shifts
+        # eg. 20000101 -> 19991231 because of local timezone, so end is 1999+2
+        years = range(start_dt.year, end_dt.year+2)
         if self.unit == "day_of_month":
-            s = start.year + 1/12.0 * start.month
-            e = end.year + 1/12.0 * end.month
-            num_months = int(round((e - s) * 12)) + 1   # add 1 for fencepost
-            start_year = start.year
-            start_month = start.month
-            ym = [divmod(i, 12)
-                  for i in range(start_month-1, start_month-1+num_months)]
-            months = [start.replace(year=start_year+y, month=m+1, day=1)
-                      for (y,m) in ym]
-            ticks = [dt.replace(day=i) for dt in months for i in self.vals]
+            # get naive datetimes for start of each day of each month
+            # in range of years.  Excess will be discarded later.
+            months = range(1, 13)
+            dates = [datetime(year, month, i)
+                     for year in years for month in months for i in self.vals]
 
         elif self.unit == "month_of_year":
-            years = [start.replace(year=newyear, day=1)
-                     for newyear in range(start.year, end.year+1)]
-            ticks = [dt.replace(month=i, day=1)
-                     for dt in years for i in self.vals]
-
+            # get naive datetimes for start of each month in range of years
+            dates = [datetime(year, month, 1)
+                      for year in years for month in self.vals]
         else:
             raise ValueError("Unknown calendar unit '%s'" % self.unit)
 
-        if len(ticks) > 0:
-            # Find the first and last index in all_ticks that falls
-            # within (start,end)
-            for start_ndx in range(len(ticks)):
-                if ticks[start_ndx] >= start:
-                    break
-            for end_ndx in range(len(ticks)-1, 0, -1):
-                if ticks[end_ndx] <= end:
-                    break
-            ticks = ticks[start_ndx : end_ndx+1]
+        # safely convert to seconds since epoch
+        ticks = [dt_to_sec(date) for date in dates]
 
-        return map(dt_to_sec, ticks)
+        # trim excess timestamps
+        ticks = [t for t in ticks if start <= t <= end]
+
+        return ticks
 
     def labels(self, start, end, numlabels=None, char_width=None):
         """ Returns a series of ticks and corresponding strings for labels


### PR DESCRIPTION
This PR fixes a couple of long-standing bugs in the ticking code for time axes.

* The first should fix the selection of tick times for day of month and month of year, which had timezone issues.
* The second fixes the _tests_ for the time_scale module, which worked if you ran them with a computer set to UTC, but otherwise probably not.
* Adds versions of certain interesting tests which simulate running the code in non-UTC timezones, in particular timezones with non-whole-hour offsets.

For the PR reviewer: Chaco's time scale handling works internally in seconds since the Unix Epoch, but displays and selects ticks according to those times in the current timezone.

There are likely many other issues with the time scale code, but this at least allows us to run the tests cleanly and reproducably.