### PR TITLE
Add source click option used on cron jobs to install ets packages from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     - INSTALL_EDM_VERSION=2.0.0
       PYTHONUNBUFFERED="1"
       QT_DEBUG_PLUGINS="1"
+    - TRAVIS_EVENT_TYPE='cron'
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,13 @@ before_install:
 
   - edm install -y wheel click coverage
 install:
-  - for toolkit in ${TOOLKITS}; do edm run -- python ci/edmtool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done
+  - for toolkit in ${TOOLKITS}; do
+        if [[ ${TRAVIS_EVENT_TYPE} == "cron" ]] ; then
+          edm run -- python ci/edmtool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit;
+        else
+          edm run -- python ci/edmtool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit;
+        fi;
+    done
 script:
   - for toolkit in ${TOOLKITS}; do edm run -- python ci/edmtool.py test --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
     - INSTALL_EDM_VERSION=2.0.0
       PYTHONUNBUFFERED="1"
       QT_DEBUG_PLUGINS="1"
-    - TRAVIS_EVENT_TYPE='cron'
 
 matrix:
   include:

--- a/chaco/__init__.py
+++ b/chaco/__init__.py
@@ -6,6 +6,10 @@
 from ._version import full_version as __version__  # noqa
 
 __requires__ = [
+   'traits',
+   'traitsui',
+   'pyface',
+   'numpy',
    'enable',
    'six'
 ]


### PR DESCRIPTION
fixes #522

This PR adds a `--source` click option and uses this option on cron jobs to install other ets packages from source.
Note that previously enable was installed from source always and that was how traits, traitsui and pyface got installed.  Following Marks comment here: https://github.com/enthought/envisage/pull/325#issuecomment-713410126, I added all of these to `__requires__` in `__init__.py`.  Additionally, I made it so that by default enable is not installed from source, but it will be when the `--source` flag is used.  

This follows what is done in other ets projects (e.g https://github.com/enthought/envisage/blob/8245931f7e3dfcb6513bfb7dc2ae9b10ca6f89a1/etstool.py#L255-L273)
