### PR TITLE
Feature: scatter inspector event

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@ Chaco CHANGELOG
 Release 4.7.1
 -------------
 
+New features/Improvements
+
+* Add a inspector_event attribute to ScatterInspector to get 
+  notifications when both (un)hovering or (de)selecting (PR#395).
+
 Fixes
 
 * Avoid datetime issue on Windows 10 (PR#387)

--- a/chaco/tools/scatter_inspector.py
+++ b/chaco/tools/scatter_inspector.py
@@ -2,7 +2,7 @@
 """
 
 # Enthought library imports
-from traits.api import Any, Bool, Event, HasStrictTraits, Str
+from traits.api import Any, Bool, Enum, Event, HasStrictTraits, Str
 
 # Local, relative imports
 from .select_tool import SelectTool
@@ -16,9 +16,9 @@ DESELECT_EVENT = "deselect"
 
 class ScatterInspectorEvent(HasStrictTraits):
     #: Is it a hover event or a selection event?
-    event_type = Str
+    event_type = Enum([HOVER_EVENT, SELECT_EVENT, DESELECT_EVENT])
 
-    #: What index was inspected?
+    #: What index was involved?
     event_index = Any
 
 
@@ -34,11 +34,11 @@ class ScatterInspector(SelectTool):
     """
 
     # If persistent_hover is False, then a point will be de-hovered as soon as
-    # the mouse leaves its hittesting area.  If persistent_hover is True, then
+    # the mouse leaves its hit-testing area. If persistent_hover is True, then
     # a point does no de-hover until another point get hover focus.
     persistent_hover = Bool(False)
 
-    # The names of the data source metadata for hover and selection.
+    # The names of the data source metadata for hover and selection events.
     hover_metadata_name = Str('hover')
     selection_metadata_name = Str('selections')
 
@@ -147,14 +147,16 @@ class ScatterInspector(SelectTool):
                         new_list = md[self.selection_metadata_name] + [index]
                         md[self.selection_metadata_name] = new_list
                         # Manually trigger the metadata_changed event on
-                        # the datasource.  Datasources only automatically
+                        # the datasource. Datasources only automatically
                         # fire notifications when the values inside the
                         # metadata dict change, but they do not listen
                         # for further changes on those values.
+                        # DEPRECATED: use self.inspector_event instead:
                         getattr(plot, name).metadata_changed = True
                 else:
                     md[self.selection_metadata_name] = [index]
 
+            # Test to only issue 1 event per selection, not 1 per axis:
             if name == 'index':
                 self.inspector_event = insp_event
 

--- a/chaco/tools/scatter_inspector.py
+++ b/chaco/tools/scatter_inspector.py
@@ -2,10 +2,24 @@
 """
 
 # Enthought library imports
-from traits.api import Bool, Str
+from traits.api import Any, Bool, Event, HasStrictTraits, Str
 
 # Local, relative imports
 from .select_tool import SelectTool
+
+HOVER_EVENT = "hover"
+
+SELECT_EVENT = "select"
+
+DESELECT_EVENT = "deselect"
+
+
+class ScatterInspectorEvent(HasStrictTraits):
+    #: Is it a hover event or a selection event?
+    event_type = Str
+
+    #: What index was inspected?
+    event_index = Any
 
 
 class ScatterInspector(SelectTool):
@@ -15,8 +29,8 @@ class ScatterInspector(SelectTool):
     index and value data sources, and allows clicking to select the point.
     Other components can listen for metadata updates on the data sources.
 
-    By default, it writes the index of the point under the cursor to the "hover"
-    key in metadata, and the index of a clicked point to "selection".
+    By default, it writes the index of the point under the cursor to the
+    "hover" key in metadata, and the index of a clicked point to "selection".
     """
 
     # If persistent_hover is False, then a point will be de-hovered as soon as
@@ -28,14 +42,17 @@ class ScatterInspector(SelectTool):
     hover_metadata_name = Str('hover')
     selection_metadata_name = Str('selections')
 
-    #------------------------------------------------------------------------
+    # This tool emits events when hover or selection changes
+    inspector_event = Event(ScatterInspectorEvent)
+
+    # -------------------------------------------------------------------------
     # Override/configure inherited traits
-    #------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
 
     # This tool is not visible
     visible = False
 
-    # This tool does not have a visual reprentation
+    # This tool does not have a visual representation
     draw_mode = "none"
 
     def normal_mouse_move(self, event):
@@ -43,24 +60,33 @@ class ScatterInspector(SelectTool):
 
         If the cursor is within **threshold** of a data point, the method
         writes the index to the plot's data sources' "hover" metadata.
+
+        This method emits a ScatterInspectorEvent when a new scatter point is
+        hovered over and when the mouse leaves that point.
         """
         plot = self.component
         index = plot.map_index((event.x, event.y), threshold=self.threshold)
+        insp_event = ScatterInspectorEvent(event_type=HOVER_EVENT,
+                                           event_index=index)
         if index is not None:
+            old = plot.index.metadata.get(self.hover_metadata_name, None)
             plot.index.metadata[self.hover_metadata_name] = [index]
+            if old != [index]:
+                self.inspector_event = insp_event
             if hasattr(plot, "value"):
                 plot.value.metadata[self.hover_metadata_name] = [index]
         elif not self.persistent_hover:
-            plot.index.metadata.pop(self.hover_metadata_name, None)
+            old = plot.index.metadata.pop(self.hover_metadata_name, None)
+            if old:
+                self.inspector_event = insp_event
             if hasattr(plot, "value"):
                 plot.value.metadata.pop(self.hover_metadata_name, None)
+
         return
 
     def _get_selection_state(self, event):
         plot = self.component
         index = plot.map_index((event.x, event.y), threshold=self.threshold)
-        #index_md = plot.index.metadata.get(self.selection_metadata_name, None)
-        #value_md = plot.value.metadata.get(self.selection_metadata_name, None)
 
         already_selected = False
         for name in ('index', 'value'):
@@ -84,21 +110,27 @@ class ScatterInspector(SelectTool):
         deselects all points.
         """
         plot = self.component
+        insp_event = ScatterInspectorEvent(event_type=DESELECT_EVENT,
+                                           event_index=index)
         for name in ('index', 'value'):
             if not hasattr(plot, name):
                 continue
             md = getattr(plot, name).metadata
-            if not self.selection_metadata_name in md:
+            if self.selection_metadata_name not in md:
                 pass
             elif index in md[self.selection_metadata_name]:
                 new_list = md[self.selection_metadata_name][:]
                 new_list.remove(index)
                 md[self.selection_metadata_name] = new_list
-                getattr(plot, name).metadata_changed = True
+                # Only issue 1 event:
+                if name == 'index':
+                    self.inspector_event = insp_event
         return
 
     def _select(self, index, append=True):
         plot = self.component
+        insp_event = ScatterInspectorEvent(event_type=SELECT_EVENT,
+                                           event_index=index)
         for name in ('index', 'value'):
             if not hasattr(plot, name):
                 continue
@@ -122,6 +154,10 @@ class ScatterInspector(SelectTool):
                         getattr(plot, name).metadata_changed = True
                 else:
                     md[self.selection_metadata_name] = [index]
+
+            if name == 'index':
+                self.inspector_event = insp_event
+
         return
 
 

--- a/chaco/tools/tests/scatter_inspector_test_case.py
+++ b/chaco/tools/tests/scatter_inspector_test_case.py
@@ -1,0 +1,171 @@
+""" Tests for the ScatterInspector Chaco tool
+"""
+
+from unittest import TestCase
+import numpy
+
+from chaco.api import create_scatter_plot
+from chaco.tools.api import ScatterInspector
+from enable.testing import EnableTestAssistant
+from traits.testing.unittest_tools import UnittestTools
+
+
+class TestScatterInspectorTool(EnableTestAssistant, TestCase, UnittestTools):
+    """ Tests for the ScatterInspector tool """
+
+    def setUp(self):
+        values = numpy.arange(10)
+        self.plot = create_scatter_plot((values, values))
+        self.plot.bounds = [100, 100]
+        self.plot._window = self.create_mock_window()
+        self.tool = ScatterInspector(component=self.plot)
+        self.plot.active_tool = self.tool
+        self.plot.do_layout()
+
+        self.insp_event = None
+
+    def tearDown(self):
+        del self.tool
+        del self.plot
+
+    def test_default_state(self):
+        tool = self.tool
+        hover_name = tool.hover_metadata_name
+        selection_name = tool.selection_metadata_name
+        index_md = tool.component.index.metadata
+        value_md = tool.component.value.metadata
+
+        self.assertEqual(index_md[selection_name], [])
+        self.assertEqual(value_md[selection_name], [])
+
+        self.assertNotIn(hover_name, index_md)
+        self.assertNotIn(hover_name, value_md)
+
+    def test_hover(self):
+        tool = self.tool
+        name = tool.hover_metadata_name
+        index_md = tool.component.index.metadata
+        value_md = tool.component.value.metadata
+
+        # Move to first point
+        self.mouse_move(tool, 0, 0)
+        self.assertEqual(index_md[name], [0])
+        self.assertEqual(value_md[name], [0])
+
+        # Move to off diagonal to not be close to a scatter point:
+        self.mouse_move(tool, 10, 0)
+        self.assertNotIn(name, index_md)
+        self.assertNotIn(name, value_md)
+
+        # Move to second point
+        self.mouse_move(tool, 10, 10)
+        self.assertEqual(index_md[name], [1])
+        self.assertEqual(value_md[name], [1])
+
+    def test_select(self):
+        tool = self.tool
+        name = tool.selection_metadata_name
+        index_md = tool.component.index.metadata
+        value_md = tool.component.value.metadata
+
+        # Click on first point
+        self.mouse_down(tool, 0, 0)
+        self.assertEqual(index_md[name], [0])
+        self.assertEqual(value_md[name], [0])
+
+        # Click on second point
+        self.mouse_down(tool, 10, 10)
+        self.assertEqual(index_md[name], [0, 1])
+        self.assertEqual(value_md[name], [0, 1])
+
+    def test_unselect(self):
+        tool = self.tool
+        name = tool.selection_metadata_name
+        index_md = tool.component.index.metadata
+        value_md = tool.component.value.metadata
+
+        self.mouse_down(tool, 0, 0)
+        self.mouse_down(tool, 10, 10)
+        self.assertEqual(index_md[name], [0, 1])
+        self.assertEqual(value_md[name], [0, 1])
+
+        # Deselect the second point
+        self.mouse_down(tool, 10, 10)
+        self.assertEqual(index_md[name], [0])
+        self.assertEqual(value_md[name], [0])
+
+        # Deselect the first point
+        self.mouse_down(tool, 0, 0)
+        self.assertEqual(index_md[name], [])
+        self.assertEqual(value_md[name], [])
+
+    def test_hover_triggers_event(self):
+        tool = self.tool
+
+        # Add a listener to catch the emitted event:
+        tool.on_trait_change(self.store_inspector_event, "inspector_event")
+        try:
+            self.assertIsNone(self.insp_event)
+
+            # Move to the first scatter point
+            with self.assertTraitChanges(tool, "inspector_event", 1):
+                self.mouse_move(tool, 0, 0)
+
+                self.assertEqual(self.insp_event.event_type, "hover")
+                self.assertEqual(self.insp_event.event_index, 0)
+
+            # Moving around the same scatter point doesn't trigger events:
+            with self.assertTraitDoesNotChange(tool, "inspector_event"):
+                self.mouse_move(tool, 1, 0)
+
+            # Leave the scatter point event:
+            with self.assertTraitChanges(tool, "inspector_event", 1):
+                self.mouse_move(tool, 10, 0)
+                self.assertEqual(self.insp_event.event_type, "hover")
+                self.assertEqual(self.insp_event.event_index, None)
+
+            # Move to the second scatter point
+            with self.assertTraitChanges(tool, "inspector_event", 1):
+                self.mouse_move(tool, 10, 10)
+
+                self.assertEqual(self.insp_event.event_type, "hover")
+                self.assertEqual(self.insp_event.event_index, 1)
+        finally:
+            tool.on_trait_change(self.store_inspector_event, "inspector_event",
+                                 remove=True)
+
+    def test_select_triggers_event(self):
+        tool = self.tool
+
+        # Add a listener to catch the emitted event:
+        tool.on_trait_change(self.store_inspector_event, "inspector_event")
+        try:
+            self.assertIsNone(self.insp_event)
+
+            # Select the first scatter point
+            with self.assertTraitChanges(tool, "inspector_event", 1):
+                self.mouse_down(tool, 0, 0)
+
+                self.assertEqual(self.insp_event.event_type, "select")
+                self.assertEqual(self.insp_event.event_index, 0)
+
+            # Leave the scatter point event:
+            with self.assertTraitChanges(tool, "inspector_event", 1):
+                self.mouse_down(tool, 10, 10)
+                self.assertEqual(self.insp_event.event_type, "select")
+                self.assertEqual(self.insp_event.event_index, 1)
+
+            # Deselect the second scatter point
+            with self.assertTraitChanges(tool, "inspector_event", 1):
+                self.mouse_down(tool, 10, 10)
+
+                self.assertEqual(self.insp_event.event_type, "deselect")
+                self.assertEqual(self.insp_event.event_index, 1)
+        finally:
+            tool.on_trait_change(self.store_inspector_event, "inspector_event",
+                                 remove=True)
+
+    # Helper methods ----------------------------------------------------------
+
+    def store_inspector_event(self, event):
+        self.insp_event = event

--- a/examples/demo/basic/scatter_inspector.py
+++ b/examples/demo/basic/scatter_inspector.py
@@ -40,7 +40,8 @@ def _create_plot_component():
     plot.overlays.append(ZoomTool(plot))
 
     # Attach the inspector and its overlay
-    scatter.tools.append(ScatterInspector(scatter))
+    inspector = ScatterInspector(scatter)
+    scatter.tools.append(inspector)
     overlay = ScatterInspectorOverlay(scatter,
                     hover_color="red",
                     hover_marker_size=6,
@@ -49,6 +50,11 @@ def _create_plot_component():
                     selection_outline_color="purple",
                     selection_line_width=3)
     scatter.overlays.append(overlay)
+
+    # Optional: add a listener on inspector events:
+    def echo(new):
+        print("{} event on element {}".format(new.event_type, new.event_index))
+    inspector.on_trait_change(echo, "inspector_event")
 
     return plot
 


### PR DESCRIPTION
Goal: I am building connected scatter plots and wanted to propagate hover and selection events from one plot to the other. Selection events can be propagated by listener to the tool's component's index's metadata_changed, but that's very labor intensive. And there was no way to propagate hover events.

This PR fixes both these issues, by proposing to emit custom `ScatterInspectorEvent`, which holds information about the type of event, and the scatter point index being involved. The logic is:
  * a `select` type event gets emitted on selection and a different `deselect` event gets emitted when deselecting a point.
  * a single `hover` event gets emitted when hovering a point (no event if the mouse moves while on the same point)
  * a `hover` event gets emitted when mouse leaves a point, with index `None`.

This PR also adds tests for the inspector that were missing, and a tiny bit of styling fixes that I couldn't refrain from making.

Backward compatibility: This PR should be 100% backward compatible, since I am leaving the (now redundant) `getattr(plot, name).metadata_changed = True` events. I thought of replacing `True` by a more interesting `ScatterInspectorEvent`, but that would require modifying the `AbstractDataSource` code, which feels too intrusive for my goal.

Feedback is welcome, especially on the strategy for when to emit hover events, and whether it would be more logical to emit some "`unhover`" events when leaving a point rather than a `hover` event with `None` index.