### PR TITLE
FIX: Circular imports in toolbar_plot and transform_color_mapper

### DIFF
--- a/chaco/function_image_data.py
+++ b/chaco/function_image_data.py
@@ -1,6 +1,7 @@
 from numpy import array
 from traits.api import Instance, Callable, on_trait_change
-from chaco.api import DataRange2D, ImageData
+from .data_range_2d import DataRange2D
+from .image_data import ImageData
 
 # Adapted (ie. copied and modified) from function_data_source.
 

--- a/chaco/layers/status_layer.py
+++ b/chaco/layers/status_layer.py
@@ -4,7 +4,7 @@ from __future__ import with_statement
 import os.path
 import xml.etree.cElementTree as etree
 
-from chaco.api import AbstractOverlay
+from chaco.abstract_overlay import AbstractOverlay
 from pyface.timer.timer import Timer
 from traits.api import Instance, Str, Enum, Float, Int
 from enable.savage.svg.document import SVGDocument

--- a/chaco/layers/svg_range_selection_overlay.py
+++ b/chaco/layers/svg_range_selection_overlay.py
@@ -4,7 +4,7 @@ from __future__ import with_statement
 import os
 import numpy
 
-from chaco.api import GridMapper
+from chaco.grid_mapper import GridMapper
 from traits.api import Property, Enum, Str, cached_property
 
 from .status_layer import StatusLayer

--- a/chaco/overlays/container_overlay.py
+++ b/chaco/overlays/container_overlay.py
@@ -7,7 +7,7 @@ components in plot overlays.
 
 from traits.api import Instance
 from enable.api import Container, Component
-from chaco.api import PlotComponent
+from chaco.plot_component import PlotComponent
 
 
 class ContainerOverlay(Container, PlotComponent):

--- a/chaco/overlays/coordinate_line_overlay.py
+++ b/chaco/overlays/coordinate_line_overlay.py
@@ -8,7 +8,7 @@ from __future__ import with_statement
 
 from traits.api import Instance, Float, Array
 from enable.api import black_color_trait, LineStyle, Component
-from chaco.api import AbstractOverlay
+from chaco.abstract_overlay import AbstractOverlay
 
 
 class CoordinateLineOverlay(AbstractOverlay):

--- a/chaco/overlays/databox.py
+++ b/chaco/overlays/databox.py
@@ -4,7 +4,7 @@ from __future__ import with_statement
 from traits.api import (Bool, Enum, Float, Int, CList, Property, Trait,
         on_trait_change)
 from enable.api import ColorTrait
-from chaco.api import AbstractOverlay
+from chaco.abstract_overlay import AbstractOverlay
 
 
 class DataBox(AbstractOverlay):

--- a/chaco/selectable_legend.py
+++ b/chaco/selectable_legend.py
@@ -1,5 +1,5 @@
 
-from chaco.tools.api import SelectTool
+from chaco.tools.select_tool import SelectTool
 from traits.api import List
 
 from .legend import Legend

--- a/chaco/shell/commands.py
+++ b/chaco/shell/commands.py
@@ -11,8 +11,7 @@ try:
 except ImportError:
     GetApp = lambda: None
 
-from chaco.api import Plot, color_map_name_dict
-from chaco.scales.api import ScaleSystem
+from chaco.plot import Plot
 from chaco.tools.api import PanTool, ZoomTool
 
 # Note: these are imported to be exposed in the namespace.
@@ -797,7 +796,7 @@ def save(filename="chacoplot.png", dpi=72, pagesize="letter", dest_box=None, uni
         print("Saved to", filename)
 
     elif ext in [".bmp", ".png", ".jpg"]:
-        from chaco.api import PlotGraphicsContext
+        from chaco.plot_graphics_context import PlotGraphicsContext
         gc = PlotGraphicsContext(tuple(p.outer_bounds), dpi=dpi)
 
         # temporarily turn off the backbuffer for offscreen rendering

--- a/chaco/shell/commands.py
+++ b/chaco/shell/commands.py
@@ -12,10 +12,11 @@ except ImportError:
     GetApp = lambda: None
 
 from chaco.plot import Plot
-from chaco.tools.api import PanTool, ZoomTool
+from chaco.tools.pan_tool import PanTool
+from chaco.tools.zoom_tool import ZoomTool
 
 # Note: these are imported to be exposed in the namespace.
-from chaco.scales.api import (FixedScale, Pow10Scale, LogScale,
+from chaco.scales.scales import (FixedScale, Pow10Scale, LogScale,
     CalendarScaleSystem)
 from chaco.default_colormaps import *
 

--- a/chaco/shell/commands.py
+++ b/chaco/shell/commands.py
@@ -16,8 +16,8 @@ from chaco.tools.pan_tool import PanTool
 from chaco.tools.zoom_tool import ZoomTool
 
 # Note: these are imported to be exposed in the namespace.
-from chaco.scales.scales import (FixedScale, Pow10Scale, LogScale,
-    CalendarScaleSystem)
+from chaco.scales.scales import (FixedScale, Pow10Scale, LogScale)
+from chaco.scales.time_scale import CalendarScaleSystem
 from chaco.default_colormaps import *
 
 from . import plot_maker

--- a/chaco/shell/plot_maker.py
+++ b/chaco/shell/plot_maker.py
@@ -13,8 +13,9 @@ import six
 from numpy import all, array, arange, asarray, reshape, shape, transpose
 
 # Chaco imports
-from chaco.api import (create_line_plot, create_scatter_plot,
-    ArrayDataSource, ImageData)
+from chaco.plot_factory import (create_line_plot, create_scatter_plot)
+from chaco.array_data_source import ArrayDataSource
+from chaco.image_data import ImageData
 
 from chaco.tools.api import HighlightTool
 

--- a/chaco/shell/plot_maker.py
+++ b/chaco/shell/plot_maker.py
@@ -17,7 +17,7 @@ from chaco.plot_factory import (create_line_plot, create_scatter_plot)
 from chaco.array_data_source import ArrayDataSource
 from chaco.image_data import ImageData
 
-from chaco.tools.api import HighlightTool
+from chaco.tools.highlight_tool import HighlightTool
 
 
 

--- a/chaco/shell/scaly_plot.py
+++ b/chaco/shell/scaly_plot.py
@@ -3,10 +3,14 @@
 
 from traits.api import Any
 
-from chaco.api import (DataRange2D, LinearMapper, LogMapper,
-    PlotGrid, Plot, PlotAxis)
-from chaco.scales_tick_generator import ScalesTickGenerator
+from chaco.axis import PlotAxis
+from chaco.data_range_2d import DataRange2D
+from chaco.grid import PlotGrid
+from chaco.linear_mapper import LinearMapper
+from chaco.log_mapper import LogMapper
+from chaco.plot import Plot
 from chaco.scales.api import DefaultScale, LogScale, ScaleSystem
+from chaco.scales_tick_generator import ScalesTickGenerator
 
 
 def add_default_axes(plot, orientation="normal", vtitle="", htitle=""):

--- a/chaco/shell/scaly_plot.py
+++ b/chaco/shell/scaly_plot.py
@@ -9,7 +9,7 @@ from chaco.grid import PlotGrid
 from chaco.linear_mapper import LinearMapper
 from chaco.log_mapper import LogMapper
 from chaco.plot import Plot
-from chaco.scales.api import DefaultScale, LogScale, ScaleSystem
+from chaco.scales.scales import DefaultScale, LogScale, ScaleSystem
 from chaco.scales_tick_generator import ScalesTickGenerator
 
 

--- a/chaco/tests/test_default_colormaps.py
+++ b/chaco/tests/test_default_colormaps.py
@@ -15,7 +15,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from chaco.api import DataRange1D
-from .. import default_colormaps
+from chaco import default_colormaps
 
 
 class DefaultColormapsTestCase(unittest.TestCase):

--- a/chaco/toolbar_plot.py
+++ b/chaco/toolbar_plot.py
@@ -1,4 +1,4 @@
-from chaco.api import Plot
+from chaco.plot import Plot
 from chaco.tools.toolbars.plot_toolbar import PlotToolbar
 from traits.api import Type, DelegatesTo, Instance, Enum, \
         on_trait_change

--- a/chaco/tools/dataprinter.py
+++ b/chaco/tools/dataprinter.py
@@ -8,7 +8,7 @@ from traits.api import Str
 from enable.api import BaseTool
 
 # Chaco imports
-from chaco.api import BaseXYPlot
+from chaco.base_xy_plot import BaseXYPlot
 
 
 class DataPrinter(BaseTool):

--- a/chaco/tools/draw_points_tool.py
+++ b/chaco/tools/draw_points_tool.py
@@ -8,7 +8,7 @@ from traits.api import Instance, Bool
 from enable.api import BaseTool
 
 # Chaco import
-from chaco.api import ArrayDataSource
+from chaco.array_data_source import ArrayDataSource
 
 
 class DrawPointsTool(BaseTool):

--- a/chaco/tools/highlight_tool.py
+++ b/chaco/tools/highlight_tool.py
@@ -8,7 +8,7 @@ from traits.api import Enum, Float, Str
 from enable.api import BaseTool
 
 # Chaco imports
-from chaco.api import BasePlotContainer
+from chaco.base_plot_container import BasePlotContainer
 
 
 class HighlightTool(BaseTool):

--- a/chaco/tools/image_inspector_tool.py
+++ b/chaco/tools/image_inspector_tool.py
@@ -6,7 +6,9 @@ from enable.api import BaseTool, KeySpec
 from traits.api import Any, Bool, Enum, Event, Tuple
 
 # Chaco imports
-from chaco.api import AbstractOverlay, ImagePlot, TextBoxOverlay
+from chaco.abstract_overlay import AbstractOverlay
+from chaco.image_plot import ImagePlot
+from chaco.text_box_overlay import TextBoxOverlay
 
 
 class ImageInspectorTool(BaseTool):

--- a/chaco/tools/lasso_selection.py
+++ b/chaco/tools/lasso_selection.py
@@ -10,8 +10,10 @@ from traits.api import Any, Array, Enum, Event, Bool, Instance, \
 from kiva.api import points_in_polygon
 
 # Chaco imports
-from chaco.api import AbstractController, AbstractDataSource, \
-        BaseXYPlot, Base2DPlot
+from chaco.abstract_controller import AbstractController
+from chaco.abstract_data_source import AbstractDataSource
+from chaco.base_xy_plot import BaseXYPlot
+from chaco.base_2d_plot import Base2DPlot
 
 
 class LassoSelection(AbstractController):

--- a/chaco/tools/legend_highlighter.py
+++ b/chaco/tools/legend_highlighter.py
@@ -1,7 +1,7 @@
 from itertools import chain
 
 # ETS imports
-from chaco.tools.api import LegendTool
+from .legend_tool import LegendTool
 from traits.api import List, Float
 
 concat = chain.from_iterable

--- a/chaco/tools/line_inspector.py
+++ b/chaco/tools/line_inspector.py
@@ -7,7 +7,8 @@ from enable.api import BaseTool, ColorTrait, LineStyle
 from traits.api import Any, Bool, Enum, Float, Str, Trait
 
 # Chaco imports
-from chaco.api import BaseXYPlot, Base2DPlot
+from chaco.base_xy_plot import BaseXYPlot
+from chaco.base_2d_plot import Base2DPlot
 
 
 class LineInspector(BaseTool):

--- a/chaco/tools/line_segment_tool.py
+++ b/chaco/tools/line_segment_tool.py
@@ -10,7 +10,7 @@ from enable.api import Component, Pointer, Line
 from traits.api import Any, Bool, Enum, Instance, Int, List, Trait, Tuple
 
 # Chaco imports
-from chaco.api import AbstractOverlay
+from chaco.abstract_overlay import AbstractOverlay
 
 
 

--- a/chaco/tools/range_selection.py
+++ b/chaco/tools/range_selection.py
@@ -9,7 +9,7 @@ from traits.api import Any, Array, ArrayOrNone, Bool, Enum, Event, Float, \
 from enable.api import KeySpec
 
 # Chaco imports
-from chaco.api import AbstractController
+from chaco.abstract_controller import AbstractController
 
 
 class RangeSelection(AbstractController):

--- a/chaco/tools/range_selection_overlay.py
+++ b/chaco/tools/range_selection_overlay.py
@@ -9,7 +9,10 @@ from numpy import arange, array
 from enable.api import ColorTrait, LineStyle
 from traits.api import Enum, Float, Property, Str, Instance, \
         cached_property
-from chaco.api import AbstractOverlay, arg_find_runs, GridMapper, AbstractMapper
+from chaco.abstract_overlay import AbstractOverlay
+from chaco.base import arg_find_runs
+from chaco.grid_mapper import GridMapper
+from chaco.abstract_mapper import AbstractMapper
 
 
 class RangeSelectionOverlay(AbstractOverlay):

--- a/chaco/tools/regression_lasso.py
+++ b/chaco/tools/regression_lasso.py
@@ -11,8 +11,9 @@ from enable.api import ColorTrait, LineStyle
 from traits.api import Any, Float, Instance
 
 # Chaco imports
-from chaco.api import LassoOverlay, Label
-from chaco.tools.api import LassoSelection
+from chaco.lasso_overlay import LassoOverlay
+from chaco.label import Label
+from .lasso_selection import LassoSelection
 
 
 class RegressionLasso(LassoSelection):

--- a/chaco/tools/save_tool.py
+++ b/chaco/tools/save_tool.py
@@ -56,7 +56,7 @@ class SaveTool(BaseTool):
     def _save_raster(self):
         """ Saves an image of the component.
         """
-        from chaco.api import PlotGraphicsContext
+        from chaco.plot_graphics_context import PlotGraphicsContext
         gc = PlotGraphicsContext((int(self.component.outer_width), int(self.component.outer_height)))
         self.component.draw(gc, mode="normal")
         gc.save(self.filename)

--- a/chaco/tools/tracking_pan_tool.py
+++ b/chaco/tools/tracking_pan_tool.py
@@ -1,7 +1,7 @@
 """ Defines the TrackingPanTool class.
 """
 # Chaco imports
-from chaco.tools.api import PanTool
+from .pan_tool import PanTool
 
 class TrackingPanTool(PanTool):
     """ Allows the user to pan around a plot.

--- a/chaco/tools/traits_tool.py
+++ b/chaco/tools/traits_tool.py
@@ -6,7 +6,8 @@ from enable.api import BaseTool, Container
 from traits.api import List, Dict, Str
 
 # Chaco imports
-from chaco.api import PlotAxis, ColorBar
+from chaco.axis import PlotAxis
+from chaco.color_bar import ColorBar
 
 
 class Fifo(object):

--- a/chaco/transform_color_mapper.py
+++ b/chaco/transform_color_mapper.py
@@ -1,6 +1,6 @@
 from numpy import clip, isinf, ones_like, empty
 
-from chaco.api import ColorMapper
+from chaco.color_mapper import ColorMapper
 from traits.api import Trait, Callable, Tuple, Float, on_trait_change
 
 from .speedups import map_colors, map_colors_uint8

--- a/chaco/ui/popupable_plot.py
+++ b/chaco/ui/popupable_plot.py
@@ -1,7 +1,7 @@
 # Enthought library imports
 from traits.api import List
-from chaco.api import VPlotContainer
 from chaco.plot import Plot
+from chaco.plot_containers import VPlotContainer
 from chaco.tools.api import PanTool, ZoomTool
 from chaco.ui.plot_window import PlotWindow
 

--- a/chaco/ui/popupable_plot.py
+++ b/chaco/ui/popupable_plot.py
@@ -2,7 +2,8 @@
 from traits.api import List
 from chaco.plot import Plot
 from chaco.plot_containers import VPlotContainer
-from chaco.tools.api import PanTool, ZoomTool
+from chaco.tools.pan_tool import PanTool
+from chaco.tools.zoom_tool import ZoomTool
 from chaco.ui.plot_window import PlotWindow
 
 from traitsui.wx.constants import WindowColor


### PR DESCRIPTION
Import directly from the module where each class is implemented instead of importing from `chaco.api`.