### PR TITLE
Remove erroneous comment about label_rotation of LabelAxis.

### DIFF
--- a/chaco/label_axis.py
+++ b/chaco/label_axis.py
@@ -19,7 +19,7 @@ class LabelAxis(PlotAxis):
     #: List of labels to use on tick marks.
     labels = List(Str)
 
-    #: The angle of rotation of the label. Only multiples of 90 are supported.
+    #: The angle of rotation of the label.
     label_rotation = Float(0)
 
     #: List of indices of ticks


### PR DESCRIPTION
It is possible to specify a rotation angle for the labels of a `LabelAxis` to be any value: they don't have to be multiples of 90 and the comment is wrong. 

For example, this is what I am getting with 30:
![Screen Shot 2019-06-06 at 5 14 00 PM](https://user-images.githubusercontent.com/593945/59070095-0786a700-887f-11e9-91ab-8254080b0460.png)
