### PR TITLE
Issue with range zoom being an opaque color

### DIFF
--- a/chaco/tools/better_selecting_zoom.py
+++ b/chaco/tools/better_selecting_zoom.py
@@ -392,14 +392,7 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
                 x2, y2 = self._screen_end
                 rect = (x, y, x2-x+1, y2-y+1)
                 if self.color != "transparent":
-                    if self.alpha:
-                        color = list(self.color_)
-                        if len(color) == 4:
-                            color[3] = self.alpha
-                        else:
-                            color += [self.alpha]
-                    else:
-                        color = self.color_
+                    color = self._get_fill_color()
                     gc.set_fill_color(color)
                     gc.draw_rect(rect)
                 else:
@@ -420,13 +413,26 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
 
         with gc:
             gc.set_antialias(0)
-            gc.set_alpha(self.alpha)
-            gc.set_fill_color(self.color_)
+            color = self._get_fill_color()
+            gc.set_fill_color(color)
             gc.set_stroke_color(self.border_color_)
             gc.clip_to_rect(component.x, component.y, component.width, component.height)
             gc.draw_rect((lower_left[0], lower_left[1], upper_right[0], upper_right[1]))
 
         return
+
+    def _get_fill_color(self):
+        """Get the fill color based on the alpha and the color property
+        """
+        if self.alpha:
+            color = list(self.color_)
+            if len(color) == 4:
+                color[3] = self.alpha
+            else:
+                color += [self.alpha]
+        else:
+            color = self.color_
+        return color
 
     def _determine_axis(self):
         """ Determines whether the index of the coordinate along the axis of

--- a/chaco/tools/tests/range_zoom_test_case.py
+++ b/chaco/tools/tests/range_zoom_test_case.py
@@ -1,0 +1,71 @@
+from unittest import TestCase
+
+import mock
+import numpy
+
+from chaco.api import create_line_plot
+from chaco.tools.api import BetterSelectingZoom
+from enable.testing import EnableTestAssistant
+
+
+class BackgroundColorTestCase(EnableTestAssistant, TestCase):
+    """Regression tests for BetterSelectingZoom issue with background alpha.
+
+    The BetterSelectingZoom overlay would override any user-specified value for
+    the alpha channel of the selection plot, causing the selected region to
+    appear completely opaque. This issue was reported (and fixed) in GH #309.
+
+    """
+    def setUp(self):
+        values = numpy.arange(10)
+        self.plot = create_line_plot((values, values))
+        self.plot.bounds = [100, 100]
+        self.plot._window = self.create_mock_window()
+        self.tool = BetterSelectingZoom(component=self.plot, always_on=True)
+        self.plot.active_tool = self.tool
+        self.plot.do_layout()
+
+    def tearDown(self):
+        del self.tool
+        del self.plot
+
+    def test_rgba_background_box(self):
+        tool = self.tool
+        tool.tool_mode = 'box'
+        tool.alpha = 0.3
+        tool.color = 'red'
+        gc = self.create_mock_gc(100, 100, methods=('set_fill_color',))
+
+        kwargs = {
+            'window': self.plot._window, 'control_down': True
+        }
+        self.mouse_down(self.tool, 0.0, 0.0, **kwargs)
+        self.mouse_move(self.tool, 10.0, 10.0, **kwargs)
+
+        tool.overlay(self.plot, gc)
+
+        self.assertEqual(gc.set_fill_color.call_args,
+                         mock.call([1.0, 0.0, 0.0, 0.3]))
+
+    def test_rgba_background_range(self):
+        tool = self.tool
+        tool.tool_mode = 'range'
+        tool.alpha = 0.3
+        tool.color = 'red'
+        gc = self.create_mock_gc(100, 100, methods=('set_fill_color',))
+
+        kwargs = {
+            'window': self.plot._window, 'control_down': True
+        }
+        self.mouse_down(self.tool, 0.0, 0.0, **kwargs)
+        self.mouse_move(self.tool, 10.0, 10.0, **kwargs)
+
+        tool.overlay(self.plot, gc)
+
+        self.assertEqual(gc.set_fill_color.call_args,
+                         mock.call([1.0, 0.0, 0.0, 0.3]))
+
+
+if __name__ == '__main__':
+    from unittest import main
+    main()


### PR DESCRIPTION
There is a small problem with the better_selecting_zoom... The range zoom is opaque... This is caused by setting the alpha on the range zoom before the the color is set... Overriding the alpha property.

I did a small refactoring so that the code for setting the fill color is now the same for both the box zoom and range zoom.