### PR TITLE
Import from traits.api instead of from traits.has_traits

### DIFF
--- a/examples/user_guide/plot_types/plot_window.py
+++ b/examples/user_guide/plot_types/plot_window.py
@@ -1,8 +1,7 @@
 from chaco.api import PlotComponent
 from chaco.data_view import DataView
 from enable.component_editor import ComponentEditor
-from traits.api import HasTraits, Instance
-from traits.has_traits import on_trait_change
+from traits.api import HasTraits, Instance, on_trait_change
 from traitsui.api import Item, View
 
 class PlotWindow(HasTraits):


### PR DESCRIPTION
For safety against future Traits internal refactors, import from traits.api whenever possible.