### PR TITLE
FIX: missing color bar when direction flipped

### DIFF
--- a/chaco/color_bar.py
+++ b/chaco/color_bar.py
@@ -140,7 +140,10 @@ class ColorBar(AbstractPlotRenderer):
 
             mapper = self.index_mapper
 
-            scrn_points = arange(mapper.low_pos, mapper.high_pos+1)
+            direction = 1 if self.direction == 'normal' else -1
+            scrn_points = arange(
+                mapper.low_pos, mapper.high_pos + 1, direction
+            )
 
             # Get the data values associated with the list of screen points.
             if mapper.range.low == mapper.range.high:
@@ -149,7 +152,6 @@ class ColorBar(AbstractPlotRenderer):
                 data_points = array([mapper.range.high])
             else:
                 data_points = mapper.map_data(scrn_points)
-
             if self.direction == 'flipped':
                 data_points = data_points[::-1]
 

--- a/chaco/color_bar.py
+++ b/chaco/color_bar.py
@@ -140,10 +140,11 @@ class ColorBar(AbstractPlotRenderer):
 
             mapper = self.index_mapper
 
-            direction = 1 if self.direction == 'normal' else -1
-            scrn_points = arange(
-                mapper.low_pos, mapper.high_pos + 1, direction
-            )
+            low = mapper.low_pos
+            high = mapper.high_pos
+            if self.direction == 'flipped':
+                low, high = high, low
+            scrn_points = arange(low, high + 1)
 
             # Get the data values associated with the list of screen points.
             if mapper.range.low == mapper.range.high:
@@ -152,8 +153,6 @@ class ColorBar(AbstractPlotRenderer):
                 data_points = array([mapper.range.high])
             else:
                 data_points = mapper.map_data(scrn_points)
-            if self.direction == 'flipped':
-                data_points = data_points[::-1]
 
             # Get the colors associated with the data points.
             colors = self.color_mapper.map_screen(data_points)


### PR DESCRIPTION
Closes #311. The `arange` produced an empty array when the `direction` attribute is set to `flipped` since `mapper.low_pos > mapper.high_pos`. This PR tells `arange` to descend when using the `flipped` direction rather than ascend. Here is the example from #311 before:
![image](https://cloud.githubusercontent.com/assets/8642896/23413984/041ed5e0-fda0-11e6-9889-6f30dbafa64e.png)

and after:
![image](https://cloud.githubusercontent.com/assets/8642896/23414014/1df76e14-fda0-11e6-9e3f-61422d083412.png)
