### PR TITLE
TST: Switch on default warning flag for CI test command

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -190,7 +190,8 @@ def test(runtime, toolkit, environment):
 
     environ['PYTHONUNBUFFERED'] = "1"
     commands = [
-        "edm run -e {environment} -- coverage run -m unittest discover -v chaco"
+        "edm run -e {environment} -- python -W default -m "
+        "coverage run -m unittest discover -v chaco"
     ]
 
     cwd = os.getcwd()


### PR DESCRIPTION
fixes #533 

This PR makes the exact same change that was made in https://github.com/enthought/envisage/pull/326 to solve the same issue.  It adds the -W default flag.