### PR TITLE
fix variable names for building from source distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,14 +101,14 @@ if not is_released:
     elif os.path.exists(filename):
         # must be a source distribution, use existing version file
         try:
-            git_revision, full_version = read_version_py(chaco_version_path)
+            git_rev, fullversion = read_version_py(chaco_version_path)
         except (SyntaxError, KeyError):
             raise RuntimeError("Unable to read git_revision. Try removing "
                                "chaco/_version.py and the build directory "
                                "before building.")
 
 
-        match = re.match(r'.*?\.dev(?P<dev_num>\d+)', full_v)
+        match = re.match(r'.*?\.dev(?P<dev_num>\d+)', fullversion)
         if match is None:
             dev_num = '0'
         else:


### PR DESCRIPTION
I received the following error when trying to build from the source 4.6.0 tarball obtained from
https://github.com/enthought/chaco/releases/download/4.6.0/chaco-4.6.0.tar.gz
```
Traceback (most recent call last):
  File "setup.py", line 133, in <module>
    write_version_py()
  File "setup.py", line 113, in write_version_py
    match = re.match(r'.*?\.dev(?P<dev_num>\d+)', full_v)
NameError: name 'full_v' is not defined
```

This PR fixes the variable names in this section of setup.py.
Not 100% certain if it should be `full_version` or `fullversion`, but I went with the latter as that is what seemed to be used in the other cases.

(Alternately, deleting chaco/_version.py also allows the build to proceed by avoiding this section of setup.py)