### PR TITLE
Add option for aligning label in index direction in TextPlot1D

### DIFF
--- a/chaco/text_plot_1d.py
+++ b/chaco/text_plot_1d.py
@@ -46,6 +46,10 @@ class TextPlot1D(Base1DPlot):
     #: alignment of text relative to non-index direction
     alignment = Enum("center", "left", "right", "top", "bottom")
 
+    #: alignment of text relative to index direction and centered around the
+    #: provided value point
+    index_alignment = Enum("right", "center", "left", "top", "bottom")
+
     #: offset of text relative to non-index direction in pixels
     text_offset = Float
 
@@ -108,8 +112,31 @@ class TextPlot1D(Base1DPlot):
             gc.clip_to_rect(self.x, self.y, self.width, self.height)
             for pt, label in sm.zip(pts, labels):
                 with gc:
-                    gc.translate_ctm(*pt)
+                    x, y = self._get_index_text_position(gc, pt, label)
+                    gc.translate_ctm(x, y)
                     label.draw(gc)
+
+    def _get_index_text_position(self, gc, pt, label):
+        """ Compute the text label position in the index direction """
+        x, y = pt
+        width, height = label.get_bounding_box(gc)
+
+        if self.orientation == 'v':
+            position, width = y, height
+        else:
+            position = x
+
+        if self.index_alignment == 'center':
+            position -= width/2.0
+        elif self.index_alignment in ['left', 'bottom']:
+            position -= width
+        # If alignment is 'right' or 'top' we do nothing as that already
+        # matches the default behavior
+
+        if self.orientation == 'v':
+            return x, position
+        else:
+            return position, y
 
     def _get_text_position(self):
         """ Compute the text label position in the non-index direction """


### PR DESCRIPTION
This is a nice little feature that I implemented for another project and wanted to port here as well. This PR adds options to align the label in the index direction (either left/center/right or top/center/bottom depending on orientation). There were already options for this sort of thing in the non-index direction but there was no way to do it in the index direction.

Screenshot with toy plot showing the new possible positioning: left/center/right or top/center/bottom (previously the label was always placed where the blue letters are)
<img width="515" alt="screenshot 2019-01-10 at 11 59 38" src="https://user-images.githubusercontent.com/4663211/50995996-b74a2980-1518-11e9-932e-f26a8e070370.png">
