### PR TITLE
Fix and clean up multiaxis.py example

### DIFF
--- a/examples/demo/multiaxis.py
+++ b/examples/demo/multiaxis.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
 """
 Draws several overlapping line plots like simple_line.py, but uses a separate
-Y range for each plot.  Also has a second Y-axis on the right hand side.
-Demonstrates use of the BroadcasterTool.
+Y range for j1 compared to the other 3 curves. Also has a second Y-axis on the
+right hand side for j1. Demonstrates use of the BroadcasterTool.
 
-Left-drag pans the plot.
-
-Right-click and dragging on the legend allows you to reposition the legend.
-
-Double-clicking on line or scatter plots brings up a traits editor for the
-plot.
+Interactive behavior:
+* Left-drag pans the plot.
+* Right-click and dragging on the legend allows you to reposition the legend.
+* Double-clicking on line or scatter plots brings up a traits editor for the
+  plot.
 """
 
 # Major library imports
@@ -62,17 +61,19 @@ def _create_plot_component():
         elif i != 1:
             # For the new plot to be mapped correctly on the first plot's axis:
             plot0 = plots["Bessel j_0"]
+            plot.index_mapper = plot0.index_mapper
             plot.value_mapper = plot0.value_mapper
             plot0.value_mapper.range.add(plot.value)
 
-        # Create a pan tool and give it a reference to the plot it should
-        # manipulate, but don't attach it to the plot.  Instead, attach it to
-        # the broadcaster.
-        pan = PanTool(plot)
-        broadcaster.tools.append(pan)
+        # Create a pan/zoom tool and give it a reference to the plot it should
+        # manipulate, but don't attach it to the plot. Instead, attach it to
+        # the broadcaster. Do it only for each independent set of axis_mappers:
+        if i in [0, 1]:
+            pan = PanTool(component=plot)
+            broadcaster.tools.append(pan)
 
-        zoom = ZoomTool(component=plot)
-        broadcaster.tools.append(zoom)
+            zoom = ZoomTool(component=plot)
+            broadcaster.tools.append(zoom)
 
         container.add(plot)
         plots["Bessel j_%d" % i] = plot
@@ -84,15 +85,16 @@ def _create_plot_component():
     plot1.underlays.append(axis)
     axis.title = "Bessel j1"
 
-    # Add the broadcast tool to the container, instead of to an
-    # individual plot
-    container.tools.append(broadcaster)
+    # Add the broadcast tool to one of the renderers: adding it to the
+    # container instead breaks the box mode of the ZoomTool:
+    plot0 = plots["Bessel j_0"]
+    plot0.tools.append(broadcaster)
 
+    # Create a legend, with tools to move it around and highlight renderers:
     legend = Legend(component=container, padding=10, align="ur")
     legend.tools.append(LegendTool(legend, drag_button="right"))
     legend.tools.append(LegendHighlighter(legend))
     container.overlays.append(legend)
-
     # Set the list of plots on the legend
     legend.plots = plots
 

--- a/examples/demo/multiaxis.py
+++ b/examples/demo/multiaxis.py
@@ -56,7 +56,7 @@ def _create_plot_component():
             left_axis, _ = add_default_axes(plot)
             left_axis.title = "Bessel j0, j2, j3"
         elif i != 1:
-            # For the new plot to be mapped correctly on the first plot's axis:
+            # Map correctly j2 and j3 on the first plot's axis:
             plot0 = plots["Bessel j_0"]
             plot.index_mapper = plot0.index_mapper
             plot.value_mapper = plot0.value_mapper

--- a/examples/demo/multiaxis.py
+++ b/examples/demo/multiaxis.py
@@ -49,7 +49,8 @@ def _create_plot_component():
     broadcaster = BroadcasterTool()
     for i in range(4):
         y = jn(i, x)
-        plot = create_line_plot((x,y), color=tuple(COLOR_PALETTE[i]), width=2.0)
+        plot = create_line_plot((x, y), color=tuple(COLOR_PALETTE[i]),
+                                width=2.0)
         plot.index.sort_order = "ascending"
         plot.bgcolor = "white"
         plot.border_visible = True
@@ -57,6 +58,11 @@ def _create_plot_component():
             add_default_grids(plot)
             left_axis, _ = add_default_axes(plot)
             left_axis.title = "Bessel j0, j2, j3"
+        elif i != 1:
+            # For the new plot to be mapped correctly on the first plot's axis:
+            plot0 = plots["Bessel j_0"]
+            plot.value_mapper = plot0.value_mapper
+            plot0.value_mapper.range.add(plot.value)
 
         # Create a pan tool and give it a reference to the plot it should
         # manipulate, but don't attach it to the plot.  Instead, attach it to

--- a/examples/demo/multiaxis.py
+++ b/examples/demo/multiaxis.py
@@ -36,7 +36,7 @@ from chaco.tools.api import (PanTool, LegendTool, LegendHighlighter,
 def _create_plot_component():
 
     container = OverlayPlotContainer(padding=60, fill_padding=True,
-                                     bgcolor="lightgray", use_backbuffer=True)
+                                     use_backbuffer=True, border_visible=True)
 
     # Create the initial X-series of data
     numpoints = 100
@@ -51,9 +51,6 @@ def _create_plot_component():
         y = jn(i, x)
         plot = create_line_plot((x, y), color=tuple(COLOR_PALETTE[i]),
                                 width=2.0)
-        plot.index.sort_order = "ascending"
-        plot.bgcolor = "white"
-        plot.border_visible = True
         if i == 0:
             add_default_grids(plot)
             left_axis, _ = add_default_axes(plot)

--- a/examples/demo/multiaxis.py
+++ b/examples/demo/multiaxis.py
@@ -26,15 +26,17 @@ from chaco.api import create_line_plot, add_default_axes, \
                                 add_default_grids, OverlayPlotContainer, \
                                 PlotLabel, Legend, PlotAxis
 from chaco.tools.api import (PanTool, LegendTool, LegendHighlighter,
-                             TraitsTool, BroadcasterTool)
+                             TraitsTool, BroadcasterTool, ZoomTool)
 
-#===============================================================================
-# # Create the Chaco plot.
-#===============================================================================
+# =============================================================================
+# Create the Chaco plot.
+# =============================================================================
+
+
 def _create_plot_component():
 
-    container = OverlayPlotContainer(padding = 50, fill_padding = True,
-                                     bgcolor = "lightgray", use_backbuffer=True)
+    container = OverlayPlotContainer(padding=60, fill_padding = True,
+                                     bgcolor="lightgray", use_backbuffer=True)
 
     # Create the initial X-series of data
     numpoints = 100
@@ -53,7 +55,8 @@ def _create_plot_component():
         plot.border_visible = True
         if i == 0:
             add_default_grids(plot)
-            add_default_axes(plot)
+            left_axis, _ = add_default_axes(plot)
+            left_axis.title = "Bessel j0, j2, j3"
 
         # Create a pan tool and give it a reference to the plot it should
         # manipulate, but don't attach it to the plot.  Instead, attach it to
@@ -61,14 +64,18 @@ def _create_plot_component():
         pan = PanTool(plot)
         broadcaster.tools.append(pan)
 
+        zoom = ZoomTool(component=plot)
+        broadcaster.tools.append(zoom)
+
         container.add(plot)
-        plots["Bessel j_%d"%i] = plot
+        plots["Bessel j_%d" % i] = plot
 
     # Add an axis on the right-hand side that corresponds to the second plot.
     # Note that it uses plot.value_mapper instead of plot0.value_mapper.
     plot1 = plots["Bessel j_1"]
     axis = PlotAxis(plot1, orientation="right")
     plot1.underlays.append(axis)
+    axis.title = "Bessel j1"
 
     # Add the broadcast tool to the container, instead of to an
     # individual plot
@@ -85,7 +92,7 @@ def _create_plot_component():
     # Add the title at the top
     container.overlays.append(PlotLabel("Bessel functions",
                               component=container,
-                              font = "swiss 16",
+                              font="swiss 16",
                               overlay_position="top"))
 
     # Add the traits inspector tool to the container
@@ -93,14 +100,17 @@ def _create_plot_component():
 
     return container
 
-#===============================================================================
-# Attributes to use for the plot view.
-size=(800,700)
-title="Multi-Y plot"
 
-#===============================================================================
-# # Demo class that is used by the demo.py application.
-#===============================================================================
+# =============================================================================
+# Attributes to use for the plot view.
+size = (800, 700)
+title = "Multi-Y plot"
+
+# =============================================================================
+# Demo class that is used by the demo.py application.
+# =============================================================================
+
+
 class Demo(HasTraits):
     plot = Instance(Component)
 
@@ -116,9 +126,8 @@ class Demo(HasTraits):
     def _plot_default(self):
         return _create_plot_component()
 
+
 demo = Demo()
 
 if __name__ == "__main__":
     demo.configure_traits()
-
-#--EOF---

--- a/examples/demo/multiaxis.py
+++ b/examples/demo/multiaxis.py
@@ -8,7 +8,8 @@ Left-drag pans the plot.
 
 Right-click and dragging on the legend allows you to reposition the legend.
 
-Double-clicking on line or scatter plots brings up a traits editor for the plot.
+Double-clicking on line or scatter plots brings up a traits editor for the
+plot.
 """
 
 # Major library imports
@@ -19,7 +20,7 @@ from chaco.example_support import COLOR_PALETTE
 # Enthought library imports
 from enable.api import Component, ComponentEditor
 from traits.api import HasTraits, Instance
-from traitsui.api import Item, Group, View
+from traitsui.api import Item, VGroup, View
 
 # Chaco imports
 from chaco.api import create_line_plot, add_default_axes, \
@@ -35,7 +36,7 @@ from chaco.tools.api import (PanTool, LegendTool, LegendHighlighter,
 
 def _create_plot_component():
 
-    container = OverlayPlotContainer(padding=60, fill_padding = True,
+    container = OverlayPlotContainer(padding=60, fill_padding=True,
                                      bgcolor="lightgray", use_backbuffer=True)
 
     # Create the initial X-series of data
@@ -121,13 +122,11 @@ class Demo(HasTraits):
     plot = Instance(Component)
 
     traits_view = View(
-                    Group(
+                    VGroup(
                         Item('plot', editor=ComponentEditor(size=size),
-                             show_label=False),
-                        orientation = "vertical"),
+                             show_label=False)),
                     resizable=True, title=title,
-                    width=size[0], height=size[1]
-                    )
+                    width=size[0], height=size[1])
 
     def _plot_default(self):
         return _create_plot_component()


### PR DESCRIPTION
- Aligned j0, j2 and j3's `value_mapper` so curves are correctly placed. To some extent, that changes a bit the purpose of the example to be more like the kind of thing that's scientifically useful (as opposed to disconnecting 4 plot's y mappers, but only displaying 2 axis).
- Added axis titles to clarify where to read y-values.
- Added a zoom tool because it is tricky to do and universally needed.
- pep8 fixes.