### PR TITLE
MAINT: Get docs to build again

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,14 @@
 Chaco CHANGELOG
 ===============
 
+Release 4.7.1
+-------------
+
+Fixes
+
+* Fix doc build (PR#384)
+* Upcast to int_ instead of int64 to avoid bincount issue (PR#383)
+
 Release 4.7.0
 -------------
 

--- a/chaco/tools/dataprinter.py
+++ b/chaco/tools/dataprinter.py
@@ -38,8 +38,8 @@ class DataPrinter(BaseTool):
                 y = plot.value.get_data()[ndx]
                 print(self.format % (x,y))
             else:
-                print("dataprinter: don't know how to handle plots of type", end=" ")
-                print(plot.__class__.__name__)
+                print("dataprinter: don't know how to handle plots of type {}".format(
+                    plot.__class__.__name__))
         return
 
 

--- a/docs/source/sphinxext/comment_eater.py
+++ b/docs/source/sphinxext/comment_eater.py
@@ -1,11 +1,10 @@
-import six.moves as sm
-
+from cStringIO import StringIO
 import compiler
 import inspect
 import textwrap
 import tokenize
 
-from .compiler_unparse import unparse
+from compiler_unparse import unparse
 
 
 class Comment(object):
@@ -77,7 +76,7 @@ class CommentBlocker(object):
     def process_file(self, file):
         """ Process a file object.
         """
-        for token in tokenize.generate_tokens(sm.next(file)):
+        for token in tokenize.generate_tokens(file.next):
             self.process_token(*token)
         self.make_index()
 
@@ -155,7 +154,7 @@ def get_class_traits(klass):
     # FIXME: gracefully handle errors here or in the caller?
     source = inspect.getsource(klass)
     cb = CommentBlocker()
-    cb.process_file(sm.StringIO(source))
+    cb.process_file(StringIO(source))
     mod_ast = compiler.parse(source)
     class_ast = mod_ast.node.nodes[0]
     for node in class_ast.code.nodes:

--- a/docs/source/sphinxext/compiler_unparse.py
+++ b/docs/source/sphinxext/compiler_unparse.py
@@ -12,14 +12,11 @@
 """
 
 import sys
-
-import six
-import six.moves as sm
-
+import cStringIO
 from compiler.ast import Const, Name, Tuple, Div, Mul, Sub, Add
 
 def unparse(ast, single_line_functions=False):
-    s = sm.cStringIO.StringIO()
+    s = cStringIO.StringIO()
     UnparseCompilerAst(ast, s, single_line_functions)
     return s.getvalue().lstrip()
 

--- a/docs/source/sphinxext/docscrape.py
+++ b/docs/source/sphinxext/docscrape.py
@@ -399,7 +399,7 @@ class FunctionDoc(NumpyDocString):
         self._role = role # e.g. "func" or "meth"
         try:
             NumpyDocString.__init__(self,inspect.getdoc(func) or '')
-        except ValueError, e:
+        except ValueError as e:
             print '*'*78
             print "ERROR: '%s' while parsing `%s`" % (e, self._f)
             print '*'*78
@@ -415,7 +415,7 @@ class FunctionDoc(NumpyDocString):
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*','\*')
                 signature = '%s%s' % (func_name, argspec)
-            except TypeError, e:
+            except TypeError as e:
                 signature = '%s()' % func_name
             self['Signature'] = signature
 
@@ -437,7 +437,7 @@ class FunctionDoc(NumpyDocString):
                  'meth': 'method'}
 
         if self._role:
-            if not roles.has_key(self._role):
+            if self._role not in roles:
                 print "Warning: invalid role %s" % self._role
             out += '.. %s:: %s\n    \n\n' % (roles.get(self._role,''),
                                              func_name)

--- a/docs/source/sphinxext/docscrape.py
+++ b/docs/source/sphinxext/docscrape.py
@@ -1,16 +1,12 @@
 """Extract reference documentation from the NumPy source tree.
 
 """
-from __future__ import print_function
 
 import inspect
 import textwrap
 import re
-
-import six
-import six.moves as sm
-
 import pydoc
+from StringIO import StringIO
 from warnings import warn
 
 class Reader(object):
@@ -126,7 +122,7 @@ class NumpyDocString(object):
         return self._parsed_data[key]
 
     def __setitem__(self,key,val):
-        if key not in self._parsed_data:
+        if not self._parsed_data.has_key(key):
             warn("Unknown section %s" % key)
         else:
             self._parsed_data[key] = val
@@ -366,7 +362,7 @@ class NumpyDocString(object):
         idx = self['index']
         out = []
         out += ['.. index:: %s' % idx.get('default','')]
-        for section, references in six.iteritems(idx):
+        for section, references in idx.iteritems():
             if section == 'default':
                 continue
             out += ['   :%s: %s' % (section, ', '.join(references))]
@@ -403,13 +399,13 @@ class FunctionDoc(NumpyDocString):
         self._role = role # e.g. "func" or "meth"
         try:
             NumpyDocString.__init__(self,inspect.getdoc(func) or '')
-        except ValueError as e:
-            print('*'*78)
-            print("ERROR: '%s' while parsing `%s`" % (e, self._f))
-            print('*'*78)
-            #print("Docstring follows:")
-            #print(doclines)
-            #print('='*78)
+        except ValueError, e:
+            print '*'*78
+            print "ERROR: '%s' while parsing `%s`" % (e, self._f)
+            print '*'*78
+            #print "Docstring follows:"
+            #print doclines
+            #print '='*78
 
         if not self['Signature']:
             func, func_name = self.get_func()
@@ -419,7 +415,7 @@ class FunctionDoc(NumpyDocString):
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*','\*')
                 signature = '%s%s' % (func_name, argspec)
-            except TypeError as e:
+            except TypeError, e:
                 signature = '%s()' % func_name
             self['Signature'] = signature
 
@@ -441,8 +437,8 @@ class FunctionDoc(NumpyDocString):
                  'meth': 'method'}
 
         if self._role:
-            if self._role not in roles:
-                print("Warning: invalid role %s" % self._role)
+            if not roles.has_key(self._role):
+                print "Warning: invalid role %s" % self._role
             out += '.. %s:: %s\n    \n\n' % (roles.get(self._role,''),
                                              func_name)
 

--- a/docs/source/sphinxext/docscrape_sphinx.py
+++ b/docs/source/sphinxext/docscrape_sphinx.py
@@ -1,9 +1,5 @@
 import re, textwrap
-
-import six
-
-from .docscrape import NumpyDocString, FunctionDoc, ClassDoc
-
+from docscrape import NumpyDocString, FunctionDoc, ClassDoc
 
 class SphinxDocString(NumpyDocString):
     # string conversion routines
@@ -70,7 +66,7 @@ class SphinxDocString(NumpyDocString):
             return out
 
         out += ['.. index:: %s' % idx.get('default','')]
-        for section, references in six.iteritems(idx):
+        for section, references in idx.iteritems():
             if section == 'default':
                 continue
             elif section == 'refguide':

--- a/docs/source/sphinxext/numpydoc.py
+++ b/docs/source/sphinxext/numpydoc.py
@@ -1,13 +1,6 @@
-from __future__ import print_function
-
 import os, re, pydoc
-
-import six
-import six.moves as sm
-
-from .docscrape_sphinx import SphinxDocString, SphinxClassDoc, SphinxFunctionDoc
+from docscrape_sphinx import SphinxDocString, SphinxClassDoc, SphinxFunctionDoc
 import inspect
-
 
 def mangle_docstrings(app, what, name, obj, options, lines,
                       reference_offset=[0]):
@@ -33,7 +26,7 @@ def mangle_docstrings(app, what, name, obj, options, lines,
             try:
                 references.append(int(l[len('.. ['):l.index(']')]))
             except ValueError:
-                print("WARNING: invalid reference in %s docstring" % name)
+                print "WARNING: invalid reference in %s docstring" % name
 
     # Start renaming from the biggest number, otherwise we may
     # overwrite references.
@@ -88,7 +81,7 @@ def initialize(app):
 
     fn = app.config.numpydoc_phantom_import_file
     if (fn and os.path.isfile(fn)):
-        print("[numpydoc] Phantom importing modules from", fn, "...")
+        print "[numpydoc] Phantom importing modules from", fn, "..."
         import_phantom_module(fn)
 
 def setup(app):
@@ -265,7 +258,7 @@ def _import_by_name(name):
         name_parts = name.split('.')
         last_j = 0
         modname = None
-        for j in reversed(sm.xrange(1, len(name_parts)+1)):
+        for j in reversed(range(1, len(name_parts)+1)):
             last_j = j
             modname = '.'.join(name_parts[:j])
             try:
@@ -282,7 +275,7 @@ def _import_by_name(name):
             return obj
         else:
             return sys.modules[modname]
-    except (ValueError, ImportError, AttributeError, KeyError) as e:
+    except (ValueError, ImportError, AttributeError, KeyError), e:
         raise ImportError(e)
 
 #------------------------------------------------------------------------------
@@ -322,7 +315,7 @@ def monkeypatch_sphinx_ext_autodoc():
     if sphinx.ext.autodoc.format_signature is our_format_signature:
         return
 
-    print("[numpydoc] Monkeypatching sphinx.ext.autodoc ...")
+    print "[numpydoc] Monkeypatching sphinx.ext.autodoc ..."
     _original_format_signature = sphinx.ext.autodoc.format_signature
     sphinx.ext.autodoc.format_signature = our_format_signature
 
@@ -438,7 +431,6 @@ def import_phantom_module(xml_file):
                 doc = "%s%s\n\n%s" % (funcname, argspec, doc)
             obj = lambda: 0
             obj.__argspec_is_invalid_ = True
-
             obj.func_name = funcname
             obj.__name__ = name
             obj.__doc__ = doc

--- a/docs/source/sphinxext/numpydoc.py
+++ b/docs/source/sphinxext/numpydoc.py
@@ -275,7 +275,7 @@ def _import_by_name(name):
             return obj
         else:
             return sys.modules[modname]
-    except (ValueError, ImportError, AttributeError, KeyError), e:
+    except (ValueError, ImportError, AttributeError, KeyError) as e:
         raise ImportError(e)
 
 #------------------------------------------------------------------------------

--- a/docs/source/sphinxext/traitsdoc.py
+++ b/docs/source/sphinxext/traitsdoc.py
@@ -1,14 +1,11 @@
-from __future__ import print_function
-
 import inspect
 import os
 import pydoc
 
-from . import docscrape
-from .docscrape_sphinx import SphinxClassDoc, SphinxFunctionDoc
-from . import numpydoc
-from . import comment_eater
-
+import docscrape
+from docscrape_sphinx import SphinxClassDoc, SphinxFunctionDoc
+import numpydoc
+import comment_eater
 
 class SphinxTraitsDoc(SphinxClassDoc):
     def __init__(self, cls, modulename='', func_doc=SphinxFunctionDoc):
@@ -129,7 +126,7 @@ def initialize(app):
 
     fn = app.config.numpydoc_phantom_import_file
     if (fn and os.path.isfile(fn)):
-        print("[numpydoc] Phantom importing modules from", fn, "...")
+        print "[numpydoc] Phantom importing modules from", fn, "..."
         numpydoc.import_phantom_module(fn)
 
 def setup(app):


### PR DESCRIPTION
To get the docs build back on the rails (#380), I reverted the Python 2/3 compatibility layer from https://github.com/enthought/chaco/pull/369 for the Sphinx extensions (the rest of the compatibility layer is still in place). I began by updating the import statements to match what Sphinx expects, but even after doing this I found that some of the six constructs didn't play well with the rest of the code. As this code is old and will not work on Python 3 without some serious maintenance (#324), I decided to just roll back that part of the code.

closes #380 