### PR TITLE
FIX: Use single comma-separated trait names in on_trait_change, not multiple arguments

### DIFF
--- a/examples/demo/advanced/data_cube.py
+++ b/examples/demo/advanced/data_cube.py
@@ -68,7 +68,7 @@ class Model(HasTraits):
         super(Model, self).__init__(*args, **kwargs)
         self.compute_model()
 
-    @on_trait_change("npts_+", "min_+", "max_+")
+    @on_trait_change("npts_+, min_+, max_+")
     def compute_model(self):
         def vfunc(x, y, z):
             return sin(x*z) * cos(y)*sin(z) + sin(0.5*z)


### PR DESCRIPTION
Fixes the `advanced/data_cube.py` demo, which passed multiple arguments to the `on_trait_change` decorator instead of a comma-separated string.