### PR TITLE
Fix a test that fails with NumPy 1.16.x.

### DIFF
--- a/chaco/tools/tests/test_range_selection.py
+++ b/chaco/tools/tests/test_range_selection.py
@@ -61,9 +61,10 @@ class RangeSelectionTestCase(EnableTestAssistant, unittest.TestCase):
         renderer = plot.plot(('x', 'y'))[0]
         tool = RangeSelection(renderer)
         with warnings.catch_warnings(record=True) as w:
-            # Ignore warnings coming from Traits
+            # Ignore warnings coming from any package other than Chaco
             warnings.filterwarnings(
-                "ignore", 'elementwise == comparison failed'
+                "ignore",
+                module="(?!chaco)",
             )
             tool.selection = np.array([2.0, 3.0])
 


### PR DESCRIPTION
`test_selection_no_warning` is checking that Chaco itself doesn't raise any warnings on selection assignment. Previously, we were filtering out a known NumPy warning; that filter doesn't work with NumPy 1.16.x because the warning message changed.

This PR updates the filter to filter out all warning messages from packages other than Chaco.

Fixes #468.


