### PR TITLE
Release 4.6.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ from setuptools import setup, Extension, find_packages
 
 MAJOR = 4
 MINOR = 6
-MICRO = 1
+MICRO = 2
 
-IS_RELEASED = True
+IS_RELEASED = False
 
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ MAJOR = 4
 MINOR = 6
 MICRO = 1
 
-IS_RELEASED = False
+IS_RELEASED = True
 
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Release 4.6.1

This supersedes https://github.com/enthought/chaco/pull/340 which was my earlier, unfinished attempt at releasing 4.6.1. As that PR was closed without merging and no tags were created for 4.6.1, I decided to re-use the version number (rather than jump straight to 4.6.2).