### PR TITLE
 A couple of fixes to keep VS2010 compatibility and avoid a deprecate…

### DIFF
--- a/chaco/base.py
+++ b/chaco/base.py
@@ -7,7 +7,7 @@ from math import radians, sqrt
 
 # Major library imports
 from numpy import (array, argsort, concatenate, cos, diff, dot, empty, isfinite,
-                   nonzero, pi, searchsorted, seterr, sin)
+                   nonzero, pi, searchsorted, seterr, sin, uint8)
 
 # Enthought library imports
 from traits.api import CArray, Enum, Trait
@@ -220,7 +220,7 @@ def arg_true_runs(bool_array):
     """ Find runs where array is True """
     if len(bool_array) == 0:
         return []
-    runs = arg_find_runs(bool_array, 'flat')
+    runs = arg_find_runs(bool_array.astype(uint8), 'flat')
     # runs have to alternate true and false
     if bool_array[0]:
         # even runs are true

--- a/chaco/base.py
+++ b/chaco/base.py
@@ -7,7 +7,7 @@ from math import radians, sqrt
 
 # Major library imports
 from numpy import (array, argsort, concatenate, cos, diff, dot, empty, isfinite,
-                   nonzero, pi, searchsorted, seterr, sin, uint8)
+                   nonzero, pi, searchsorted, seterr, sin, int8)
 
 # Enthought library imports
 from traits.api import CArray, Enum, Trait
@@ -220,7 +220,7 @@ def arg_true_runs(bool_array):
     """ Find runs where array is True """
     if len(bool_array) == 0:
         return []
-    runs = arg_find_runs(bool_array.astype(uint8), 'flat')
+    runs = arg_find_runs(bool_array.view(int8), 'flat')
     # runs have to alternate true and false
     if bool_array[0]:
         # even runs are true

--- a/chaco/contour/cntr.c
+++ b/chaco/contour/cntr.c
@@ -1709,11 +1709,7 @@ static PyMethodDef module_methods[] = {
 MOD_INIT(contour)
 {
     PyObject* m = NULL;
-
-    if (PyType_Ready(&CntrType) < 0)
-        RETURN_MODINIT;
-
-#if PY_MAJOR_VERSION >= 3
+#if PY_MAJOR_VERSION >= 3    
     static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         "contour",     /* m_name */
@@ -1725,9 +1721,12 @@ MOD_INIT(contour)
         NULL,                /* m_clear */
         NULL,                /* m_free */
     };
+#endif
+    if (PyType_Ready(&CntrType) < 0)
+        RETURN_MODINIT;
 
+#if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
-
 #else
     m = Py_InitModule3("contour", module_methods,
                        "Contouring engine as an extension type");


### PR DESCRIPTION
…d warnings with newer versions of numpy

The first fix is on chaco\contour\cntrc.c to move the moduledef
declaration to the top the MOD_INIT function to be complain with older
compilers followingn the old C89 specification (such as VS 2010), the
credit to spot this goes to @stevenengler . The change should be
compatible with any other compiler.

The second change is on chaco\base.py to avoid a deprecate warning on
newer versions of numpy that do not accept differantion of boolean
arrays. The current fix simply recasted the array as uint8.