### PR TITLE
Fix two uses of the deprecated Logger.warn method.

### DIFF
--- a/chaco/barplot.py
+++ b/chaco/barplot.py
@@ -230,8 +230,9 @@ class BarPlot(AbstractPlotRenderer):
             return
 
         if len(index) == 0 or len(value) == 0 or len(index) != len(value):
-            logger.warn("Chaco: using empty dataset; index_len=%d, value_len=%d." \
-                                % (len(index), len(value)))
+            logger.warning(
+                "Chaco: using empty dataset; index_len=%d, value_len=%d."
+                % (len(index), len(value)))
             self._cached_data_pts = array([])
             self._cache_valid = True
             return

--- a/chaco/errorbar_plot.py
+++ b/chaco/errorbar_plot.py
@@ -79,8 +79,7 @@ class ErrorBarPlot(LinePlot):
             logger.warning(
                 "Chaco: using empty dataset; index_len=%d, "
                 "value_low_len=%d, value_high_len=%d."
-                % (l1,l2,l3)
-            )
+                % (l1,l2,l3))
             self._cached_data_pts = []
             self._cache_valid = True
             return

--- a/chaco/errorbar_plot.py
+++ b/chaco/errorbar_plot.py
@@ -76,7 +76,11 @@ class ErrorBarPlot(LinePlot):
 
         l1, l2, l3 = sm.map(len, (index, value_low, value_high))
         if 0 in (l1, l2, l3) or not (l1 == l2 == l3):
-            logger.warn("Chaco: using empty dataset; index_len=%d, value_low_len=%d, value_high_len=%d." % (l1,l2,l3))
+            logger.warning(
+                "Chaco: using empty dataset; index_len=%d, "
+                "value_low_len=%d, value_high_len=%d."
+                % (l1,l2,l3)
+            )
             self._cached_data_pts = []
             self._cache_valid = True
             return


### PR DESCRIPTION
This is a drive-by fix for `DeprecationWarning` messages seen in the output of the test suite of a Chaco-using project.