### PR TITLE
Tweak: docstring for ArrayPlotData.set_data and ArrayPlotData.update_data

### DIFF
--- a/chaco/array_plot_data.py
+++ b/chaco/array_plot_data.py
@@ -122,6 +122,10 @@ class ArrayPlotData(AbstractPlotData):
         -------
         The name under which the array was set.
 
+        See Also
+        --------
+        update_data: Use if needing to set multiple ArrayPlotData entries at
+            once, for example because their dimension changes.
         """
         if not self.writable:
             return None
@@ -135,12 +139,15 @@ class ArrayPlotData(AbstractPlotData):
 
 
     def update_data(self, *args, **kwargs):
-        """ Sets the specified array as the value for either the specified
-        name or a generated name.
+        """ Updates any number of arrays before triggering a `data_changed`
+        event.
 
         Implements AbstractPlotData's update_data() method.  This method has
         the same signature as the dictionary update() method.
 
+        See Also
+        --------
+        set_data: Simpler interface to set only 1 entry at a time.
         """
         if not self.writable:
             return None

--- a/chaco/array_plot_data.py
+++ b/chaco/array_plot_data.py
@@ -125,7 +125,8 @@ class ArrayPlotData(AbstractPlotData):
         See Also
         --------
         update_data: Use if needing to set multiple ArrayPlotData entries at
-            once, for example because their dimension changes.
+            once, for example because new arrays' dimensions change and
+            updating one at a time would break an existing Plot.
         """
         if not self.writable:
             return None
@@ -142,8 +143,12 @@ class ArrayPlotData(AbstractPlotData):
         """ Updates any number of arrays before triggering a `data_changed`
         event.
 
-        Implements AbstractPlotData's update_data() method.  This method has
-        the same signature as the dictionary update() method.
+        Useful to set multiple ArrayPlotData entries at once, for example
+        because new arrays' dimensions change and updating one at a time would
+        break an existing Plot.
+
+        Note: Implements AbstractPlotData's update_data() method.  This method
+        has the same signature as the dictionary update() method.
 
         See Also
         --------


### PR DESCRIPTION
- Add `see also` section in docstring of `set_data` pointing to `update_data` (since I always forget its name). 
- Replace copy-pasta docstring in `update_data` by something more accurate.