### PR TITLE
Refactor DataPrinter to add _build_text_from_event method

### DIFF
--- a/chaco/tools/dataprinter.py
+++ b/chaco/tools/dataprinter.py
@@ -16,7 +16,7 @@ class DataPrinter(BaseTool):
     point under the cursor.
     """
 
-    #: This tool is a listener, and does not display anything (overrides BaseTool).
+    #: This tool is a listener and does not display anything
     visible = False
 
     #: Turn off drawing, because the tool prints to stdout.
@@ -33,14 +33,18 @@ class DataPrinter(BaseTool):
         plot = self.component
         if plot is not None:
             if isinstance(plot, BaseXYPlot):
-                ndx = plot.map_index((event.x, event.y), index_only = True)
-                x = plot.index.get_data()[ndx]
-                y = plot.value.get_data()[ndx]
-                print(self.format % (x,y))
+                text = self._build_text_from_event(event)
+                print(text)
             else:
-                print("dataprinter: don't know how to handle plots of type {}".format(
-                    plot.__class__.__name__))
+                msg = "dataprinter: don't know how to handle plots of type {}"
+                print(msg.format(plot.__class__.__name__))
         return
 
-
-# EOF
+    def _build_text_from_event(self, event):
+        """ Build the text to display from the mouse event.
+        """
+        plot = self.component
+        ndx = plot.map_index((event.x, event.y), index_only=True)
+        x = plot.index.get_data()[ndx]
+        y = plot.value.get_data()[ndx]
+        return self.format % (x, y)


### PR DESCRIPTION
Goal is to mirror what was done in `ImageInspectorOverlay` in #431 for consistency and educational purposes.

(Few more tweaks to make the file pep8 compliant.)