### PR TITLE
Add missing property index_range to 1D plots

### DIFF
--- a/chaco/base_1d_plot.py
+++ b/chaco/base_1d_plot.py
@@ -32,6 +32,9 @@ class Base1DPlot(AbstractPlotRenderer):
     #: Screen mapper for index data.
     index_mapper = Instance(AbstractMapper)
 
+    #: Convenience property for accessing the data range of the mapper.
+    index_range = Property
+
     #: Corresponds to either **index_mapper** or None, depending on
     #: the orientation of the plot.
     x_mapper = Property(depends_on=['orientation', 'index_mapper'])
@@ -268,6 +271,12 @@ class Base1DPlot(AbstractPlotRenderer):
     #------------------------------------------------------------------------
     # Property setters and getters
     #------------------------------------------------------------------------
+
+    def _get_index_range(self):
+        return self.index_mapper.range
+
+    def _set_index_range(self, val):
+        self.index_mapper.range = val
 
     @cached_property
     def _get_x_mapper(self):

--- a/chaco/base_1d_plot.py
+++ b/chaco/base_1d_plot.py
@@ -33,7 +33,7 @@ class Base1DPlot(AbstractPlotRenderer):
     index_mapper = Instance(AbstractMapper)
 
     #: Convenience property for accessing the data range of the mapper.
-    index_range = Property
+    index_range = Property(depends_on="index_mapper.range")
 
     #: Corresponds to either **index_mapper** or None, depending on
     #: the orientation of the plot.

--- a/chaco/tests/test_line_scatterplot.py
+++ b/chaco/tests/test_line_scatterplot.py
@@ -29,6 +29,8 @@ class LineScatterPlot1DTest(unittest.TestCase):
         self.assertIsNone(self.scatterplot.x_mapper)
         self.assertEqual(self.scatterplot.y_mapper,
                          self.scatterplot.index_mapper)
+        self.assertIs(self.scatterplot.index_range,
+                      self.scatterplot.index_mapper.range)
 
         gc = PlotGraphicsContext(self.size)
         gc.render_component(self.scatterplot)

--- a/chaco/tests/test_line_scatterplot.py
+++ b/chaco/tests/test_line_scatterplot.py
@@ -155,3 +155,26 @@ class LineScatterPlot1DTest(unittest.TestCase):
         gc.render_component(self.scatterplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
+
+    def test_scatter_1d_set_index_range(self):
+        new_range = DataRange1D(low=0.42, high=1.42)
+        self.scatterplot.index_range = new_range
+        self.assertEqual(self.scatterplot.index_mapper.range, new_range)
+
+    def test_scatter_1d_set_index_mapper_notifies_index_range(self):
+        new_range = DataRange1D(low=0.42, high=1.42)
+
+        # Given
+        self.notification_has_fired = False
+
+        def _listener():
+            self.notification_has_fired = True
+
+        self.scatterplot.on_trait_change(_listener, "index_range")
+
+        # When
+        self.scatterplot.index_mapper = LinearMapper(range=new_range)
+
+        # Then
+        self.assertTrue(self.notification_has_fired)
+        self.assertIs(self.scatterplot.index_range, new_range)

--- a/chaco/tests/test_line_scatterplot.py
+++ b/chaco/tests/test_line_scatterplot.py
@@ -3,13 +3,15 @@ import unittest
 from numpy import alltrue, arange, array
 from numpy.testing import assert_almost_equal
 
+from traits.testing.unittest_tools import UnittestTools
+
 # Chaco imports
 from chaco.api import (ArrayDataSource, DataRange1D, LinearMapper,
                        PlotGraphicsContext)
 from chaco.line_scatterplot_1d import LineScatterPlot1D
 
 
-class LineScatterPlot1DTest(unittest.TestCase):
+class LineScatterPlot1DTest(UnittestTools, unittest.TestCase):
 
     def setUp(self):
         self.size = (250, 250)
@@ -164,17 +166,8 @@ class LineScatterPlot1DTest(unittest.TestCase):
     def test_linescatter_1d_set_index_mapper_notifies_index_range(self):
         new_range = DataRange1D(low=0.42, high=1.42)
 
-        # Given
-        self.notification_has_fired = False
+        with self.assertTraitChanges(
+                self.linescatterplot, "index_range", count=1):
+            self.linescatterplot.index_mapper = LinearMapper(range=new_range)
 
-        def _listener():
-            self.notification_has_fired = True
-
-        self.linescatterplot.on_trait_change(_listener, "index_range")
-
-        # When
-        self.linescatterplot.index_mapper = LinearMapper(range=new_range)
-
-        # Then
-        self.assertTrue(self.notification_has_fired)
         self.assertIs(self.linescatterplot.index_range, new_range)

--- a/chaco/tests/test_line_scatterplot.py
+++ b/chaco/tests/test_line_scatterplot.py
@@ -17,151 +17,151 @@ class LineScatterPlot1DTest(unittest.TestCase):
         index_range = DataRange1D()
         index_range.add(data_source)
         index_mapper = LinearMapper(range=index_range)
-        self.scatterplot = LineScatterPlot1D(
+        self.linescatterplot = LineScatterPlot1D(
             index=data_source,
             index_mapper=index_mapper,
             border_visible=False,
         )
-        self.scatterplot.outer_bounds = list(self.size)
+        self.linescatterplot.outer_bounds = list(self.size)
 
-    def test_scatter_1d(self):
-        self.assertEqual(self.scatterplot.origin, 'bottom left')
-        self.assertIsNone(self.scatterplot.x_mapper)
-        self.assertEqual(self.scatterplot.y_mapper,
-                         self.scatterplot.index_mapper)
-        self.assertIs(self.scatterplot.index_range,
-                      self.scatterplot.index_mapper.range)
+    def test_linescatter_1d(self):
+        self.assertEqual(self.linescatterplot.origin, 'bottom left')
+        self.assertIsNone(self.linescatterplot.x_mapper)
+        self.assertEqual(self.linescatterplot.y_mapper,
+                         self.linescatterplot.index_mapper)
+        self.assertIs(self.linescatterplot.index_range,
+                      self.linescatterplot.index_mapper.range)
 
         gc = PlotGraphicsContext(self.size)
-        gc.render_component(self.scatterplot)
+        gc.render_component(self.linescatterplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    def test_scatter_1d_horizontal(self):
-        self.scatterplot.orientation = 'h'
+    def test_linescatter_1d_horizontal(self):
+        self.linescatterplot.orientation = 'h'
 
-        self.assertEqual(self.scatterplot.origin, 'bottom left')
-        self.assertEqual(self.scatterplot.x_mapper,
-                         self.scatterplot.index_mapper)
-        self.assertIsNone(self.scatterplot.y_mapper)
+        self.assertEqual(self.linescatterplot.origin, 'bottom left')
+        self.assertEqual(self.linescatterplot.x_mapper,
+                         self.linescatterplot.index_mapper)
+        self.assertIsNone(self.linescatterplot.y_mapper)
 
         gc = PlotGraphicsContext(self.size)
-        gc.render_component(self.scatterplot)
+        gc.render_component(self.linescatterplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    def test_scatter_1d_flipped(self):
-        self.scatterplot.direction = 'flipped'
+    def test_linescatter_1d_flipped(self):
+        self.linescatterplot.direction = 'flipped'
 
-        self.assertEqual(self.scatterplot.origin, 'top left')
-        self.assertIsNone(self.scatterplot.x_mapper)
-        self.assertEqual(self.scatterplot.y_mapper,
-                         self.scatterplot.index_mapper)
+        self.assertEqual(self.linescatterplot.origin, 'top left')
+        self.assertIsNone(self.linescatterplot.x_mapper)
+        self.assertEqual(self.linescatterplot.y_mapper,
+                         self.linescatterplot.index_mapper)
 
         gc = PlotGraphicsContext(self.size)
-        gc.render_component(self.scatterplot)
+        gc.render_component(self.linescatterplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    def test_scatter_1d_horizontal_flipped(self):
-        self.scatterplot.direction = 'flipped'
-        self.scatterplot.orientation = 'h'
+    def test_linescatter_1d_horizontal_flipped(self):
+        self.linescatterplot.direction = 'flipped'
+        self.linescatterplot.orientation = 'h'
 
-        self.assertEqual(self.scatterplot.origin, 'bottom right')
-        self.assertEqual(self.scatterplot.x_mapper,
-                         self.scatterplot.index_mapper)
-        self.assertIsNone(self.scatterplot.y_mapper)
+        self.assertEqual(self.linescatterplot.origin, 'bottom right')
+        self.assertEqual(self.linescatterplot.x_mapper,
+                         self.linescatterplot.index_mapper)
+        self.assertIsNone(self.linescatterplot.y_mapper)
 
         gc = PlotGraphicsContext(self.size)
-        gc.render_component(self.scatterplot)
+        gc.render_component(self.linescatterplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    def test_scatter_1d_thicker(self):
-        self.scatterplot.line_width = 2.0
+    def test_linescatter_1d_thicker(self):
+        self.linescatterplot.line_width = 2.0
         gc = PlotGraphicsContext(self.size)
-        gc.render_component(self.scatterplot)
+        gc.render_component(self.linescatterplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    def test_scatter_1d_color(self):
-        self.scatterplot.color = 'orange'
+    def test_linescatter_1d_color(self):
+        self.linescatterplot.color = 'orange'
         gc = PlotGraphicsContext(self.size)
-        gc.render_component(self.scatterplot)
+        gc.render_component(self.linescatterplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    def test_scatter_1d_line_style(self):
-        self.scatterplot.line_style = 'dash'
+    def test_linescatter_1d_line_style(self):
+        self.linescatterplot.line_style = 'dash'
         gc = PlotGraphicsContext(self.size)
-        gc.render_component(self.scatterplot)
+        gc.render_component(self.linescatterplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    def test_scatter_1d_map_data(self):
+    def test_linescatter_1d_map_data(self):
         points = array([[0, 124.5], [124.5, 0]])
-        assert_almost_equal(self.scatterplot.map_data(points),
+        assert_almost_equal(self.linescatterplot.map_data(points),
                             array([4.5, 0]))
 
-    def test_scatter_1d_map_data_horizontal(self):
-        self.scatterplot.orientation = 'h'
+    def test_linescatter_1d_map_data_horizontal(self):
+        self.linescatterplot.orientation = 'h'
         points = array([[0, 124.5], [124.5, 0]])
-        assert_almost_equal(self.scatterplot.map_data(points),
+        assert_almost_equal(self.linescatterplot.map_data(points),
                             array([0, 4.5]))
 
-    def test_scatter_1d_map_data_flipped(self):
-        self.scatterplot.direction = 'flipped'
+    def test_linescatter_1d_map_data_flipped(self):
+        self.linescatterplot.direction = 'flipped'
         points = array([[0, 124.5], [124.5, 0]])
-        assert_almost_equal(self.scatterplot.map_data(points),
+        assert_almost_equal(self.linescatterplot.map_data(points),
                             array([4.5, 9.0]))
 
-    def test_scatter_1d_map_data_horizontal_flipped(self):
-        self.scatterplot.direction = 'flipped'
-        self.scatterplot.orientation = 'h'
+    def test_linescatter_1d_map_data_horizontal_flipped(self):
+        self.linescatterplot.direction = 'flipped'
+        self.linescatterplot.orientation = 'h'
         points = array([[0, 124.5], [124.5, 0]])
-        assert_almost_equal(self.scatterplot.map_data(points),
+        assert_almost_equal(self.linescatterplot.map_data(points),
                             array([9.0, 4.5]))
 
-    def test_scatter_1d_selection(self):
-        self.scatterplot.index.metadata['selections'] = [
+    def test_linescatter_1d_selection(self):
+        self.linescatterplot.index.metadata['selections'] = [
             (arange(10) % 2 == 0),
         ]
 
         gc = PlotGraphicsContext(self.size)
-        gc.render_component(self.scatterplot)
+        gc.render_component(self.linescatterplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    def test_scatter_1d_selection_mask_name(self):
+    def test_linescatter_1d_selection_mask_name(self):
         # select with a mask
-        self.scatterplot.selection_metadata_name = 'highlight_masks'
-        self.scatterplot.index.metadata['highlight_masks'] = [
+        self.linescatterplot.selection_metadata_name = 'highlight_masks'
+        self.linescatterplot.index.metadata['highlight_masks'] = [
             (arange(10) % 2 == 0),
         ]
 
         gc = PlotGraphicsContext(self.size)
-        gc.render_component(self.scatterplot)
+        gc.render_component(self.linescatterplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    def test_scatter_1d_selection_alpha(self):
+    def test_linescatter_1d_selection_alpha(self):
         # test with different alpha
-        self.scatterplot.unselected_alpha = 0.4
-        self.scatterplot.index.metadata['selections'] = [
+        self.linescatterplot.unselected_alpha = 0.4
+        self.linescatterplot.index.metadata['selections'] = [
             (arange(10) % 2 == 0),
         ]
 
         gc = PlotGraphicsContext(self.size)
-        gc.render_component(self.scatterplot)
+        gc.render_component(self.linescatterplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    def test_scatter_1d_set_index_range(self):
+    def test_linescatter_1d_set_index_range(self):
         new_range = DataRange1D(low=0.42, high=1.42)
-        self.scatterplot.index_range = new_range
-        self.assertEqual(self.scatterplot.index_mapper.range, new_range)
+        self.linescatterplot.index_range = new_range
+        self.assertEqual(self.linescatterplot.index_mapper.range, new_range)
 
-    def test_scatter_1d_set_index_mapper_notifies_index_range(self):
+    def test_linescatter_1d_set_index_mapper_notifies_index_range(self):
         new_range = DataRange1D(low=0.42, high=1.42)
 
         # Given
@@ -170,11 +170,11 @@ class LineScatterPlot1DTest(unittest.TestCase):
         def _listener():
             self.notification_has_fired = True
 
-        self.scatterplot.on_trait_change(_listener, "index_range")
+        self.linescatterplot.on_trait_change(_listener, "index_range")
 
         # When
-        self.scatterplot.index_mapper = LinearMapper(range=new_range)
+        self.linescatterplot.index_mapper = LinearMapper(range=new_range)
 
         # Then
         self.assertTrue(self.notification_has_fired)
-        self.assertIs(self.scatterplot.index_range, new_range)
+        self.assertIs(self.linescatterplot.index_range, new_range)

--- a/chaco/tests/test_plot.py
+++ b/chaco/tests/test_plot.py
@@ -22,14 +22,17 @@ class PlotTestCase(unittest.TestCase):
         arr = arange(10)
         data = ArrayPlotData(x=arr, y=arr)
         plot = Plot(data)
-        renderer = plot.plot(('x', 'y'))[0]
+        renderer_2d = plot.plot(('x', 'y'))[0]
+        renderer_1d = plot.plot_1d(('x'))[0]
         new_range = DataRange1D()
         old_range = plot.index_range
         self.assertIsNot(old_range, new_range)
-        self.assertIs(renderer.index_range, old_range)
+        self.assertIs(renderer_2d.index_range, old_range)
+        self.assertIs(renderer_1d.index_range, old_range)
         plot.index_range = new_range
         self.assertIs(plot.index_range, new_range)
-        self.assertIs(renderer.index_range, new_range)
+        self.assertIs(renderer_2d.index_range, new_range)
+        self.assertIs(renderer_1d.index_range, new_range)
 
     def test_segment_plot(self):
         x = arange(10)

--- a/chaco/tests/test_scatterplot_1d.py
+++ b/chaco/tests/test_scatterplot_1d.py
@@ -30,6 +30,8 @@ class Scatterplot1DTest(unittest.TestCase):
         self.assertIsNone(self.scatterplot.x_mapper)
         self.assertEqual(self.scatterplot.y_mapper,
                          self.scatterplot.index_mapper)
+        self.assertIs(self.scatterplot.index_range,
+                      self.scatterplot.index_mapper.range)
 
         gc = PlotGraphicsContext(self.size)
         gc.render_component(self.scatterplot)

--- a/chaco/tests/test_scatterplot_1d.py
+++ b/chaco/tests/test_scatterplot_1d.py
@@ -2,7 +2,9 @@ import unittest
 
 from numpy import alltrue, arange, array
 from numpy.testing import assert_almost_equal
+
 from enable.compiled_path import CompiledPath
+from traits.testing.unittest_tools import UnittestTools
 
 # Chaco imports
 from chaco.api import (ArrayDataSource, DataRange1D, LinearMapper,
@@ -10,7 +12,7 @@ from chaco.api import (ArrayDataSource, DataRange1D, LinearMapper,
 from chaco.scatterplot_1d import ScatterPlot1D
 
 
-class Scatterplot1DTest(unittest.TestCase):
+class Scatterplot1DTest(UnittestTools, unittest.TestCase):
 
     def setUp(self):
         self.size = (250, 250)
@@ -167,17 +169,7 @@ class Scatterplot1DTest(unittest.TestCase):
     def test_scatter_1d_set_index_mapper_notifies_index_range(self):
         new_range = DataRange1D(low=0.42, high=1.42)
 
-        # Given
-        self.notification_has_fired = False
+        with self.assertTraitChanges(self.scatterplot, "index_range", count=1):
+            self.scatterplot.index_mapper = LinearMapper(range=new_range)
 
-        def _listener():
-            self.notification_has_fired = True
-
-        self.scatterplot.on_trait_change(_listener, "index_range")
-
-        # When
-        self.scatterplot.index_mapper = LinearMapper(range=new_range)
-
-        # Then
-        self.assertTrue(self.notification_has_fired)
         self.assertIs(self.scatterplot.index_range, new_range)

--- a/chaco/tests/test_scatterplot_1d.py
+++ b/chaco/tests/test_scatterplot_1d.py
@@ -158,3 +158,26 @@ class Scatterplot1DTest(unittest.TestCase):
         gc.render_component(self.scatterplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
+
+    def test_scatter_1d_set_index_range(self):
+        new_range = DataRange1D(low=0.42, high=1.42)
+        self.scatterplot.index_range = new_range
+        self.assertEqual(self.scatterplot.index_mapper.range, new_range)
+
+    def test_scatter_1d_set_index_mapper_notifies_index_range(self):
+        new_range = DataRange1D(low=0.42, high=1.42)
+
+        # Given
+        self.notification_has_fired = False
+
+        def _listener():
+            self.notification_has_fired = True
+
+        self.scatterplot.on_trait_change(_listener, "index_range")
+
+        # When
+        self.scatterplot.index_mapper = LinearMapper(range=new_range)
+
+        # Then
+        self.assertTrue(self.notification_has_fired)
+        self.assertIs(self.scatterplot.index_range, new_range)

--- a/chaco/tests/test_text_plot_1d.py
+++ b/chaco/tests/test_text_plot_1d.py
@@ -110,3 +110,26 @@ class TextPlot1DTest(unittest.TestCase):
         points = array([[0, 124.5], [124.5, 0]])
         assert_almost_equal(self.scatterplot.map_data(points),
                             array([9.0, 4.5]))
+
+    def test_scatter_1d_set_index_range(self):
+        new_range = DataRange1D(low=0.42, high=1.42)
+        self.scatterplot.index_range = new_range
+        self.assertEqual(self.scatterplot.index_mapper.range, new_range)
+
+    def test_scatter_1d_set_index_mapper_notifies_index_range(self):
+        new_range = DataRange1D(low=0.42, high=1.42)
+
+        # Given
+        self.notification_has_fired = False
+
+        def _listener():
+            self.notification_has_fired = True
+
+        self.scatterplot.on_trait_change(_listener, "index_range")
+
+        # When
+        self.scatterplot.index_mapper = LinearMapper(range=new_range)
+
+        # Then
+        self.assertTrue(self.notification_has_fired)
+        self.assertIs(self.scatterplot.index_range, new_range)

--- a/chaco/tests/test_text_plot_1d.py
+++ b/chaco/tests/test_text_plot_1d.py
@@ -32,6 +32,8 @@ class TextPlot1DTest(unittest.TestCase):
         self.assertIsNone(self.scatterplot.x_mapper)
         self.assertEqual(self.scatterplot.y_mapper,
                          self.scatterplot.index_mapper)
+        self.assertIs(self.scatterplot.index_range,
+                      self.scatterplot.index_mapper.range)
 
         gc = PlotGraphicsContext(self.size)
         gc.render_component(self.scatterplot)

--- a/chaco/tests/test_text_plot_1d.py
+++ b/chaco/tests/test_text_plot_1d.py
@@ -3,13 +3,15 @@ import unittest
 from numpy import alltrue, arange, array
 from numpy.testing import assert_almost_equal
 
+from traits.testing.unittest_tools import UnittestTools
+
 # Chaco imports
 from chaco.api import (ArrayDataSource, DataRange1D, LinearMapper,
                        PlotGraphicsContext)
 from chaco.text_plot_1d import TextPlot1D
 
 
-class TextPlot1DTest(unittest.TestCase):
+class TextPlot1DTest(UnittestTools, unittest.TestCase):
 
     def setUp(self):
         self.size = (250, 250)
@@ -119,17 +121,7 @@ class TextPlot1DTest(unittest.TestCase):
     def test_text_1d_set_index_mapper_notifies_index_range(self):
         new_range = DataRange1D(low=0.42, high=1.42)
 
-        # Given
-        self.notification_has_fired = False
+        with self.assertTraitChanges(self.textplot, "index_range", count=1):
+            self.textplot.index_mapper = LinearMapper(range=new_range)
 
-        def _listener():
-            self.notification_has_fired = True
-
-        self.textplot.on_trait_change(_listener, "index_range")
-
-        # When
-        self.textplot.index_mapper = LinearMapper(range=new_range)
-
-        # Then
-        self.assertTrue(self.notification_has_fired)
         self.assertIs(self.textplot.index_range, new_range)

--- a/chaco/tests/test_text_plot_1d.py
+++ b/chaco/tests/test_text_plot_1d.py
@@ -19,104 +19,104 @@ class TextPlot1DTest(unittest.TestCase):
         index_range = DataRange1D()
         index_range.add(data_source)
         index_mapper = LinearMapper(range=index_range)
-        self.scatterplot = TextPlot1D(
+        self.textplot = TextPlot1D(
             index=data_source,
             index_mapper=index_mapper,
             value=text_data,
             border_visible=False,
         )
-        self.scatterplot.outer_bounds = list(self.size)
+        self.textplot.outer_bounds = list(self.size)
 
-    def test_scatter_1d(self):
-        self.assertEqual(self.scatterplot.origin, 'bottom left')
-        self.assertIsNone(self.scatterplot.x_mapper)
-        self.assertEqual(self.scatterplot.y_mapper,
-                         self.scatterplot.index_mapper)
-        self.assertIs(self.scatterplot.index_range,
-                      self.scatterplot.index_mapper.range)
+    def test_text_1d(self):
+        self.assertEqual(self.textplot.origin, 'bottom left')
+        self.assertIsNone(self.textplot.x_mapper)
+        self.assertEqual(self.textplot.y_mapper,
+                         self.textplot.index_mapper)
+        self.assertIs(self.textplot.index_range,
+                      self.textplot.index_mapper.range)
 
         gc = PlotGraphicsContext(self.size)
-        gc.render_component(self.scatterplot)
+        gc.render_component(self.textplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    def test_scatter_1d_horizontal(self):
-        self.scatterplot.orientation = 'h'
+    def test_text_1d_horizontal(self):
+        self.textplot.orientation = 'h'
 
-        self.assertEqual(self.scatterplot.origin, 'bottom left')
-        self.assertEqual(self.scatterplot.x_mapper,
-                         self.scatterplot.index_mapper)
-        self.assertIsNone(self.scatterplot.y_mapper)
+        self.assertEqual(self.textplot.origin, 'bottom left')
+        self.assertEqual(self.textplot.x_mapper,
+                         self.textplot.index_mapper)
+        self.assertIsNone(self.textplot.y_mapper)
 
         gc = PlotGraphicsContext(self.size)
-        gc.render_component(self.scatterplot)
+        gc.render_component(self.textplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    def test_scatter_1d_flipped(self):
-        self.scatterplot.direction = 'flipped'
+    def test_text_1d_flipped(self):
+        self.textplot.direction = 'flipped'
 
-        self.assertEqual(self.scatterplot.origin, 'top left')
-        self.assertIsNone(self.scatterplot.x_mapper)
-        self.assertEqual(self.scatterplot.y_mapper,
-                         self.scatterplot.index_mapper)
+        self.assertEqual(self.textplot.origin, 'top left')
+        self.assertIsNone(self.textplot.x_mapper)
+        self.assertEqual(self.textplot.y_mapper,
+                         self.textplot.index_mapper)
 
         gc = PlotGraphicsContext(self.size)
-        gc.render_component(self.scatterplot)
+        gc.render_component(self.textplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    def test_scatter_1d_horizontal_flipped(self):
-        self.scatterplot.direction = 'flipped'
-        self.scatterplot.orientation = 'h'
+    def test_text_1d_horizontal_flipped(self):
+        self.textplot.direction = 'flipped'
+        self.textplot.orientation = 'h'
 
-        self.assertEqual(self.scatterplot.origin, 'bottom right')
-        self.assertEqual(self.scatterplot.x_mapper,
-                         self.scatterplot.index_mapper)
-        self.assertIsNone(self.scatterplot.y_mapper)
+        self.assertEqual(self.textplot.origin, 'bottom right')
+        self.assertEqual(self.textplot.x_mapper,
+                         self.textplot.index_mapper)
+        self.assertIsNone(self.textplot.y_mapper)
 
         gc = PlotGraphicsContext(self.size)
-        gc.render_component(self.scatterplot)
+        gc.render_component(self.textplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    def test_scatter_1d_rotated(self):
-        self.scatterplot.text_rotate_angle = 45
+    def test_text_1d_rotated(self):
+        self.textplot.text_rotate_angle = 45
         gc = PlotGraphicsContext(self.size)
-        gc.render_component(self.scatterplot)
+        gc.render_component(self.textplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    def test_scatter_1d_map_data(self):
+    def test_text_1d_map_data(self):
         points = array([[0, 124.5], [124.5, 0]])
-        assert_almost_equal(self.scatterplot.map_data(points),
+        assert_almost_equal(self.textplot.map_data(points),
                             array([4.5, 0]))
 
-    def test_scatter_1d_map_data_horizontal(self):
-        self.scatterplot.orientation = 'h'
+    def test_text_1d_map_data_horizontal(self):
+        self.textplot.orientation = 'h'
         points = array([[0, 124.5], [124.5, 0]])
-        assert_almost_equal(self.scatterplot.map_data(points),
+        assert_almost_equal(self.textplot.map_data(points),
                             array([0, 4.5]))
 
-    def test_scatter_1d_map_data_flipped(self):
-        self.scatterplot.direction = 'flipped'
+    def test_text_1d_map_data_flipped(self):
+        self.textplot.direction = 'flipped'
         points = array([[0, 124.5], [124.5, 0]])
-        assert_almost_equal(self.scatterplot.map_data(points),
+        assert_almost_equal(self.textplot.map_data(points),
                             array([4.5, 9.0]))
 
-    def test_scatter_1d_map_data_horizontal_flipped(self):
-        self.scatterplot.direction = 'flipped'
-        self.scatterplot.orientation = 'h'
+    def test_text_1d_map_data_horizontal_flipped(self):
+        self.textplot.direction = 'flipped'
+        self.textplot.orientation = 'h'
         points = array([[0, 124.5], [124.5, 0]])
-        assert_almost_equal(self.scatterplot.map_data(points),
+        assert_almost_equal(self.textplot.map_data(points),
                             array([9.0, 4.5]))
 
-    def test_scatter_1d_set_index_range(self):
+    def test_text_1d_set_index_range(self):
         new_range = DataRange1D(low=0.42, high=1.42)
-        self.scatterplot.index_range = new_range
-        self.assertEqual(self.scatterplot.index_mapper.range, new_range)
+        self.textplot.index_range = new_range
+        self.assertEqual(self.textplot.index_mapper.range, new_range)
 
-    def test_scatter_1d_set_index_mapper_notifies_index_range(self):
+    def test_text_1d_set_index_mapper_notifies_index_range(self):
         new_range = DataRange1D(low=0.42, high=1.42)
 
         # Given
@@ -125,11 +125,11 @@ class TextPlot1DTest(unittest.TestCase):
         def _listener():
             self.notification_has_fired = True
 
-        self.scatterplot.on_trait_change(_listener, "index_range")
+        self.textplot.on_trait_change(_listener, "index_range")
 
         # When
-        self.scatterplot.index_mapper = LinearMapper(range=new_range)
+        self.textplot.index_mapper = LinearMapper(range=new_range)
 
         # Then
         self.assertTrue(self.notification_has_fired)
-        self.assertIs(self.scatterplot.index_range, new_range)
+        self.assertIs(self.textplot.index_range, new_range)

--- a/chaco/tests/text_plot_test_case.py
+++ b/chaco/tests/text_plot_test_case.py
@@ -40,6 +40,8 @@ class TextPlotTest(unittest.TestCase):
         self.assertEqual(self.text_plot.origin, 'bottom left')
         self.assertEqual(self.text_plot.x_mapper, self.text_plot.index_mapper)
         self.assertEqual(self.text_plot.y_mapper, self.text_plot.value_mapper)
+        self.assertIs(self.text_plot.index_range,
+                      self.text_plot.index_mapper.range)
 
         gc = PlotGraphicsContext(self.size)
         gc.render_component(self.text_plot)

--- a/chaco/tests/text_plot_test_case.py
+++ b/chaco/tests/text_plot_test_case.py
@@ -42,6 +42,8 @@ class TextPlotTest(unittest.TestCase):
         self.assertEqual(self.text_plot.y_mapper, self.text_plot.value_mapper)
         self.assertIs(self.text_plot.index_range,
                       self.text_plot.index_mapper.range)
+        self.assertIs(self.text_plot.value_range,
+                      self.text_plot.value_mapper.range)
 
         gc = PlotGraphicsContext(self.size)
         gc.render_component(self.text_plot)


### PR DESCRIPTION
Adds a `index_range` property, synonym of `index_mapper.range`, to `Base1DPlot`. This corresponds to a similarly defined property in `Base2DPlot`, and `Plot._handle_range_changed()` expects this attribute to exist in order to work properly.

\+ new assertions for regression testing.

Closes #490 
