### PR TITLE
BUG: Copy over HOME value to git environment.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def git_version():
     def _minimal_ext_cmd(cmd):
         # construct minimal environment
         env = {}
-        for k in ['SYSTEMROOT', 'PATH']:
+        for k in ['SYSTEMROOT', 'PATH', 'HOME']:
             v = os.environ.get(k)
             if v is not None:
                 env[k] = v


### PR DESCRIPTION
Some installations of git have `~` expansions in their global `gitconfig` files. `git` processes need to have the `HOME` environment variable defined.

This fix will need to be propagated to other `setup.py` files that reuse this code.