### PR TITLE
FIX: Enforce underscore for click command

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -106,7 +106,11 @@ environment_vars = {
 }
 
 
-@click.group()
+def normalize(name):
+    return name.replace("_", "-")
+
+
+@click.group(context_settings={"token_normalize_func": normalize})
 def cli():
     pass
 


### PR DESCRIPTION
Applying a quick fix for [Command names with underscores must be invoked with dashes instead when upgrading from 6.7 to 7.0](https://github.com/pallets/click/issues/1123)

This will make the documentation command consistent:
https://github.com/enthought/chaco/blob/192675d6cb579df56458b87988026d895e7a7a84/ci/edmtool.py#L44