### PR TITLE
MAINT: Remove stray usage of unittest2.

### DIFF
--- a/chaco/tests/test_ticks.py
+++ b/chaco/tests/test_ticks.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 
 from chaco.ticks import DefaultTickGenerator, MinorTickGenerator, auto_interval
 
@@ -23,6 +23,7 @@ class TestDefaultTickGenerator(unittest.TestCase):
         expected_num_ticks = (high - low) / interval + 1
         self.assertEqual(len(ticks), expected_num_ticks)
 
+
 class TestMinorTickGenerator(unittest.TestCase):
 
     def setUp(self):
@@ -33,12 +34,12 @@ class TestMinorTickGenerator(unittest.TestCase):
         it should return the same results as a DefaultTickGenerator
         """
         self.default_tick_generator = DefaultTickGenerator()
-        
+
         high = 1.0
         low = 0.0
-        
+
         intervals = [0.05, 0.1, 0.2, 0.25, 0.5]
-        
+
         for i in intervals:
             ticksMinor = self.tick_generator.get_ticks(
                 data_low=0,
@@ -55,16 +56,16 @@ class TestMinorTickGenerator(unittest.TestCase):
                 interval=i,
             )
             self.assertEqual(ticksMinor.tolist(), ticksDefault.tolist())
-    
+
     def test_minor_tick_generator_without_interval(self):
         """A minor tick generator should return more ticks than
         the default tick generator.
         """
         self.default_tick_generator = DefaultTickGenerator()
-        
+
         high = 1.0
         low = 0.0
-        
+
         ticksMinor = self.tick_generator.get_ticks(
             data_low=0,
             data_high=1,
@@ -79,8 +80,9 @@ class TestMinorTickGenerator(unittest.TestCase):
             bounds_high=high,
             interval='auto',
         )
-        
+
         self.assertGreater(len(ticksMinor), len(ticksDefault))
+
 
 class TestAutoInterval(unittest.TestCase):
     def test_default_auto_interval(self):
@@ -106,6 +108,7 @@ class TestAutoInterval(unittest.TestCase):
             num_ticks = int((data_high - data_low) / interval)
             self.assertGreaterEqual(num_ticks, 3)
             self.assertLessEqual(num_ticks, max_ticks)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
We dropped this a while back but a stray `unittest2` import found its way in with the merge of a long-lived PR.