### PR TITLE
Disable macOS builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ env:
 matrix:
   include:
   - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
-  - os : osx
-    env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
   fast_finish: true
 
 branches:


### PR DESCRIPTION
macOS minutes are expensive; remove macOS builds from the Travis CI configuration. Longer term, we'll plan to migrate to GitHub Actions.