### PR TITLE
Fix contour plot grids

### DIFF
--- a/chaco/contour_line_plot.py
+++ b/chaco/contour_line_plot.py
@@ -4,7 +4,7 @@
 from __future__ import with_statement
 
 # Major library imports
-from numpy import array, isfinite, linspace, meshgrid, transpose
+from numpy import array, isfinite, meshgrid, transpose
 
 # Enthought library imports
 from enable.api import LineStyle
@@ -105,7 +105,8 @@ class ContourLinePlot(BaseContourPlot):
                     if self.orientation == "h":
                         strace = self.index_mapper.map_screen(trace)
                     else:
-                        strace = array(self.index_mapper.map_screen(trace))[:,::-1]
+                        strace = array(
+                            self.index_mapper.map_screen(trace))[:, ::-1]
                     gc.begin_path()
                     gc.lines(strace)
                     gc.stroke_path()
@@ -114,7 +115,7 @@ class ContourLinePlot(BaseContourPlot):
         """ Updates the cache of contour lines """
         if self.value.is_masked():
             # XXX masked data and get_data_mask not currently implemented
-            data = self.value.get_data_mask()
+            data, mask = self.value.get_data_mask()
             mask &= isfinite(data)
         else:
             data = self.value.get_data()
@@ -155,7 +156,7 @@ class ContourLinePlot(BaseContourPlot):
         else:
             self._widths = []
             for i in range(len(self._levels)):
-                self._widths.append(self.widths[i%len(self.widths)])
+                self._widths.append(self.widths[i % len(self.widths)])
 
         self._widths_cache_valid = True
 
@@ -182,11 +183,10 @@ class ContourLinePlot(BaseContourPlot):
         else:
             self._styles = []
             for i in range(len(self._levels)):
-                self._style_map_trait = self.styles[i%len(self.styles)]
+                self._style_map_trait = self.styles[i % len(self.styles)]
                 self._styles.append(self._style_map_trait_)
 
         self._styles_cache_valid = True
-
 
     #------------------------------------------------------------------------
     # Event handlers

--- a/chaco/contour_poly_plot.py
+++ b/chaco/contour_poly_plot.py
@@ -4,7 +4,7 @@
 from __future__ import with_statement
 
 # Major library imports
-from numpy import array, linspace, meshgrid, transpose
+from numpy import array, isfinite, linspace, meshgrid, transpose
 
 # Enthought library imports
 from traits.api import Bool, Dict
@@ -68,17 +68,22 @@ class ContourPolyPlot(BaseContourPlot):
 
     def _update_polys(self):
         """ Updates the cache of contour polygons """
-        # x and ydata are "fenceposts" so ignore the last value
-        # XXX: this truncation is causing errors in Cntr() as of r13735
-        xdata = self.index._xdata.get_data()
-        ydata = self.index._ydata.get_data()
-        xs = linspace(xdata[0], xdata[-1], len(xdata)-1)
-        ys = linspace(ydata[0], ydata[-1], len(ydata)-1)
-        xg, yg = meshgrid(xs, ys)
-        if self.orientation == "h":
-            c = Cntr(xg, yg, self.value.raw_value)
+        if self.value.is_masked():
+            # XXX masked data and get_data_mask not currently implemented
+            data = self.value.get_data_mask()
+            mask &= isfinite(data)
         else:
-            c = Cntr(xg, yg, self.value.raw_value.T)
+            data = self.value.get_data()
+            mask = isfinite(data)
+
+        x_data, y_data = self.index.get_data()
+        xs = x_data.get_data()
+        ys = y_data.get_data()
+        xg, yg = meshgrid(xs, ys)
+
+        # note: contour wants mask True in invalid locations
+        c = Cntr(xg, yg, data, ~mask)
+
         self._cached_contours = {}
         for i in range(len(self._levels)-1):
             key = (self._levels[i], self._levels[i+1])
@@ -95,5 +100,3 @@ class ContourPolyPlot(BaseContourPlot):
 
     def _update_colors(self):
         BaseContourPlot._update_colors(self, numcolors = len(self._levels) - 1)
-
-

--- a/chaco/contour_poly_plot.py
+++ b/chaco/contour_poly_plot.py
@@ -4,7 +4,7 @@
 from __future__ import with_statement
 
 # Major library imports
-from numpy import array, isfinite, linspace, meshgrid, transpose
+from numpy import array, isfinite, meshgrid, transpose
 
 # Enthought library imports
 from traits.api import Bool, Dict
@@ -61,7 +61,8 @@ class ContourPolyPlot(BaseContourPlot):
                     if self.orientation == "h":
                         spoly = self.index_mapper.map_screen(poly)
                     else:
-                        spoly = array(self.index_mapper.map_screen(poly))[:,::-1]
+                        spoly = array(
+                            self.index_mapper.map_screen(poly))[:, ::-1]
                     gc.lines(spoly)
                     gc.close_path()
                     gc.draw_path()
@@ -70,7 +71,7 @@ class ContourPolyPlot(BaseContourPlot):
         """ Updates the cache of contour polygons """
         if self.value.is_masked():
             # XXX masked data and get_data_mask not currently implemented
-            data = self.value.get_data_mask()
+            data, mask = self.value.get_data_mask()
             mask &= isfinite(data)
         else:
             data = self.value.get_data()
@@ -99,4 +100,4 @@ class ContourPolyPlot(BaseContourPlot):
         self._poly_cache_valid = False
 
     def _update_colors(self):
-        BaseContourPlot._update_colors(self, numcolors = len(self._levels) - 1)
+        BaseContourPlot._update_colors(self, numcolors=len(self._levels) - 1)

--- a/chaco/tests_with_backend/create_2d_test_case.py
+++ b/chaco/tests_with_backend/create_2d_test_case.py
@@ -38,26 +38,26 @@ def test_bounds_2d_case():
         pv.edit_traits()
 
 
-def test_process_2d_bounds():
+def test_process_2d_bounds_cell_plot():
     # behavior: _process_2d_bounds accepts all possible ways to set x and y
     # bounds in 2d plots and returns a 1d array with equally spaced
     # intervals between the lower and upper bound of the data. The number
     # of elements in the 1d array must be of one element larger than the
-    # shape of the data, because it includes the upper bound.
+    # shape of the data, because this is cell data.
 
     height, width = 20, 10
     array_data = np.ones(shape=(height, width))
     plot = Plot()
 
     # bounds is None : infer from array_data shape
-    xs = plot._process_2d_bounds(None, array_data, 1)
+    xs = plot._process_2d_bounds(None, array_data, 1, cell_plot=True)
     assert xs.shape[0] == width + 1
-    ys = plot._process_2d_bounds(None, array_data, 0)
+    ys = plot._process_2d_bounds(None, array_data, 0, cell_plot=True)
     assert ys.shape[0] == height + 1
 
     # bounds is a tuple : it defines lower and upper range
     bounds = (1.0, 100.0)
-    xs = plot._process_2d_bounds(bounds, array_data, 1)
+    xs = plot._process_2d_bounds(bounds, array_data, 1, cell_plot=True)
     assert xs.shape[0] == width + 1
     assert xs[0] == bounds[0] and xs[-1] == bounds[1]
 
@@ -66,12 +66,66 @@ def test_process_2d_bounds():
     # corresponding axis in array_data, or it will raise a Value error
     bounds = np.zeros((height+1, ))
     bounds[0], bounds[-1] = 0.2, 21.3
-    ys = plot._process_2d_bounds(bounds, array_data, 0)
+    ys = plot._process_2d_bounds(bounds, array_data, 0, cell_plot=True)
     assert ys.shape[0] == height + 1
     assert ys[0] == bounds[0] and ys[-1] == bounds[-1]
     with assert_raises(ValueError):
         bounds = np.zeros((width // 2, ))
-        plot._process_2d_bounds(bounds, array_data, 0)
+        plot._process_2d_bounds(bounds, array_data, 0, cell_plot=True)
+
+    # bounds is a 2D array: the first and last elements along the appropriate
+    # axis are used to create equally spaced intervals.
+    # The size of the bounds must be the same as the data array, or this
+    # sill raise a ValueError
+    xbounds, ybounds = np.meshgrid(np.arange(width+1), np.arange(height+1))
+
+    xs = plot._process_2d_bounds(xbounds, array_data, 1, cell_plot=True)
+    assert xs.shape[0] == width + 1
+    assert xs[0] == xbounds[0,0] and xs[-1] == xbounds[0,-1]
+    with assert_raises(ValueError):
+        plot._process_2d_bounds(xbounds[:, :5], array_data, 1, cell_plot=True)
+
+    ys = plot._process_2d_bounds(ybounds, array_data, 0, cell_plot=True)
+    assert ys.shape[0] == height + 1
+    assert ys[0] == ybounds[0,0] and ys[-1] == ybounds[-1,0]
+    with assert_raises(ValueError):
+        plot._process_2d_bounds(ybounds[:5, :], array_data, 0, cell_plot=True)
+
+
+def test_process_2d_bounds_vertex_data():
+    # behavior: _process_2d_bounds accepts all possible ways to set x and y
+    # bounds in 2d plots and returns a 1d array with equally spaced
+    # intervals between the lower and upper bound of the data. The number
+    # of elements in the 1d array must be the same as the shape of the data,
+    # because this is vertex data.
+
+    height, width = 20, 10
+    array_data = np.ones(shape=(height, width))
+    plot = Plot()
+
+    # bounds is None : infer from array_data shape
+    xs = plot._process_2d_bounds(None, array_data, 1, cell_plot=False)
+    assert xs.shape[0] == width
+    ys = plot._process_2d_bounds(None, array_data, 0, cell_plot=False)
+    assert ys.shape[0] == height
+
+    # bounds is a tuple : it defines lower and upper range
+    bounds = (1.0, 100.0)
+    xs = plot._process_2d_bounds(bounds, array_data, 1, cell_plot=False)
+    assert xs.shape[0] == width
+    assert xs[0] == bounds[0] and xs[-1] == bounds[1]
+
+    # bounds is a 1D array: the first and last elements are used to create
+    # equally spaced intervals. Bounds must be of one element larger than the
+    # corresponding axis in array_data, or it will raise a Value error
+    bounds = np.zeros((height, ))
+    bounds[0], bounds[-1] = 0.2, 21.3
+    ys = plot._process_2d_bounds(bounds, array_data, 0, cell_plot=False)
+    assert ys.shape[0] == height
+    assert ys[0] == bounds[0] and ys[-1] == bounds[-1]
+    with assert_raises(ValueError):
+        bounds = np.zeros((width // 2, ))
+        plot._process_2d_bounds(bounds, array_data, 0, cell_plot=False)
 
     # bounds is a 2D array: the first and last elements along the appropriate
     # axis are used to create equally spaced intervals.
@@ -79,15 +133,17 @@ def test_process_2d_bounds():
     # sill raise a ValueError
     xbounds, ybounds = np.meshgrid(np.arange(width), np.arange(height))
 
-    xs = plot._process_2d_bounds(xbounds, array_data, 1)
-    assert xs.shape[0] == width + 1
-    assert xs[0] == xbounds[0,0] and xs[-2] == xbounds[0,-1]
+    xs = plot._process_2d_bounds(xbounds, array_data, 1, cell_plot=False)
+    assert xs.shape[0] == width
+    assert xs[0] == xbounds[0,0] and xs[-1] == xbounds[0,-1]
     with assert_raises(ValueError):
-        plot._process_2d_bounds(xbounds[:5,:], array_data, 1)
+        plot._process_2d_bounds(xbounds[:, :5], array_data, 1, cell_plot=False)
 
-    ys = plot._process_2d_bounds(ybounds, array_data, 0)
-    assert ys.shape[0] == height + 1
-    assert ys[0] == ybounds[0,0] and ys[-2] == ybounds[-1,0]
+    ys = plot._process_2d_bounds(ybounds, array_data, 0, cell_plot=False)
+    assert ys.shape[0] == height
+    assert ys[0] == ybounds[0,0] and ys[-1] == ybounds[-1,0]
+    with assert_raises(ValueError):
+        plot._process_2d_bounds(ybounds[:5, :], array_data, 0, cell_plot=False)
 
 
 if __name__ == '__main__':

--- a/examples/demo/basic/contour_plot.py
+++ b/examples/demo/basic/contour_plot.py
@@ -10,7 +10,8 @@ Draws a contour polygon plot with a contour line plot on top
 """
 
 # Major library imports
-from numpy import cosh, exp, linspace, meshgrid, pi, tanh
+from numpy import abs, cosh, exp, linspace, meshgrid, pi, tanh, nan
+from numpy.random import uniform
 
 # Enthought library imports
 from enable.api import Component, ComponentEditor
@@ -27,29 +28,36 @@ from chaco.tools.api import PanTool, ZoomTool
 def _create_plot_component():
 
     # Create a scalar field to contour
-    xs = linspace(-2*pi, 2*pi, 600)
-    ys = linspace(-1.5*pi, 1.5*pi, 300)
+    # uses a randomly sampled, non-uniform grid
+    xs = uniform(-2*pi, 2*pi, 600)
+    xs.sort()
+    ys = uniform(-1.5*pi, 1.5*pi, 300)
+    ys.sort()
     x, y = meshgrid(xs,ys)
     z = tanh(x*y/6)*cosh(exp(-y**2)*x/3)
     z = x*y
 
-    # Create a plot data obect and give it this data
+    # mask out a region with nan values
+    mask = ((abs(x-5) <= 1) & (abs(y-2) <= 2))
+    z[mask] = nan
+
+    # Create a plot data object and give it this data
     pd = ArrayPlotData()
     pd.set_data("imagedata", z)
 
     # Create a contour polygon plot of the data
-    plot = Plot(pd, default_origin="top left")
+    plot = Plot(pd, default_origin="bottom left")
     plot.contour_plot("imagedata",
                       type="poly",
                       poly_cmap=jet,
-                      xbounds=(xs[0], xs[-1]),
-                      ybounds=(ys[0], ys[-1]))
+                      xbounds=x,
+                      ybounds=y)
 
     # Create a contour line plot for the data, too
     plot.contour_plot("imagedata",
                       type="line",
-                      xbounds=(xs[0], xs[-1]),
-                      ybounds=(ys[0], ys[-1]))
+                      xbounds=x,
+                      ybounds=y)
 
     # Tweak some of the plot properties
     plot.title = "My First Contour Plot"


### PR DESCRIPTION
Fixes #310 amongst other issues.

This PR fixes a number of issues with contour plots, and expands their capabilities:

* allows grid points to be non-uniformly sampled x and y values (ie. not a linspace)
* allows regions to be masked out
* treats non-finite values as being masked
* fixes assumption in `Plot` code that x and y values for index must be linearly spaced
* distinguishes between 2d data plotted at vertices and 2d data plotted in cells in `Plot` code
* significant simplifications in code paths by avoiding having to handle off-by-one errors in various places.

<img width="912" alt="screen shot 2016-11-16 at 3 48 05 pm" src="https://cloud.githubusercontent.com/assets/600761/20354034/be9ed722-ac14-11e6-9f9a-1c67fc481f95.png">
