### PR TITLE
Use PySide2 from EDM instead of PyPI and Use the latest EDM version (3.0.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
     
 env:
   global:
-    - INSTALL_EDM_VERSION=2.0.0
+    - INSTALL_EDM_VERSION=3.0.1
       PYTHONUNBUFFERED="1"
       QT_DEBUG_PLUGINS="1"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
   global:
     PYTHONUNBUFFERED: "1"
-    INSTALL_EDM_VERSION: "2.0.0"
+    INSTALL_EDM_VERSION: "3.0.1"
 
   matrix:
     - RUNTIME: '3.6'

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -139,10 +139,16 @@ def install(runtime, toolkit, environment, source):
     parameters = get_parameters(runtime, toolkit, environment)
     parameters['packages'] = ' '.join(
         dependencies | extra_dependencies.get(toolkit, set()))
+
+    if toolkit == "pyside2":
+        additional_repositories = "--add-repository enthought/lgpl"
+    else:
+        additional_repositories = ""
+
     # edm commands to setup the development environment
     commands = [
         "edm environments create {environment} --force --version={runtime}",
-        "edm install -y -e {environment} {packages}",
+        "edm install -y -e {environment} {packages} " + additional_repositories,
         ("edm run -e {environment} -- pip install -r ci/requirements.txt"
          " --no-dependencies"),
         "edm run -e {environment} -- pip install . --no-deps",

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -101,7 +101,7 @@ source_dependencies = {
 github_url_fmt = "git+http://github.com/enthought/{0}.git#egg={0}"
 
 extra_dependencies = {
-    'pyside2': set(),  # pyside2 is pip-installed during the install step
+    'pyside2': {'pyside2'},
     'pyqt': {'pyqt'},
     'pyqt5': {'pyqt5'},
     'null': set()
@@ -147,11 +147,6 @@ def install(runtime, toolkit, environment, source):
          " --no-dependencies"),
         "edm run -e {environment} -- pip install . --no-deps",
     ]
-    # pip install pyside2, because we don't have it in EDM yet
-    if toolkit == 'pyside2':
-        commands.append(
-            "edm run -e {environment} -- pip install pyside2==5.11"
-        )
     
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)


### PR DESCRIPTION
fixes #536 

Also fixes #527 

In this PR we try to install pyside2 from edm instead of pip.  In order to do so, we need to use the latest version of edm in CI, so those version numbers are bumped as well.

In retrospect these should've been two separate PRs (shame!) and if a reviewer would prefer I am happy to go back and split them.  Initially I was just trying to fix 536 without realizing it required a fix for 527.