### PR TITLE
Fix attempts to get the .shape attribute of a list or tuple.

### DIFF
--- a/chaco/horizon_plot.py
+++ b/chaco/horizon_plot.py
@@ -1,6 +1,6 @@
 from __future__ import with_statement
 
-from numpy import array, transpose, ndarray, empty
+from numpy import array, float64, full_like, ndarray, transpose
 from traits.api import Instance, DelegatesTo, Bool, Int
 
 from enable.api import transparent_color_trait
@@ -16,9 +16,7 @@ class BandedMapper(LinearMapper):
 
         if self._null_data_range:
             if isinstance(data_array, (tuple, list, ndarray)):
-                x = empty(data_array.shape)
-                x.fill(self.low_pos)
-                return x
+                return full_like(data_array, self.low_pos, dtype=float64)
             else:
                 return array([self.low_pos])
         else:
@@ -82,7 +80,7 @@ class HorizonPlot(BaseXYPlot):
         # Get color bands
         bands = array(self.color_mapper._get_color_bands())
 
-        with gc: 
+        with gc:
             gc.clip_to_rect(self.x, self.y, self.width, self.height)
             # draw positive bands
             inc = -1 * array([0, y_plus_height])
@@ -93,10 +91,10 @@ class HorizonPlot(BaseXYPlot):
 
             # draw negative bands
             if self.negative_bands:
-                if self.mirror: 
+                if self.mirror:
                     points[:,1] = oy - points[:,1]
                     zeroy = oy
-                else: 
+                else:
                     points[:,1] += y_plus_height
                     inc *= -1
                     zeroy = int(yhigh) + 2
@@ -114,14 +112,14 @@ class HorizonPlot(BaseXYPlot):
         gc.set_fill_color(tuple(face_col))
         gc.begin_path()
         startx, starty = points[0]
-        gc.move_to(startx, oy) 
+        gc.move_to(startx, oy)
         gc.line_to(startx, starty)
 
         gc.lines(points)
 
         endx, endy = points[-1]
-        gc.line_to(endx, oy) 
-        gc.line_to(startx, oy) 
+        gc.line_to(endx, oy)
+        gc.line_to(startx, oy)
 
         gc.close_path()
         gc.fill_path()

--- a/chaco/linear_mapper.py
+++ b/chaco/linear_mapper.py
@@ -4,7 +4,7 @@ into a 1-D output space.
 """
 
 # Major library imports
-from numpy import array, empty, ndarray
+from numpy import array, float64, full_like, ndarray
 
 # Enthought library imports
 from traits.api import Bool, Float
@@ -45,9 +45,7 @@ class LinearMapper(Base1DMapper):
         self._compute_scale()
         if self._null_data_range:
             if isinstance(data_array, (tuple, list, ndarray)):
-                x = empty(data_array.shape)
-                x.fill(self.low_pos)
-                return x
+                return full_like(data_array, self.low_pos, dtype=float64)
             else:
                 return array([self.low_pos])
         else:

--- a/chaco/tests/test_linearmapper.py
+++ b/chaco/tests/test_linearmapper.py
@@ -1,6 +1,6 @@
 
 import unittest
-from numpy import array
+from numpy import array, ndarray
 from numpy.testing import assert_array_almost_equal, assert_equal
 
 
@@ -289,3 +289,27 @@ class LinearMapperTestCase(unittest.TestCase):
         mapper.high_pos = 100.0
         result = mapper.map_screen(ary)
         assert_array_almost_equal(result, array([50, 60, 70, 80, 90, 100]))
+
+    def test_map_screen_with_null_data_range(self):
+        r = DataRange1D()
+        mapper = LinearMapper(range=r)
+        low_pos = mapper.low_pos
+
+        data = array([5.6])
+        result = mapper.map_screen(data)
+        self.assertIsInstance(result, ndarray)
+        self.assertEqual(result.shape, (1,))
+        assert_array_almost_equal(result, array([low_pos]))
+
+        # Test support for lists and tuples
+        data = [5.6]
+        result = mapper.map_screen(data)
+        self.assertIsInstance(result, ndarray)
+        self.assertEqual(result.shape, (1,))
+        assert_array_almost_equal(result, array([low_pos]))
+
+        data = (5.6,)
+        result = mapper.map_screen(data)
+        self.assertIsInstance(result, ndarray)
+        self.assertEqual(result.shape, (1,))
+        assert_array_almost_equal(result, array([low_pos]))


### PR DESCRIPTION
This PR fixes an obvious bug in the `LinearMapper` code, where we attempt to look up the `shape` attribute of a list or a tuple.

Code ref: https://github.com/enthought/chaco/blob/e0e4f7d8bc5551191ad65295fe97f55190e87a9c/chaco/linear_mapper.py#L47-L50