### PR TITLE
Declare build dependencies.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,4 @@ include CHANGES.txt
 include LICENSE.txt
 include image_LICENSE.txt
 include dev_requirements.txt
+include pyproject.toml

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -130,7 +130,10 @@ def install(runtime, toolkit, environment):
         # Note that enable dependencies will be installed implicitly using pip
         ("edm run -e {environment} -- "
          "pip install git+https://git@github.com/enthought/enable.git"),
-        "edm run -e {environment} -- pip install . --no-deps",
+        # Use --no-build-isolation to avoid trying to build using a different
+        # NumPy version from the one currently installed.
+        ("edm run -e {environment} -- "
+         "pip install . --no-build-isolation --no-dependencies"),
     ]
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["Cython", "numpy", "setuptools", "wheel"]


### PR DESCRIPTION
This PR declares NumPy and Cython as build dependencies; without this, a `pip install` into an environment that lacks NumPy and/or Cython will fail.