### PR TITLE
Update unittest imports

### DIFF
--- a/chaco/scales/tests/test_scales.py
+++ b/chaco/scales/tests/test_scales.py
@@ -1,4 +1,4 @@
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from numpy import array
 

--- a/chaco/shell/tests/test_tutorial_example.py
+++ b/chaco/shell/tests/test_tutorial_example.py
@@ -3,10 +3,11 @@
 source: docs/source/user_manual/chaco_tutorial.rst
 
 """
+import unittest
+
 from numpy import linspace, pi, sin
 
 from traits.etsconfig.api import ETSConfig
-from traits.testing.unittest_tools import unittest
 from chaco.shell import plot, title, ytitle
 
 

--- a/chaco/tests/test_array_plot_data.py
+++ b/chaco/tests/test_array_plot_data.py
@@ -1,5 +1,5 @@
 import contextlib
-from traits.testing.unittest_tools import unittest
+import unittest
 
 import numpy
 


### PR DESCRIPTION
Import `unittest` from the standard library instead of importing it from `traits`.