### PR TITLE
FIX: Ensure contiguous inputs to points_in_polygon

### DIFF
--- a/chaco/polygon_plot.py
+++ b/chaco/polygon_plot.py
@@ -134,7 +134,7 @@ class PolygonPlot(BaseXYPlot):
         data_pt = self.map_data(screen_pt, all_values=True)
         index = self.index.get_data()
         value = self.value.get_data()
-        poly = np.vstack((index,value)).T
+        poly = np.column_stack((index, value))
         if points_in_polygon([data_pt], poly)[0] == 1:
             return True
         else:

--- a/chaco/tools/lasso_selection.py
+++ b/chaco/tools/lasso_selection.py
@@ -2,7 +2,7 @@
 """
 # Major library imports
 import numpy
-from numpy import array, empty, sometrue, vstack, zeros, ascontiguousarray
+from numpy import array, column_stack, empty, sometrue, vstack, zeros
 
 # Enthought library imports
 from traits.api import Any, Array, Enum, Event, Bool, Instance, \
@@ -308,9 +308,8 @@ class LassoSelection(AbstractController):
     def _get_data(self):
         """ Returns the datapoints in the plot, as an Nx2 array of (x,y).
         """
-        points = array((self.plot.index.get_data(),
-                        self.plot.value.get_data()))
-        return ascontiguousarray(points.T)
+        return column_stack((self.plot.index.get_data(),
+                             self.plot.value.get_data()))
 
     #------------------------------------------------------------------------
     # Property getter/setters


### PR DESCRIPTION
Ahem... Right. So, in #409, I said there was one other call to `points_in_polygon`, but it looked OK. Well, I was wrong. It was being called with a transposed input. This corrects that.