### PR TITLE
Remove Python 2.7, 3.5 testing, add PyQt 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,6 @@ env:
 
 matrix:
   include:
-  - env: RUNTIME=2.7 TOOLKITS="null pyqt pyside wx"
-  - os : osx
-    env: RUNTIME=2.7 TOOLKITS="null pyqt pyside wx"
-  - env: RUNTIME=3.5 TOOLKITS="null pyqt"
-  - os : osx
-    env: RUNTIME=3.5 TOOLKITS="null pyqt"
   - env: RUNTIME=3.6 TOOLKITS="null pyqt"
   - os : osx
     env: RUNTIME=3.6 TOOLKITS="null pyqt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
     - ccache
     - cmake
     - swig
+    - libxkbcommon-x11-0
     - libglu1-mesa-dev
     - libxcb-icccm4
     - libxcb-image0

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ env:
 
 matrix:
   include:
-  - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5"
+  - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
   - os : osx
-    env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5"
+    env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
   fast_finish: true
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ env:
 
 matrix:
   include:
-  - env: RUNTIME=3.6 TOOLKITS="null pyqt"
+  - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5"
   - os : osx
-    env: RUNTIME=3.6 TOOLKITS="null pyqt"
+    env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5"
   fast_finish: true
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,18 @@ addons:
     - cmake
     - swig
     - libglu1-mesa-dev
-
+    - libxcb-icccm4
+    - libxcb-image0
+    - libxcb-keysyms1
+    - libxcb-randr0
+    - libxcb-render-util0
+    - libxcb-xinerama0
+    
 env:
   global:
     - INSTALL_EDM_VERSION=2.0.0
       PYTHONUNBUFFERED="1"
+      QT_DEBUG_PLUGINS="1"
 
 matrix:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 
   matrix:
     - RUNTIME: '3.6'
-      TOOLKITS: "null pyqt pyqt2"
+      TOOLKITS: "null pyqt pyqt2 pyside2"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,12 +8,8 @@ environment:
     INSTALL_EDM_VERSION: "2.0.0"
 
   matrix:
-    - RUNTIME: '2.7'
-      TOOLKITS: "null pyqt pyside wx"
-    - RUNTIME: '3.5'
-      TOOLKITS: "null pyqt"
     - RUNTIME: '3.6'
-      TOOLKITS: "null pyqt"
+      TOOLKITS: "null pyqt pyqt2"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 
   matrix:
     - RUNTIME: '3.6'
-      TOOLKITS: "null pyqt pyqt2 pyside2"
+      TOOLKITS: "null pyqt pyqt5 pyside2"
 
 branches:
   only:

--- a/chaco/shell/plot_window.py
+++ b/chaco/shell/plot_window.py
@@ -137,9 +137,14 @@ elif ETSConfig.toolkit == "qt4":
         def __init__(self, is_image=False, bgcolor="white",
                      image_default_origin="top left", *args, **kw):
 
+            size = kw.pop("size", None)
+            if isinstance(size, tuple):
+                size = QtCore.QSize(*size)
+            
             super(PlotWindow, self).__init__(None, *args, **kw )
-            if 'size' in kw and isinstance(kw['size'], tuple):
-                self.resize(*kw['size'])
+
+            if size is not None:
+                self.resize(size)
 
             # Some defaults which should be overridden by preferences.
             self.bgcolor = bgcolor

--- a/chaco/shell/plot_window.py
+++ b/chaco/shell/plot_window.py
@@ -137,10 +137,9 @@ elif ETSConfig.toolkit == "qt4":
         def __init__(self, is_image=False, bgcolor="white",
                      image_default_origin="top left", *args, **kw):
 
-            if 'size' in kw and isinstance(kw['size'], tuple):
-                # Convert to a QSize.
-                kw['size'] = QtCore.QSize(*kw['size'])
             super(PlotWindow, self).__init__(None, *args, **kw )
+            if 'size' in kw and isinstance(kw['size'], tuple):
+                self.resize(*kw['size'])
 
             # Some defaults which should be overridden by preferences.
             self.bgcolor = bgcolor

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -71,7 +71,7 @@ from contextlib import contextmanager
 import click
 
 supported_combinations = {
-    '3.6': {'pyqt', 'pyqt5', 'null'},
+    '3.6': {'pyside2', 'pyqt', 'pyqt5', 'null'},
 }
 
 dependencies = {
@@ -87,6 +87,7 @@ dependencies = {
 }
 
 extra_dependencies = {
+    'pyside2': set(),
     'pyside': {'pyside'},
     'pyqt': {'pyqt'},
     'pyqt5': {'pyqt5'},
@@ -95,6 +96,7 @@ extra_dependencies = {
 }
 
 environment_vars = {
+    'pyside2': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside2'},
     'pyside': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside'},
     'pyqt': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt'},
     'pyqt5': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt5'},
@@ -129,6 +131,12 @@ def install(runtime, toolkit, environment):
          "pip install git+https://git@github.com/enthought/enable.git"),
         "edm run -e {environment} -- pip install . --no-deps",
     ]
+    # pip install pyside2, because we don't have them in EDM yet
+    if toolkit == 'pyside2':
+        commands.append(
+            "edm run -e {environment} -- pip install pyside2==5.11"
+        )
+    
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)
     click.echo('Done install')

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -43,7 +43,7 @@ you can run tests in all supported runtimes and toolkits (with cleanup)
 using::
     python edmtool.py test_all
 
-Currently supported runtime values are ``2.7`` and ``3.5``, and currently
+Currently supported runtime values are ``3.6``, and currently
 supported toolkits are ``null``, ``pyqt``, ``pyside``, and ``wx``.  Not all
 combinations of toolkits and runtimes will work, but the tasks will fail with
 a clear error if that is the case. Tests can still be run via the usual means
@@ -60,9 +60,6 @@ Other changes to commands should be a straightforward change to the listed
 commands for each task. See the EDM documentation for more information about
 how to run commands within an EDM enviornment.
 """
-
-from __future__ import print_function
-
 import glob
 import os
 import subprocess
@@ -74,8 +71,6 @@ from contextlib import contextmanager
 import click
 
 supported_combinations = {
-    '2.7': {'pyqt', 'pyside', 'wx', 'null'},
-    '3.5': {'pyqt', 'null'},
     '3.6': {'pyqt', 'null'},
 }
 
@@ -112,7 +107,7 @@ def cli():
 
 
 @cli.command()
-@click.option('--runtime', default='3.5')
+@click.option('--runtime', default='3.6')
 @click.option('--toolkit', default='null')
 @click.option('--environment', default=None)
 def install(runtime, toolkit, environment):
@@ -138,7 +133,7 @@ def install(runtime, toolkit, environment):
 
 
 @cli.command()
-@click.option('--runtime', default='3.5')
+@click.option('--runtime', default='3.6')
 @click.option('--toolkit', default='null')
 @click.option('--environment', default=None)
 def test(runtime, toolkit, environment):
@@ -172,7 +167,7 @@ def test(runtime, toolkit, environment):
 
 
 @cli.command()
-@click.option('--runtime', default='3.5')
+@click.option('--runtime', default='3.6')
 @click.option('--toolkit', default='null')
 @click.option('--environment', default=None)
 def cleanup(runtime, toolkit, environment):
@@ -189,7 +184,7 @@ def cleanup(runtime, toolkit, environment):
 
 
 @cli.command()
-@click.option('--runtime', default='3.5')
+@click.option('--runtime', default='3.6')
 @click.option('--toolkit', default='null')
 def test_clean(runtime, toolkit):
     """ Run tests in a clean environment, cleaning up afterwards
@@ -204,7 +199,7 @@ def test_clean(runtime, toolkit):
 
 
 @cli.command()
-@click.option('--runtime', default='3.5')
+@click.option('--runtime', default='3.6')
 @click.option('--toolkit', default='null')
 @click.option('--environment', default=None)
 def update(runtime, toolkit, environment):

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -44,7 +44,7 @@ using::
     python edmtool.py test_all
 
 Currently supported runtime values are ``3.6``, and currently
-supported toolkits are ``null``, ``pyqt``, ``pyside``, and ``wx``.  Not all
+supported toolkits are ``null``, ``pyqt``, and ``pyqt5``.  Not all
 combinations of toolkits and runtimes will work, but the tasks will fail with
 a clear error if that is the case. Tests can still be run via the usual means
 in other environments if that suits a developer's purpose.

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -87,7 +87,7 @@ dependencies = {
 }
 
 extra_dependencies = {
-    'pyside2': set(),  # pyside2 is pip installed during the install step
+    'pyside2': set(),  # pyside2 is pip-installed during the install step
     'pyqt': {'pyqt'},
     'pyqt5': {'pyqt5'},
     'null': set()
@@ -127,7 +127,7 @@ def install(runtime, toolkit, environment):
          "pip install git+https://git@github.com/enthought/enable.git"),
         "edm run -e {environment} -- pip install . --no-deps",
     ]
-    # pip install pyside2, because we don't have them in EDM yet
+    # pip install pyside2, because we don't have it in EDM yet
     if toolkit == 'pyside2':
         commands.append(
             "edm run -e {environment} -- pip install pyside2==5.11"

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -71,7 +71,7 @@ from contextlib import contextmanager
 import click
 
 supported_combinations = {
-    '3.6': {'pyqt', 'null'},
+    '3.6': {'pyqt', 'pyqt5', 'null'},
 }
 
 dependencies = {
@@ -89,6 +89,7 @@ dependencies = {
 extra_dependencies = {
     'pyside': {'pyside'},
     'pyqt': {'pyqt'},
+    'pyqt5': {'pyqt5'},
     'wx': {'wxpython'},
     'null': set()
 }
@@ -96,6 +97,7 @@ extra_dependencies = {
 environment_vars = {
     'pyside': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside'},
     'pyqt': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt'},
+    'pyqt5': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt5'},
     'wx': {'ETS_TOOLKIT': 'wx'},
     'null': {'ETS_TOOLKIT': 'null.image'},
 }

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -44,7 +44,7 @@ using::
     python edmtool.py test_all
 
 Currently supported runtime values are ``3.6``, and currently
-supported toolkits are ``null``, ``pyqt``, and ``pyqt5``.  Not all
+supported toolkits are ``null``, ``pyqt``, ``pyqt5`` and ``pyside2``.  Not all
 combinations of toolkits and runtimes will work, but the tasks will fail with
 a clear error if that is the case. Tests can still be run via the usual means
 in other environments if that suits a developer's purpose.
@@ -87,20 +87,16 @@ dependencies = {
 }
 
 extra_dependencies = {
-    'pyside2': set(),
-    'pyside': {'pyside'},
+    'pyside2': set(),  # pyside2 is pip installed during the install step
     'pyqt': {'pyqt'},
     'pyqt5': {'pyqt5'},
-    'wx': {'wxpython'},
     'null': set()
 }
 
 environment_vars = {
     'pyside2': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside2'},
-    'pyside': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside'},
     'pyqt': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt'},
     'pyqt5': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt5'},
-    'wx': {'ETS_TOOLKIT': 'wx'},
     'null': {'ETS_TOOLKIT': 'null.image'},
 }
 
@@ -151,11 +147,6 @@ def test(runtime, toolkit, environment):
     """
     parameters = get_parameters(runtime, toolkit, environment)
     environ = environment_vars.get(toolkit, {}).copy()
-    # FIXME : See discussion on https://github.com/enthought/chaco/pull/442
-    # Note that we are overriding the existing definition of `ETS_TOOLKIT`
-    # in the `environment_vars` dictionary.
-    if sys.platform == 'darwin' and runtime == '2.7' and toolkit == 'wx':
-        environ['ETS_TOOLKIT'] = 'wx.image'
 
     environ['PYTHONUNBUFFERED'] = "1"
     commands = [

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -244,9 +244,12 @@ def get_parameters(runtime, toolkit, environment):
     parameters = {'runtime': runtime, 'toolkit': toolkit,
                   'environment': environment}
     if toolkit not in supported_combinations[runtime]:
-        msg = ("Python {runtime}, toolkit {toolkit}, "
-               "not supported by test environments")
-        raise RuntimeError(msg.format(**parameters))
+        msg = ("Python {runtime!r}, toolkit {toolkit!r}, "
+               "not supported by test environments ({available})")
+        available = ", ".join(
+            repr(tk) for tk in sorted(supported_combinations[runtime])
+        )
+        raise RuntimeError(msg.format(available=available, **parameters))
     if environment is None:
         tmpl = 'chaco-test-{runtime}-{toolkit}'
         environment = tmpl.format(**parameters)


### PR DESCRIPTION
as it says on the tin.

Note: this means that we effectively don't test with wxpython and pyside any more. 

@rahulporuri Do you know of any other toolkits that are supported under Python 3.6?