### PR TITLE
ENH: skip DataFramePlotData tests if pandas is not installed

### DIFF
--- a/chaco/tests/data_frame_plot_data_test_case.py
+++ b/chaco/tests/data_frame_plot_data_test_case.py
@@ -1,9 +1,8 @@
 import contextlib
-from traits.testing.unittest_tools import unittest
+import unittest
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from pandas import DataFrame
 
 from chaco.api import DataFramePlotData
 from traits.api import HasTraits, Instance, List, on_trait_change
@@ -29,84 +28,88 @@ def monitor_events(plot_data):
     yield collector.data_changed_events
 
 
-class DataFramePlotDataTestCase(unittest.TestCase):
+try:
+    from pandas import DataFrame
 
-    def test_data_changed_events(self):
-        # Test data.
-        arr = np.zeros(16)
-        arr2 = np.ones(16)
 
-        df = DataFrame(index=np.arange(16))
-        plot_data = DataFramePlotData(data_frame=df)
+    class DataFramePlotDataTestCase(unittest.TestCase):
 
-        assert_array_equal(plot_data.get_data('index'), df.index.values)
+        def test_data_changed_events(self):
+            # Test data.
+            arr = np.zeros(16)
+            arr2 = np.ones(16)
 
-        with monitor_events(plot_data) as events:
-            plot_data.set_data('arr', arr)
-            self.assertEqual(events, [{'added': ['arr']}])
+            df = DataFrame(index=np.arange(16))
+            plot_data = DataFramePlotData(data_frame=df)
 
-            assert_array_equal(df['arr'].values, arr)
-
-            # While we're here, check that get_data works as advertised.
-            out = plot_data.get_data('arr')
-            assert_array_equal(arr, out)
-
-        with monitor_events(plot_data) as events:
-            plot_data.set_data('arr', arr2)
-            self.assertEqual(events, [{'changed': ['arr']}])
-            assert_array_equal(df['arr'].values, arr2)
-
-        with monitor_events(plot_data) as events:
-            plot_data.del_data('arr')
-            self.assertEqual(events, [{'removed': ['arr']}])
-
-    def test_no_index_column(self):
-        # Test data.
-        idx = np.arange(16)
-        arr = np.zeros(16)
-        df = DataFrame(index=idx)
-        plot_data = DataFramePlotData(data_frame=df)
-
-        assert_array_equal(plot_data.get_data('index'), df.index.values)
-
-        # Can set 'index'
-        with monitor_events(plot_data) as events:
-            plot_data.set_data('index', arr)
-            self.assertEqual(events, [{'changed': ['index']}])
-            self.assertNotIn('index', df.columns)
-            assert_array_equal(df.index.values, arr)
-
-        # Cannot remove 'index' column
-        with self.assertRaises(KeyError):
-            plot_data.del_data('index')
-
-    def test_index_column(self):
-        # Test data.
-        idx = np.arange(16)
-        arr = np.zeros(16)
-        arr2 = np.ones(16)
-        data = {'index': arr}
-        df = DataFrame(data, index=idx)
-        plot_data = DataFramePlotData(data_frame=df)
-
-        assert_array_equal(plot_data.get_data('index'), df['index'].values)
-
-        # Can set 'index' column
-        with monitor_events(plot_data) as events:
-            plot_data.set_data('index', arr2)
-            self.assertEqual(events, [{'changed': ['index']}])
-            assert_array_equal(df['index'].values, arr2)
-
-        # Can remove 'index' column
-        with monitor_events(plot_data) as events:
-            plot_data.del_data('index')
-            self.assertNotIn('index', df.columns)
-            # Since there is always an index, this will register a 'changed'
-            # event instead of a 'removed' event.
-            self.assertEqual(events, [{'changed': ['index']}])
             assert_array_equal(plot_data.get_data('index'), df.index.values)
 
+            with monitor_events(plot_data) as events:
+                plot_data.set_data('arr', arr)
+                self.assertEqual(events, [{'added': ['arr']}])
 
-if __name__ == '__main__':
-    import nose
-    nose.run()
+                assert_array_equal(df['arr'].values, arr)
+
+                # While we're here, check that get_data works as advertised.
+                out = plot_data.get_data('arr')
+                assert_array_equal(arr, out)
+
+            with monitor_events(plot_data) as events:
+                plot_data.set_data('arr', arr2)
+                self.assertEqual(events, [{'changed': ['arr']}])
+                assert_array_equal(df['arr'].values, arr2)
+
+            with monitor_events(plot_data) as events:
+                plot_data.del_data('arr')
+                self.assertEqual(events, [{'removed': ['arr']}])
+
+        def test_no_index_column(self):
+            # Test data.
+            idx = np.arange(16)
+            arr = np.zeros(16)
+            df = DataFrame(index=idx)
+            plot_data = DataFramePlotData(data_frame=df)
+
+            assert_array_equal(plot_data.get_data('index'), df.index.values)
+
+            # Can set 'index'
+            with monitor_events(plot_data) as events:
+                plot_data.set_data('index', arr)
+                self.assertEqual(events, [{'changed': ['index']}])
+                self.assertNotIn('index', df.columns)
+                assert_array_equal(df.index.values, arr)
+
+            # Cannot remove 'index' column
+            with self.assertRaises(KeyError):
+                plot_data.del_data('index')
+
+        def test_index_column(self):
+            # Test data.
+            idx = np.arange(16)
+            arr = np.zeros(16)
+            arr2 = np.ones(16)
+            data = {'index': arr}
+            df = DataFrame(data, index=idx)
+            plot_data = DataFramePlotData(data_frame=df)
+
+            assert_array_equal(plot_data.get_data('index'), df['index'].values)
+
+            # Can set 'index' column
+            with monitor_events(plot_data) as events:
+                plot_data.set_data('index', arr2)
+                self.assertEqual(events, [{'changed': ['index']}])
+                assert_array_equal(df['index'].values, arr2)
+
+            # Can remove 'index' column
+            with monitor_events(plot_data) as events:
+                plot_data.del_data('index')
+                self.assertNotIn('index', df.columns)
+                # Since there is always an index, this will register a 'changed'
+                # event instead of a 'removed' event.
+                self.assertEqual(events, [{'changed': ['index']}])
+                assert_array_equal(plot_data.get_data('index'), df.index.values)
+
+except ImportError:
+    raise unittest.SkipTest(
+        "Cannot import pandas. Skipping all tests"
+    )

--- a/chaco/tests/data_frame_plot_data_test_case.py
+++ b/chaco/tests/data_frame_plot_data_test_case.py
@@ -7,6 +7,13 @@ from numpy.testing import assert_array_equal
 from chaco.api import DataFramePlotData
 from traits.api import HasTraits, Instance, List, on_trait_change
 
+try:
+    from pandas import DataFrame
+    pandas_imported = True
+
+except ImportError:
+    pandas_imported = False
+
 
 class DataFramePlotDataEventsCollector(HasTraits):
     plot_data = Instance(DataFramePlotData)
@@ -28,88 +35,81 @@ def monitor_events(plot_data):
     yield collector.data_changed_events
 
 
-try:
-    from pandas import DataFrame
+class DataFramePlotDataTestCase(unittest.TestCase):
+    @unittest.skipUnless(pandas_imported, "Requires pandas")
+    def test_data_changed_events(self):
+        # Test data.
+        arr = np.zeros(16)
+        arr2 = np.ones(16)
 
+        df = DataFrame(index=np.arange(16))
+        plot_data = DataFramePlotData(data_frame=df)
 
-    class DataFramePlotDataTestCase(unittest.TestCase):
+        assert_array_equal(plot_data.get_data('index'), df.index.values)
 
-        def test_data_changed_events(self):
-            # Test data.
-            arr = np.zeros(16)
-            arr2 = np.ones(16)
+        with monitor_events(plot_data) as events:
+            plot_data.set_data('arr', arr)
+            self.assertEqual(events, [{'added': ['arr']}])
 
-            df = DataFrame(index=np.arange(16))
-            plot_data = DataFramePlotData(data_frame=df)
+            assert_array_equal(df['arr'].values, arr)
 
+            # While we're here, check that get_data works as advertised.
+            out = plot_data.get_data('arr')
+            assert_array_equal(arr, out)
+
+        with monitor_events(plot_data) as events:
+            plot_data.set_data('arr', arr2)
+            self.assertEqual(events, [{'changed': ['arr']}])
+            assert_array_equal(df['arr'].values, arr2)
+
+        with monitor_events(plot_data) as events:
+            plot_data.del_data('arr')
+            self.assertEqual(events, [{'removed': ['arr']}])
+
+    @unittest.skipUnless(pandas_imported, "Requires pandas")
+    def test_no_index_column(self):
+        # Test data.
+        idx = np.arange(16)
+        arr = np.zeros(16)
+        df = DataFrame(index=idx)
+        plot_data = DataFramePlotData(data_frame=df)
+
+        assert_array_equal(plot_data.get_data('index'), df.index.values)
+
+        # Can set 'index'
+        with monitor_events(plot_data) as events:
+            plot_data.set_data('index', arr)
+            self.assertEqual(events, [{'changed': ['index']}])
+            self.assertNotIn('index', df.columns)
+            assert_array_equal(df.index.values, arr)
+
+        # Cannot remove 'index' column
+        with self.assertRaises(KeyError):
+            plot_data.del_data('index')
+
+    @unittest.skipUnless(pandas_imported, "Requires pandas")
+    def test_index_column(self):
+        # Test data.
+        idx = np.arange(16)
+        arr = np.zeros(16)
+        arr2 = np.ones(16)
+        data = {'index': arr}
+        df = DataFrame(data, index=idx)
+        plot_data = DataFramePlotData(data_frame=df)
+
+        assert_array_equal(plot_data.get_data('index'), df['index'].values)
+
+        # Can set 'index' column
+        with monitor_events(plot_data) as events:
+            plot_data.set_data('index', arr2)
+            self.assertEqual(events, [{'changed': ['index']}])
+            assert_array_equal(df['index'].values, arr2)
+
+        # Can remove 'index' column
+        with monitor_events(plot_data) as events:
+            plot_data.del_data('index')
+            self.assertNotIn('index', df.columns)
+            # Since there is always an index, this will register a 'changed'
+            # event instead of a 'removed' event.
+            self.assertEqual(events, [{'changed': ['index']}])
             assert_array_equal(plot_data.get_data('index'), df.index.values)
-
-            with monitor_events(plot_data) as events:
-                plot_data.set_data('arr', arr)
-                self.assertEqual(events, [{'added': ['arr']}])
-
-                assert_array_equal(df['arr'].values, arr)
-
-                # While we're here, check that get_data works as advertised.
-                out = plot_data.get_data('arr')
-                assert_array_equal(arr, out)
-
-            with monitor_events(plot_data) as events:
-                plot_data.set_data('arr', arr2)
-                self.assertEqual(events, [{'changed': ['arr']}])
-                assert_array_equal(df['arr'].values, arr2)
-
-            with monitor_events(plot_data) as events:
-                plot_data.del_data('arr')
-                self.assertEqual(events, [{'removed': ['arr']}])
-
-        def test_no_index_column(self):
-            # Test data.
-            idx = np.arange(16)
-            arr = np.zeros(16)
-            df = DataFrame(index=idx)
-            plot_data = DataFramePlotData(data_frame=df)
-
-            assert_array_equal(plot_data.get_data('index'), df.index.values)
-
-            # Can set 'index'
-            with monitor_events(plot_data) as events:
-                plot_data.set_data('index', arr)
-                self.assertEqual(events, [{'changed': ['index']}])
-                self.assertNotIn('index', df.columns)
-                assert_array_equal(df.index.values, arr)
-
-            # Cannot remove 'index' column
-            with self.assertRaises(KeyError):
-                plot_data.del_data('index')
-
-        def test_index_column(self):
-            # Test data.
-            idx = np.arange(16)
-            arr = np.zeros(16)
-            arr2 = np.ones(16)
-            data = {'index': arr}
-            df = DataFrame(data, index=idx)
-            plot_data = DataFramePlotData(data_frame=df)
-
-            assert_array_equal(plot_data.get_data('index'), df['index'].values)
-
-            # Can set 'index' column
-            with monitor_events(plot_data) as events:
-                plot_data.set_data('index', arr2)
-                self.assertEqual(events, [{'changed': ['index']}])
-                assert_array_equal(df['index'].values, arr2)
-
-            # Can remove 'index' column
-            with monitor_events(plot_data) as events:
-                plot_data.del_data('index')
-                self.assertNotIn('index', df.columns)
-                # Since there is always an index, this will register a 'changed'
-                # event instead of a 'removed' event.
-                self.assertEqual(events, [{'changed': ['index']}])
-                assert_array_equal(plot_data.get_data('index'), df.index.values)
-
-except ImportError:
-    raise unittest.SkipTest(
-        "Cannot import pandas. Skipping all tests"
-    )


### PR DESCRIPTION
This PR adds pandas DataFramePlotData skip if pandas package does not exist.

Closes #392 