### PR TITLE
Remove use of six and __future__ imports

### DIFF
--- a/chaco/__init__.py
+++ b/chaco/__init__.py
@@ -10,6 +10,5 @@ __requires__ = [
    'traitsui',
    'pyface',
    'numpy',
-   'enable',
-   'six'
+   'enable'
 ]

--- a/chaco/array_plot_data.py
+++ b/chaco/array_plot_data.py
@@ -1,7 +1,5 @@
 """ Defines ArrayPlotData.
 """
-import six
-import six.moves as sm
 from numpy import array, ndarray
 
 # Enthought library imports
@@ -63,7 +61,7 @@ class ArrayPlotData(AbstractPlotData):
         """
         super(AbstractPlotData, self).__init__()
         self._update_data(kw)
-        data = dict(sm.zip(self._generate_names(len(data)), data))
+        data = dict(zip(self._generate_names(len(data)), data))
         self._update_data(data)
 
 

--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -1,8 +1,5 @@
 """ Defines the PlotAxis class, and associated validator and UI.
 """
-
-from __future__ import with_statement
-
 # Major library import
 from numpy import array, around, absolute, cos, dot, float64, inf, pi, \
                   sqrt, sin, transpose

--- a/chaco/axis_view.py
+++ b/chaco/axis_view.py
@@ -1,7 +1,4 @@
 """ Defines the Traits UI view for a PlotAxis """
-
-import six
-
 from traits.api import TraitError
 from traitsui.api import View, HGroup, Group, VGroup, Item, TextEditor
 
@@ -14,7 +11,7 @@ def float_or_auto(val):
     try:
         return float(val)
     except:
-        if isinstance(val, six.string_types) and val == "auto":
+        if isinstance(val, str) and val == "auto":
             return val
     raise TraitError("Tick interval must be a number or 'auto'.")
 
@@ -32,11 +29,8 @@ AxisView = View(VGroup(
                     label="Main"),
                 Group(
                     Item("tick_color", label="Color", style="custom"),
-                         #editor=EnableRGBAColorEditor()),
                     Item("tick_weight", label="Thickness"),
-                    #Item("tick_label_font", label="Font"),
                     Item("tick_label_color", label="Label color", style="custom"),
-                         #editor=EnableRGBAColorEditor()),
                     HGroup(
                         Item("tick_in", label="Tick in"),
                         Item("tick_out", label="Tick out"),
@@ -45,7 +39,6 @@ AxisView = View(VGroup(
                     label="Ticks"),
                 Group(
                     Item("axis_line_color", label="Color", style="custom"),
-                         #editor=EnableRGBAColorEditor()),
                     Item("axis_line_weight", label="Thickness"),
                     Item("axis_line_visible", label="Visible"),
                     label="Line"),

--- a/chaco/barplot.py
+++ b/chaco/barplot.py
@@ -1,8 +1,5 @@
 """ Defines the BarPlot class.
 """
-
-from __future__ import with_statement
-
 import logging
 
 from numpy import array, compress, column_stack, invert, isnan, transpose, zeros

--- a/chaco/base_1d_plot.py
+++ b/chaco/base_1d_plot.py
@@ -1,9 +1,6 @@
 """
 Abstract base class for 1-D plots which only use one axis
 """
-
-from __future__ import absolute_import
-
 # Standard library imports
 from numpy import argsort, asarray
 

--- a/chaco/base_candle_plot.py
+++ b/chaco/base_candle_plot.py
@@ -1,6 +1,3 @@
-
-from __future__ import with_statement
-
 # Major library imports
 from numpy import array, column_stack
 

--- a/chaco/base_contour_plot.py
+++ b/chaco/base_contour_plot.py
@@ -1,5 +1,3 @@
-import six
-
 from numpy import array, isscalar, issubsctype, linspace, number
 
 # Enthought library imports
@@ -101,7 +99,7 @@ class BaseContourPlot(Base2DPlot):
             self._colors = [self._color_map_trait_] * numcolors
 
         # If we are given a single color, apply it to all levels
-        elif isinstance(colors, six.string_types):
+        elif isinstance(colors, str):
             self._color_map_trait = colors
             self._colors = [self._color_map_trait_] * numcolors
 

--- a/chaco/base_plot_frame.py
+++ b/chaco/base_plot_frame.py
@@ -10,8 +10,6 @@
 
 from __future__ import with_statement
 
-import six
-import six.moves as sm
 # Enthought library imports
 from enable.api import Container
 from traits.api import Enum

--- a/chaco/base_plot_frame.py
+++ b/chaco/base_plot_frame.py
@@ -8,8 +8,6 @@
 #
 #################################################################################
 
-from __future__ import with_statement
-
 # Enthought library imports
 from enable.api import Container
 from traits.api import Enum

--- a/chaco/base_xy_plot.py
+++ b/chaco/base_xy_plot.py
@@ -1,8 +1,5 @@
 """ Defines the base class for XY plots.
 """
-
-from __future__ import with_statement
-
 from math import sqrt
 from numpy import around, array, isnan, transpose
 

--- a/chaco/candle_plot.py
+++ b/chaco/candle_plot.py
@@ -1,6 +1,3 @@
-
-from __future__ import with_statement
-
 # Major library imports
 from numpy import array, compress, concatenate, searchsorted
 

--- a/chaco/chaco_plot_editor.py
+++ b/chaco/chaco_plot_editor.py
@@ -2,8 +2,6 @@
 Traits UI editor for WX, based on the Chaco1 PlotEditor in
 traits.ui.wx.plot_editor.
 """
-import six
-import six.moves as sm
 # Enthought library imports
 from traits.etsconfig.api import ETSConfig
 from enable.api import black_color_trait, LineStyle, ColorTrait,\

--- a/chaco/color_bar.py
+++ b/chaco/color_bar.py
@@ -1,8 +1,5 @@
 """ Defines the ColorBar class.
 """
-
-from __future__ import with_statement
-
 # Major library imports
 from numpy import array, arange, ascontiguousarray, ones, transpose, uint8
 

--- a/chaco/color_mapper.py
+++ b/chaco/color_mapper.py
@@ -1,7 +1,5 @@
 """ Defines the ColorMapper and ColorMapTemplate classes.
 """
-import six
-import six.moves as sm
 
 # Major library imports
 from numpy import arange, array, asarray, clip, divide, float32, int8, isinf, \
@@ -135,7 +133,7 @@ class ColorMapper(AbstractColormap):
         # From the offsets and the color data, generate a segment map.
         segment_map = {}
         red_values = palette[:,0]
-        segment_map['red'] = list(sm.zip(offsets, red_values, red_values))
+        segment_map['red'] = list(zip(offsets, red_values, red_values))
         green_values = palette[:,1]
         segment_map['green'] = list(zip(offsets, green_values, green_values))
         blue_values = palette[:,2]
@@ -305,7 +303,7 @@ class ColorMapper(AbstractColormap):
         if self.color_depth is 'rgba':
             luts.append(self._alpha_lut)
 
-        result = list(sm.zip(*luts))
+        result = list(zip(*luts))
 
         return result
 

--- a/chaco/colormapped_scatterplot.py
+++ b/chaco/colormapped_scatterplot.py
@@ -3,8 +3,6 @@
 
 from __future__ import with_statement
 
-import six
-import six.moves as sm
 # Major library imports
 from numpy import argsort, array, concatenate, nonzero, invert, take, \
                   isnan, transpose, newaxis, zeros, ndarray

--- a/chaco/colormapped_selection_overlay.py
+++ b/chaco/colormapped_selection_overlay.py
@@ -1,6 +1,6 @@
 """ Defines the ColormappedSelectionOverlay class.
 """
-import six.moves as sm
+import functools
 
 from numpy import logical_and
 
@@ -76,7 +76,7 @@ class ColormappedSelectionOverlay(AbstractOverlay):
             mask = (data_pts >= low) & (data_pts <= high)
 
         elif self.selection_type == 'mask':
-            mask = sm.reduce(logical_and, datasource.metadata["selection_masks"])
+            mask = functools.reduce(logical_and, datasource.metadata["selection_masks"])
             if sum(mask)<2:
                 return
 

--- a/chaco/contour_line_plot.py
+++ b/chaco/contour_line_plot.py
@@ -1,8 +1,6 @@
 """ Defines the ContourLinePlot class.
 """
 
-from __future__ import with_statement
-
 # Major library imports
 from numpy import array, isfinite, meshgrid, transpose
 

--- a/chaco/contour_poly_plot.py
+++ b/chaco/contour_poly_plot.py
@@ -1,7 +1,7 @@
 """ Defines the ContourPolyPlot class.
 """
 
-from __future__ import with_statement
+
 
 # Major library imports
 from numpy import array, isfinite, meshgrid, transpose

--- a/chaco/cross_plot_frame.py
+++ b/chaco/cross_plot_frame.py
@@ -9,9 +9,6 @@
 
 from __future__ import with_statement
 
-import six
-import six.moves as sm
-
 # Enthought library imports
 from traits.api import Bool, Float
 

--- a/chaco/cross_plot_frame.py
+++ b/chaco/cross_plot_frame.py
@@ -7,7 +7,7 @@
 #
 #################################################################################
 
-from __future__ import with_statement
+
 
 # Enthought library imports
 from traits.api import Bool, Float

--- a/chaco/data_range_1d.py
+++ b/chaco/data_range_1d.py
@@ -6,9 +6,6 @@ Defines the DataRange1D class.
 # Major library imports
 from math import ceil, floor, log
 
-import six
-import six.moves as sm
-
 from numpy import compress, inf, isinf, isnan, ndarray
 
 # Enthought library imports
@@ -342,7 +339,7 @@ class DataRange1D(BaseDataRange):
                 self._high_value = self._high_setting
             return
         else:
-            mins, maxes = sm.zip(*bounds_list)
+            mins, maxes = zip(*bounds_list)
 
             low_start, high_start = \
                      calc_bounds(self._low_setting, self._high_setting,

--- a/chaco/errorbar_plot.py
+++ b/chaco/errorbar_plot.py
@@ -1,9 +1,6 @@
 
 from __future__ import with_statement
 
-import six
-import six.moves as sm
-
 # Major library imports
 from numpy import column_stack, compress, invert, isnan, transpose
 import logging
@@ -74,7 +71,7 @@ class ErrorBarPlot(LinePlot):
         value_high, value_high_mask = self.value_high.get_data_mask()
         value_mask = value_low_mask & value_high_mask
 
-        l1, l2, l3 = sm.map(len, (index, value_low, value_high))
+        l1, l2, l3 = map(len, (index, value_low, value_high))
         if 0 in (l1, l2, l3) or not (l1 == l2 == l3):
             logger.warning(
                 "Chaco: using empty dataset; index_len=%d, "

--- a/chaco/errorbar_plot.py
+++ b/chaco/errorbar_plot.py
@@ -1,5 +1,5 @@
 
-from __future__ import with_statement
+
 
 # Major library imports
 from numpy import column_stack, compress, invert, isnan, transpose

--- a/chaco/example_support.py
+++ b/chaco/example_support.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 
 doc = \
 """

--- a/chaco/filled_line_plot.py
+++ b/chaco/filled_line_plot.py
@@ -1,5 +1,5 @@
 
-from __future__ import with_statement
+
 
 from numpy import empty
 from traits.api import Property, Enum

--- a/chaco/grid.py
+++ b/chaco/grid.py
@@ -2,7 +2,7 @@
 function.
 """
 
-from __future__ import with_statement
+
 
 from numpy import around, array, asarray, column_stack, float64, inf, zeros, zeros_like
 

--- a/chaco/grid.py
+++ b/chaco/grid.py
@@ -4,8 +4,6 @@ function.
 
 from __future__ import with_statement
 
-import six
-
 from numpy import around, array, asarray, column_stack, float64, inf, zeros, zeros_like
 
 # Enthought library imports
@@ -30,7 +28,7 @@ def float_or_auto(val):
     try:
         return float(val)
     except:
-        if isinstance(val, six.string_types) and val == "auto":
+        if isinstance(val, str) and val == "auto":
             return val
     raise TraitError("Tick interval must be a number or 'auto'.")
 

--- a/chaco/horizon_plot.py
+++ b/chaco/horizon_plot.py
@@ -1,4 +1,4 @@
-from __future__ import with_statement
+
 
 from numpy import array, float64, full_like, ndarray, transpose
 from traits.api import Instance, DelegatesTo, Bool, Int

--- a/chaco/image_plot.py
+++ b/chaco/image_plot.py
@@ -9,7 +9,7 @@
 """ Defines the ImagePlot class.
 """
 
-from __future__ import with_statement
+
 
 # Standard library imports
 from math import ceil, floor, pi

--- a/chaco/image_plot.py
+++ b/chaco/image_plot.py
@@ -15,9 +15,6 @@ from __future__ import with_statement
 from math import ceil, floor, pi
 from contextlib import contextmanager
 
-import six
-import six.moves as sm
-
 import numpy as np
 
 # Enthought library imports.
@@ -329,7 +326,7 @@ class ImagePlot(Base2DPlot):
             col_max = array_width - col_max
             col_min, col_max = col_max, col_min
 
-        index_bounds = list(sm.map(int, [col_min, col_max, row_min, row_max]))
+        index_bounds = list(map(int, [col_min, col_max, row_min, row_max]))
         screen_rect = [x_min, y_min, x_max - x_min, y_max - y_min]
         return index_bounds, screen_rect
 

--- a/chaco/jitterplot.py
+++ b/chaco/jitterplot.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from math import sqrt
 
 import numpy as np

--- a/chaco/jitterplot.py
+++ b/chaco/jitterplot.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 from math import sqrt
 
-import six.moves as sm
-
 import numpy as np
 
 from traits.api import Any, Int
@@ -123,9 +121,9 @@ class JitterPlot(ScatterPlot1D):
             self._gather_points()
             pts = self.map_screen(self._cached_data)
             if self.orientation == "h":
-                self._cached_screen_map = dict((x,y) for x,y in sm.zip(pts[:,0], pts[:,1]))
+                self._cached_screen_map = dict((x,y) for x,y in zip(pts[:,0], pts[:,1]))
             else:
-                self._cached_screen_map = dict((y,x) for x,y in sm.zip(pts[:,0], pts[:,1]))
+                self._cached_screen_map = dict((y,x) for x,y in zip(pts[:,0], pts[:,1]))
             self._cached_screen_pts = pts
             self._screen_cache_valid = True
             self._cached_data_pts_sorted = None

--- a/chaco/label.py
+++ b/chaco/label.py
@@ -1,7 +1,7 @@
 """ Defines the Label class.
 """
 
-from __future__ import with_statement
+
 
 # Major library imports
 from math import cos, sin, pi

--- a/chaco/lasso_overlay.py
+++ b/chaco/lasso_overlay.py
@@ -1,7 +1,7 @@
 """ Defines the LassoOverlay class.
 """
 
-from __future__ import with_statement
+
 
 from numpy import concatenate, newaxis
 

--- a/chaco/layers/status_layer.py
+++ b/chaco/layers/status_layer.py
@@ -1,5 +1,5 @@
 
-from __future__ import with_statement
+
 
 import os.path
 import xml.etree.cElementTree as etree

--- a/chaco/layers/svg_range_selection_overlay.py
+++ b/chaco/layers/svg_range_selection_overlay.py
@@ -1,5 +1,5 @@
 
-from __future__ import with_statement
+
 
 import os
 import numpy

--- a/chaco/legend.py
+++ b/chaco/legend.py
@@ -2,7 +2,7 @@
 CompositeIconRenderer classes.
 """
 
-from __future__ import with_statement
+
 
 from numpy import array, zeros_like
 

--- a/chaco/legend.py
+++ b/chaco/legend.py
@@ -4,9 +4,6 @@ CompositeIconRenderer classes.
 
 from __future__ import with_statement
 
-import six
-import six.moves as sm
-
 from numpy import array, zeros_like
 
 from enable.api import black_color_trait, white_color_trait
@@ -39,7 +36,7 @@ class CompositeIconRenderer(AbstractCompositeIconRenderer):
     """
     def render_icon(self, plots, *render_args):
         """ Renders an icon for a list of plots. """
-        types = set(sm.map(type, plots))
+        types = set(map(type, plots))
         if types == set([ScatterPlot]):
             self._render_scatterplots(plots, *render_args)
         elif types == set([LinePlot]):
@@ -358,7 +355,7 @@ class Legend(AbstractOverlay):
         if len(self.plots) == 0:
             return [0, 0]
 
-        plot_names, visible_plots = list(sm.map(list, sm.zip(*sorted(self.plots.items()))))
+        plot_names, visible_plots = list(map(list, zip(*sorted(self.plots.items()))))
         label_names = self.labels
         if len(label_names) == 0:
             if len(self.plots) > 0:

--- a/chaco/line_scatterplot_1d.py
+++ b/chaco/line_scatterplot_1d.py
@@ -3,7 +3,7 @@ A 1D scatterplot that draws lines across the renderer at the index values
 
 """
 
-from __future__ import absolute_import
+
 
 from numpy import empty
 

--- a/chaco/lineplot.py
+++ b/chaco/lineplot.py
@@ -1,7 +1,7 @@
 """ Defines the LinePlot class.
 """
 
-from __future__ import with_statement
+
 
 # Standard library imports
 import warnings

--- a/chaco/multi_line_plot.py
+++ b/chaco/multi_line_plot.py
@@ -1,7 +1,7 @@
 """ Defines the MultiLinePlot class.
 """
 
-from __future__ import with_statement
+
 
 # Standard library imports
 import warnings

--- a/chaco/overlays/coordinate_line_overlay.py
+++ b/chaco/overlays/coordinate_line_overlay.py
@@ -4,7 +4,7 @@ This module defines the CoordinateLineOverlay class, a Chaco overlay
 for Plot (and similar) objects.
 """
 
-from __future__ import with_statement
+
 
 from traits.api import Instance, Float, Array
 from enable.api import black_color_trait, LineStyle, Component

--- a/chaco/overlays/databox.py
+++ b/chaco/overlays/databox.py
@@ -1,5 +1,5 @@
 
-from __future__ import with_statement
+
 
 from traits.api import (Bool, Enum, Float, Int, CList, Property, Trait,
         on_trait_change)

--- a/chaco/plot.py
+++ b/chaco/plot.py
@@ -4,8 +4,6 @@
 import itertools
 import warnings
 
-import six
-import six.moves as sm
 from numpy import arange, array, ndarray, linspace
 from types import FunctionType
 
@@ -315,7 +313,7 @@ class Plot(DataView):
         if len(data) == 0:
             return
 
-        if isinstance(data, six.string_types):
+        if isinstance(data, str):
             data = (data,)
 
         self.index_scale = index_scale
@@ -774,12 +772,12 @@ class Plot(DataView):
         array_data = value_ds.get_data()
 
         # process bounds to get linspaces
-        if isinstance(xbounds, six.string_types):
+        if isinstance(xbounds, str):
             xbounds = self._get_or_create_datasource(xbounds).get_data()
 
         xs = self._process_2d_bounds(xbounds, array_data, 1, cell_plot)
 
-        if isinstance(ybounds, six.string_types):
+        if isinstance(ybounds, str):
             ybounds = self._get_or_create_datasource(ybounds).get_data()
 
         ys = self._process_2d_bounds(ybounds, array_data, 0, cell_plot)
@@ -879,24 +877,24 @@ class Plot(DataView):
 
         # Create the datasources
         if len(data) == 3:
-            index, bar_min, bar_max = sm.map(self._get_or_create_datasource, data)
+            index, bar_min, bar_max = map(self._get_or_create_datasource, data)
             self.value_range.add(bar_min, bar_max)
             center = None
             min = None
             max = None
         elif len(data) == 4:
-            index, bar_min, center, bar_max = sm.map(self._get_or_create_datasource, data)
+            index, bar_min, center, bar_max = map(self._get_or_create_datasource, data)
             self.value_range.add(bar_min, center, bar_max)
             min = None
             max = None
         elif len(data) == 5:
             index, min, bar_min, bar_max, max = \
-                sm.map(self._get_or_create_datasource, data)
+                map(self._get_or_create_datasource, data)
             self.value_range.add(min, bar_min, bar_max, max)
             center = None
         elif len(data) == 6:
             index, min, bar_min, center, bar_max, max = \
-                sm.map(self._get_or_create_datasource, data)
+                map(self._get_or_create_datasource, data)
             self.value_range.add(min, bar_min, center, bar_max, max)
         self.index_range.add(index)
 
@@ -975,7 +973,7 @@ class Plot(DataView):
         if origin is None:
             origin = self.default_origin
 
-        index, value, vectors = list(sm.map(self._get_or_create_datasource, data))
+        index, value, vectors = list(map(self._get_or_create_datasource, data))
 
         self.index_range.add(index)
         self.value_range.add(value)
@@ -1034,7 +1032,7 @@ class Plot(DataView):
         if len(data) == 0:
             return
 
-        if isinstance(data, six.string_types):
+        if isinstance(data, str):
             data = (data,)
 
         # TODO: support lists of plot types
@@ -1348,7 +1346,7 @@ class Plot(DataView):
                 if new is not None:
                     new.add(datasource)
         range_name = name + "_range"
-        for renderer in itertools.chain(*six.itervalues(self.plots)):
+        for renderer in itertools.chain(*self.plots.values()):
             if hasattr(renderer, range_name):
                 setattr(renderer, range_name, new)
 

--- a/chaco/plot_graphics_context.py
+++ b/chaco/plot_graphics_context.py
@@ -1,7 +1,7 @@
 """ Defines the PlotGraphicsContext class.
 """
 
-from __future__ import with_statement
+
 
 from enable.kiva_graphics_context import GraphicsContext
 

--- a/chaco/plot_label.py
+++ b/chaco/plot_label.py
@@ -1,7 +1,7 @@
 """ Defines the PlotLabel class.
 """
 
-from __future__ import with_statement
+
 
 from enable.font_metrics_provider import font_metrics_provider
 from traits.api import DelegatesTo, Enum, Instance, Str, Trait

--- a/chaco/plotscrollbar.py
+++ b/chaco/plotscrollbar.py
@@ -1,7 +1,5 @@
 from __future__ import print_function
 
-import six.moves as sm
-
 from traits.api import Any, Enum, Int, Property, Trait
 
 from enable.api import NativeScrollBar

--- a/chaco/plotscrollbar.py
+++ b/chaco/plotscrollbar.py
@@ -84,7 +84,7 @@ class PlotScrollBar(NativeScrollBar):
         range = self.mapper.range
         bounds_list = [source.get_bounds() for source in range.sources \
                        if source.get_size() > 0]
-        mins, maxes = sm.zip(*bounds_list)
+        mins, maxes = zip(*bounds_list)
         dmin = min(mins)
         dmax = max(maxes)
 

--- a/chaco/plotscrollbar.py
+++ b/chaco/plotscrollbar.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 
 from traits.api import Any, Enum, Int, Property, Trait
 

--- a/chaco/polar_line_renderer.py
+++ b/chaco/polar_line_renderer.py
@@ -1,7 +1,7 @@
 """ Defines the PolarLineRenderer class.
 """
 
-from __future__ import with_statement
+
 
 # Major library imports
 from numpy import array, cos, pi, sin, transpose

--- a/chaco/polygon_plot.py
+++ b/chaco/polygon_plot.py
@@ -1,7 +1,7 @@
 """ Defines the PolygonPlot class.
 """
 
-from __future__ import with_statement
+
 
 # Major library imports
 import numpy as np

--- a/chaco/quiverplot.py
+++ b/chaco/quiverplot.py
@@ -1,5 +1,5 @@
 
-from __future__ import with_statement
+
 
 from numpy import array, compress, matrix, newaxis, sqrt, zeros
 

--- a/chaco/scales/formatters.py
+++ b/chaco/scales/formatters.py
@@ -132,9 +132,9 @@ class BasicFormatter(object):
         else:
             # For decimal mode,
             if not (ticks % 1).any():
-                labels = list(sm.map(str, ticks.astype(int)))
+                labels = list(map(str, ticks.astype(int)))
             else:
-                labels = list(sm.map(str, ticks))
+                labels = list(map(str, ticks))
 
         return labels
 
@@ -213,7 +213,7 @@ class BasicFormatter(object):
             return 0, 0
 
         # use the start and end points as ticks and average their label sizes
-        labelsizes = sm.map(len, self.format([start, end]))
+        labelsizes = map(len, self.format([start, end]))
         avg_size = sum(labelsizes) / 2.0
 
         if ticker:
@@ -240,7 +240,7 @@ class IntegerFormatter(BasicFormatter):
     def format(self, ticks, numlabels=None, char_width=None, fill_ratio=0.3):
         """ Formats integer tick labels.
         """
-        return list(sm.map(str, sm.map(int, ticks)))
+        return list(map(str, map(int, ticks)))
 
 
 class OffsetFormatter(BasicFormatter):
@@ -367,7 +367,7 @@ class OffsetFormatter(BasicFormatter):
         elif char_width:
             est_ticks = round(fill_ratio * char_width / avg_size)
 
-        start, mid, end = sm.map(len, self.format([start, (start+end)/2.0, end]))
+        start, mid, end = map(len, self.format([start, (start+end)/2.0, end]))
         if est_ticks > 2:
             size = start + end + (est_ticks-2) * mid
         else:

--- a/chaco/scales/formatters.py
+++ b/chaco/scales/formatters.py
@@ -4,9 +4,6 @@ Classes for formatting labels for values or times.
 
 from math import ceil, floor, fmod, log10
 
-import six
-import six.moves as sm
-
 from numpy import abs, all, array, asarray, amax, amin
 from .safetime import strftime, time, safe_fromtimestamp, localtime
 import warnings

--- a/chaco/scales/scales.py
+++ b/chaco/scales/scales.py
@@ -6,8 +6,6 @@ special handling of time and calendar axes.
 from bisect import bisect
 from math import ceil, floor, log10
 
-import six.moves as sm
-
 from numpy import abs, argmin, array, isnan, linspace
 
 # Local imports

--- a/chaco/scales/scales.py
+++ b/chaco/scales/scales.py
@@ -86,7 +86,7 @@ class AbstractScale(object):
         """
         ticks = self.ticks(start, end, numlabels)
         labels = self.formatter.format(ticks, numlabels, char_width)
-        return list(sm.zip(ticks, labels))
+        return list(zip(ticks, labels))
 
     def label_width(self, start, end, numlabels=None, char_width=None):
         """ Returns an estimate of the total number of characters used by the
@@ -509,7 +509,7 @@ class ScaleSystem(object):
                 else:
                     scales = self.scales
 
-            counts, widths = sm.zip(*[s.label_width(start, end, char_width=char_width) \
+            counts, widths = zip(*[s.label_width(start, end, char_width=char_width) \
                                       for s in scales])
             widths = array(widths)
             closest = argmin(abs(widths - char_width*self.fill_ratio))

--- a/chaco/scales/time_scale.py
+++ b/chaco/scales/time_scale.py
@@ -15,7 +15,7 @@ from .safetime import (safe_fromtimestamp, datetime, timedelta, EPOCH,
 # Labels for date and time units.
 datetime_scale = ["microsecond", "second", "minute", "hour",
                   "day", "month", "year"]
-datetime_zeros = list(sm.zip(datetime_scale, [0, 0, 0, 0, 1, 1, 1]))
+datetime_zeros = list(zip(datetime_scale, [0, 0, 0, 0, 1, 1, 1]))
 
 
 __all__ = ["TimeScale", "CalendarScaleSystem", "HMSScales", "MDYScales",
@@ -338,7 +338,7 @@ class TimeScale(AbstractScale):
         ticks = self.ticks(start, end, numlabels)
         labels = self.formatter.format(ticks, numlabels, char_width,
                                        ticker=self)
-        return list(sm.zip(ticks, labels))
+        return list(zip(ticks, labels))
 
     def label_width(self, start, end, numlabels=None, char_width=None):
         """ Returns an estimate of total number of characters used by the

--- a/chaco/scales/time_scale.py
+++ b/chaco/scales/time_scale.py
@@ -4,9 +4,6 @@ A scale for time and calendar intervals.
 
 from math import floor
 
-import six
-import six.moves as sm
-
 from .scales import AbstractScale, ScaleSystem, frange, heckbert_interval
 from .formatters import TimeFormatter
 from .safetime import (safe_fromtimestamp, datetime, timedelta, EPOCH,
@@ -69,7 +66,7 @@ def tfrac(t, **time_unit):
     =======
     A tuple: (aligned time as UNIX time, remainder in seconds)
     """
-    time_units = list(six.iteritems(time_unit))
+    time_units = list(time_unit.items())
     if len(time_unit) > 1:
         raise ValueError("tfrac() only takes one keyword argument, got %d" % len(time_units))
     unit, period = time_units[0]
@@ -166,7 +163,7 @@ def trange(start, end, **time_unit):
     A list of times that nicely span the interval, or an empty list if *start*
     and *end* fall within the same interval.
     """
-    time_units = list(six.iteritems(time_unit))
+    time_units = list(time_unit.items())
 
     if len(time_units) != 1:
         raise ValueError("trange() only takes one keyword argument, got %d" % len(time_units))
@@ -306,11 +303,11 @@ class TimeScale(AbstractScale):
         # get range of years of interest
         # add 2 because of python ranges + guard against timezone shifts
         # eg. if 20000101 -> 19991231 because of local timezone, end is 1999+2
-        years = sm.xrange(start_dt.year, min(end_dt.year+2, MAXYEAR+1))
+        years = range(start_dt.year, min(end_dt.year+2, MAXYEAR+1))
         if self.unit == "day_of_month":
             # get naive datetimes for start of each day of each month
             # in range of years.  Excess will be discarded later.
-            months = sm.xrange(1, 13)
+            months = range(1, 13)
             dates = [datetime(year, month, i)
                      for year in years for month in months for i in self.vals]
 
@@ -360,11 +357,11 @@ HMSScales = [TimeScale(microseconds=1), TimeScale(milliseconds=1)] + \
             [TimeScale(hours=dt) for dt in (1, 2, 3, 4, 6, 12, 24)]
 
 # Default time scale for months, days, and years.
-MDYScales = [TimeScale(day_of_month=list(sm.xrange(1,31,3))),
+MDYScales = [TimeScale(day_of_month=list(range(1,31,3))),
              TimeScale(day_of_month=(1,8,15,22)),
              TimeScale(day_of_month=(1,15)),
-             TimeScale(month_of_year=list(sm.xrange(1,13))),
-             TimeScale(month_of_year=list(sm.range(1,13,3))),
+             TimeScale(month_of_year=list(range(1,13))),
+             TimeScale(month_of_year=list(range(1,13,3))),
              TimeScale(month_of_year=(1,7)),
              TimeScale(month_of_year=(1,)),] + \
             [TimeScale(years=dt) for dt in (1,2,5,10)]

--- a/chaco/scales_tick_generator.py
+++ b/chaco/scales_tick_generator.py
@@ -1,8 +1,6 @@
 """ Defines the ScalesTickGenerator class.
 """
 
-import six.moves as sm
-
 from numpy import array
 
 from traits.api import Any

--- a/chaco/scales_tick_generator.py
+++ b/chaco/scales_tick_generator.py
@@ -41,7 +41,7 @@ class ScalesTickGenerator(AbstractTickGenerator):
         test_str = "0123456789-+"
         charsize = metrics.get_full_text_extent(test_str)[0] / len(test_str)
         numchars = (bounds_high - bounds_low) / charsize
-        tmp = list(sm.zip(*self.scale.labels(data_low, data_high, numlabels=8,
+        tmp = list(zip(*self.scale.labels(data_low, data_high, numlabels=8,
                                              char_width=numchars)))
         # Check to make sure we actually have labels/ticks to show before
         # unpacking the return tuple into (tick_array, labels).

--- a/chaco/scatter_inspector_overlay.py
+++ b/chaco/scatter_inspector_overlay.py
@@ -1,5 +1,5 @@
 
-from __future__ import with_statement
+
 
 # Major library imports
 from numpy import array, asarray

--- a/chaco/scatterplot.py
+++ b/chaco/scatterplot.py
@@ -81,7 +81,7 @@ def render_markers(gc, points, marker, marker_size,
         return
 
     # marker can be string, class, or instance
-    if isinstance(marker, six.string_types):
+    if isinstance(marker, str):
         marker = MarkerNameDict[marker]()
     elif issubclass(marker, AbstractMarker):
         marker = marker()
@@ -136,7 +136,7 @@ def render_markers(gc, points, marker, marker_size,
         if not marker.antialias:
             gc.set_antialias(False)
         if not isinstance(marker, CustomMarker):
-            for pt,size in sm.zip(points, marker_size):
+            for pt,size in zip(points, marker_size):
                 sx, sy = pt
                 with gc:
                     gc.translate_ctm(sx, sy)
@@ -145,7 +145,7 @@ def render_markers(gc, points, marker, marker_size,
                     gc.draw_path(marker.draw_mode)
         else:
             path = custom_symbol
-            for pt,size in sm.zip(points, marker_size):
+            for pt,size in zip(points, marker_size):
                 sx, sy = pt
                 with gc:
                     gc.translate_ctm(sx, sy)

--- a/chaco/scatterplot.py
+++ b/chaco/scatterplot.py
@@ -5,9 +5,6 @@ function.
 # Standard library imports
 import itertools
 
-import six
-import six.moves as sm
-
 # Major library imports
 from numpy import around, array, asarray, column_stack, \
     isfinite, isnan, nanargmin, ndarray, sqrt, sum, transpose, where

--- a/chaco/scatterplot_1d.py
+++ b/chaco/scatterplot_1d.py
@@ -3,7 +3,7 @@ Scatterplot in one dimension only
 """
 
 
-from __future__ import absolute_import
+
 
 from numpy import empty
 

--- a/chaco/selectable_overlay_container.py
+++ b/chaco/selectable_overlay_container.py
@@ -1,7 +1,7 @@
 """ Defines the SelectableOverlayPlotContainer class.
 """
 
-from __future__ import with_statement
+
 
 from numpy import array, float64
 

--- a/chaco/serializable.py
+++ b/chaco/serializable.py
@@ -1,7 +1,7 @@
 """ Defines the Serializable mix-in class.
 """
 
-from __future__ import print_function
+
 
 
 class Serializable(object):

--- a/chaco/shell/commands.py
+++ b/chaco/shell/commands.py
@@ -1,7 +1,7 @@
 """ Defines commands for the Chaco shell.
 """
 
-from __future__ import print_function
+
 
 try:
     from wx import GetApp

--- a/chaco/shell/commands.py
+++ b/chaco/shell/commands.py
@@ -230,7 +230,7 @@ def colormap(map):
          The color map to use; if it is a string, it is the name of a default
          colormap; if it is a callable, it must return an AbstractColorMap.
     """
-    if isinstance(map, six.string_types):
+    if isinstance(map, str):
         session.colormap = color_map_name_dict[map]
     else:
         session.colormap = map
@@ -696,7 +696,7 @@ def _set_scale(axis, system):
             ticks = p.y_ticks
         if system == 'time':
             system = CalendarScaleSystem()
-        if isinstance(system, six.string_types):
+        if isinstance(system, str):
             setattr(p, log_linear_trait, system)
         else:
             if system is None:

--- a/chaco/shell/commands.py
+++ b/chaco/shell/commands.py
@@ -3,9 +3,6 @@
 
 from __future__ import print_function
 
-import six
-import six.moves as sm
-
 try:
     from wx import GetApp
 except ImportError:

--- a/chaco/shell/plot_maker.py
+++ b/chaco/shell/plot_maker.py
@@ -7,8 +7,6 @@ from a set of user-supplied arguments.
 import io
 import re
 
-import six
-
 # Major library imports
 from numpy import all, array, arange, asarray, reshape, shape, transpose
 

--- a/chaco/shell/plot_maker.py
+++ b/chaco/shell/plot_maker.py
@@ -216,7 +216,7 @@ def _process_group(group, plot_data=None):
         # with a format string, or an x and y were provided.  If PlotData
         # was provided, use that to disambiguate; otherwise, assume that the
         # second string is a format string.
-        if isinstance(group[1], six.string_types):
+        if isinstance(group[1], str):
             if plot_data and group[1] in plot_data.list_data():
                 x = group[0]
                 y = group[1]
@@ -256,7 +256,7 @@ def do_plot(plotdata, active_plot, *data_and_formats, **kwtraits):
     groups = []
     valid_names = plotdata.list_data()
     for arg in data_and_formats:
-        if not isinstance(arg, six.string_types):
+        if not isinstance(arg, str):
             # an array was passed in
             cur_group.append(plotdata.set_data("", arg, generate_name=True))
         elif arg in valid_names:
@@ -312,7 +312,7 @@ def do_imread(*data, **kwargs):
     """ Returns image file as array. """
 
     # Check to see if the data given is either a file path or a file object
-    if isinstance(data[0], six.string_types) or isinstance(data[0], io.IOBase):
+    if isinstance(data[0], str) or isinstance(data[0], io.IOBase):
         return ImageData.fromfile(data[0])
     else:
         raise ValueError("do_imread takes a string filename")
@@ -405,7 +405,7 @@ def _get_or_create_plot_data(data, plotdata):
     """
     valid_names = plotdata.list_data()
 
-    if not isinstance(data, six.string_types):
+    if not isinstance(data, str):
         name = plotdata.set_data("", data, generate_name=True)
     else:
         if data not in valid_names:

--- a/chaco/shell/session.py
+++ b/chaco/shell/session.py
@@ -1,7 +1,7 @@
 """ Defines the PlotSession class.
 """
 
-from __future__ import print_function
+
 
 # Enthoght library imports
 from chaco.array_plot_data import ArrayPlotData

--- a/chaco/shell/session.py
+++ b/chaco/shell/session.py
@@ -82,7 +82,7 @@ class PlotSession(HasTraits):
 
     def get_window(self, ident):
         """ Retrieves a window either by index or by name """
-        if isinstance(ident, six.string_types):
+        if isinstance(ident, str):
             return self.window_map.get(ident, None)
         elif type(ident) == int and ident < len(self.windows):
             return self.windows[ident]
@@ -98,7 +98,7 @@ class PlotSession(HasTraits):
             The name of the window in **window_map**, or the index of the
             window in **windows**.
         """
-        if isinstance(ident, six.string_types):
+        if isinstance(ident, str):
             if ident in self.window_map:
                 win = self.window_map[ident]
                 del self.window_map[ident]
@@ -149,7 +149,7 @@ class PlotSession(HasTraits):
                 p.invalidate_draw()
                 p.request_redraw()
             elif hasattr(p, "colors"):
-                if isinstance(p.colors, six.string_types) or \
+                if isinstance(p.colors, str) or \
                    isinstance(p.colors, AbstractColormap):
                     p.colors = color_map_dict[self.colormap]
 

--- a/chaco/shell/session.py
+++ b/chaco/shell/session.py
@@ -3,8 +3,6 @@
 
 from __future__ import print_function
 
-import six
-
 # Enthoght library imports
 from chaco.array_plot_data import ArrayPlotData
 from chaco.default_colormaps import *

--- a/chaco/simple_plot_frame.py
+++ b/chaco/simple_plot_frame.py
@@ -8,7 +8,7 @@
 #
 #################################################################################
 
-from __future__ import with_statement
+
 
 # Enthought library imports
 from traits.api import Bool

--- a/chaco/subdivision_cells.py
+++ b/chaco/subdivision_cells.py
@@ -2,8 +2,6 @@
 """
 import itertools
 
-import six.moves as sm
-
 from numpy import take, array, concatenate, nonzero
 
 from traits.api import HasStrictTraits, Instance, Delegate, Array, List, \
@@ -220,7 +218,7 @@ class RangedCell(AbstractCell):
         return
 
     def _get_indices(self):
-        list_of_indices = [sm.xrange(i, j) for (i, j) in self._ranges]
+        list_of_indices = [range(i, j) for (i, j) in self._ranges]
         return list(itertools.chain(*list_of_indices))
 
 

--- a/chaco/subdivision_cells.py
+++ b/chaco/subdivision_cells.py
@@ -52,7 +52,7 @@ def arg_find_runs(int_array, order='ascending'):
     rshifted = right_shift(int_array, int_array[0]-increment)
     start_indices = concatenate([[0], nonzero(int_array - (rshifted+increment))[0]])
     end_indices = left_shift(start_indices, len(int_array))
-    return list(sm.zip(start_indices, end_indices))
+    return list(zip(start_indices, end_indices))
 
 
 class AbstractCell(HasStrictTraits):

--- a/chaco/subdivision_mapper.py
+++ b/chaco/subdivision_mapper.py
@@ -2,9 +2,6 @@
 """
 # Major library imports
 
-import six
-import six.moves as sm
-
 import math
 from numpy import array, arange, concatenate, searchsorted, nonzero, transpose, \
                   argsort, zeros, sort, vstack
@@ -169,7 +166,7 @@ class SubdivisionDataMapper(AbstractDataMapper):
             if celltype == RangedCell:
                 self._cellgrid[gridx,gridy].add_ranges([(start,end)])
             else:
-                self._cellgrid[gridx,gridy].add_indices(list(sm.xrange(start,end)))
+                self._cellgrid[gridx,gridy].add_indices(list(range(start,end)))
         return
 
     def _get_indices_for_points(self, pointlist):

--- a/chaco/subdivision_mapper.py
+++ b/chaco/subdivision_mapper.py
@@ -164,7 +164,7 @@ class SubdivisionDataMapper(AbstractDataMapper):
         start_indices = concatenate([[0], diff_indices])
         end_indices = concatenate([diff_indices, [len(self._data)]])
 
-        for start,end in sm.zip(start_indices, end_indices):
+        for start,end in zip(start_indices, end_indices):
             gridx, gridy = cell_indices[start]  # can use 'end' here just as well
             if celltype == RangedCell:
                 self._cellgrid[gridx,gridy].add_ranges([(start,end)])
@@ -200,7 +200,7 @@ class SubdivisionDataMapper(AbstractDataMapper):
         row_end_indices = left_shift(row_start_indices, len(cells))
 
         rects = []
-        for rownum, start, end in sm.zip(rownums, row_start_indices, row_end_indices):
+        for rownum, start, end in zip(rownums, row_start_indices, row_end_indices):
             # y_sorted is sorted by the J (row) coordinate, so after we
             # extract the column indices, we need to sort them before
             # passing them to find_runs().

--- a/chaco/svg_graphics_context.py
+++ b/chaco/svg_graphics_context.py
@@ -1,6 +1,6 @@
 """ Defines the PlotGraphicsContext class.
 """
-from __future__ import with_statement
+
 
 from kiva.svg import GraphicsContext
 

--- a/chaco/tests/test_arraydatasource.py
+++ b/chaco/tests/test_arraydatasource.py
@@ -6,9 +6,6 @@ import pickle
 
 import unittest
 
-import six
-import six.moves as sm
-
 from numpy import arange, array, allclose, empty, isnan, nan, ones
 from numpy.testing import assert_array_equal
 import numpy as np
@@ -178,7 +175,7 @@ class ArrayDataSourceTestCase(UnittestTools, unittest.TestCase):
 
     def test_bounds_non_numeric(self):
         myarray = np.array([u'abc', u'foo',
-                            u'bar', u'def'], dtype=six.text_type)
+                            u'bar', u'def'], dtype=str)
         data_source = ArrayDataSource(myarray)
         bounds = data_source.get_bounds()
         self.assertEqual(bounds, (u'abc', u'def'))
@@ -264,7 +261,7 @@ class PointDataTestCase(unittest.TestCase):
     # Since PointData is mostly the same as ScalarData, the key things to
     # test are functionality that use _compute_bounds() and reverse_map().
     def create_array(self):
-        return array(list(zip(list(sm.range(10)), list(sm.range(0, 100, 10)))))
+        return array(list(zip(list(range(10)), list(range(0, 100, 10)))))
 
     def test_basic_set_get(self):
         myarray = self.create_array()

--- a/chaco/tests/test_data_label.py
+++ b/chaco/tests/test_data_label.py
@@ -1,7 +1,5 @@
 import unittest
 
-import six.moves as sm
-
 from chaco.api import create_scatter_plot, PlotGraphicsContext, DataLabel
 
 
@@ -13,8 +11,8 @@ class DataLabelTestCase(unittest.TestCase):
         # arrow_visible=False in the DataLabel constructor) would raise an
         # exception because of an undefined reference.
         size = (50, 50)
-        plot = create_scatter_plot(data=[list(sm.xrange(10)),
-                                         list(sm.xrange(10))])
+        plot = create_scatter_plot(data=[list(range(10)),
+                                         list(range(10))])
         label = DataLabel(component=plot,
                           data_point=(4, 4),
                           marker_color="red",

--- a/chaco/tests/test_function_data_source.py
+++ b/chaco/tests/test_function_data_source.py
@@ -4,8 +4,6 @@ Test of FunctionDataSource behavior.
 
 import unittest
 
-import six.moves as sm
-
 from numpy import array, linspace, ones
 from numpy.testing import assert_array_equal
 
@@ -71,7 +69,7 @@ class FunctionDataSourceTestCase(UnittestTools, unittest.TestCase):
                            self.data_source.get_data())
 
     def test_set_mask(self):
-        mymask = array([i % 2 for i in sm.xrange(101)], dtype=bool)
+        mymask = array([i % 2 for i in range(101)], dtype=bool)
 
         with self.assertRaises(NotImplementedError):
             self.data_source.set_mask(mymask)

--- a/chaco/tests/test_image_plot.py
+++ b/chaco/tests/test_image_plot.py
@@ -3,8 +3,6 @@ import os
 import tempfile
 from contextlib import contextmanager
 
-import six
-
 import unittest
 
 import numpy as np

--- a/chaco/tests/test_scatterplot_renderers.py
+++ b/chaco/tests/test_scatterplot_renderers.py
@@ -1,7 +1,5 @@
 import unittest
 
-import six.moves as sm
-
 from numpy import alltrue
 from enable.compiled_path import CompiledPath
 
@@ -14,7 +12,7 @@ class DrawScatterplotCase(unittest.TestCase):
         """ Coverage test to check basic case works """
         size = (50, 50)
         scatterplot = create_scatter_plot(
-            data=[list(sm.xrange(10)), list(sm.xrange(10))],
+            data=[list(range(10)), list(range(10))],
             border_visible=False,
         )
         scatterplot.outer_bounds = list(size)
@@ -27,7 +25,7 @@ class DrawScatterplotCase(unittest.TestCase):
         """ Coverage test to check circles work """
         size = (50, 50)
         scatterplot = create_scatter_plot(
-            data=[list(sm.xrange(10)), list(sm.xrange(10))],
+            data=[list(range(10)), list(range(10))],
             marker="circle",
             border_visible=False,
         )
@@ -49,7 +47,7 @@ class DrawScatterplotCase(unittest.TestCase):
 
         size = (50, 50)
         scatterplot = create_scatter_plot(
-            data=[list(sm.xrange(10)), list(sm.xrange(10))],
+            data=[list(range(10)), list(range(10))],
             marker='custom',
             border_visible=False,
         )
@@ -64,10 +62,10 @@ class DrawScatterplotCase(unittest.TestCase):
         """ Coverage test to check multiple marker size works """
         size = (50, 50)
         scatterplot = create_scatter_plot(
-            data=[list(sm.xrange(10)), list(sm.xrange(10))],
+            data=[list(range(10)), list(range(10))],
             marker="circle",
             border_visible=False,
-            marker_size=list(sm.xrange(1, 11)),
+            marker_size=list(range(1, 11)),
         )
         scatterplot.outer_bounds = list(size)
         gc = PlotGraphicsContext(size)

--- a/chaco/tests/test_serializable.py
+++ b/chaco/tests/test_serializable.py
@@ -1,6 +1,7 @@
+import pickle
+import unittest
 import warnings
 
-import unittest
 
 # pickling child classes doesn't work well in the unittest framework unless
 # the classes to be pickled are in a different file
@@ -26,14 +27,14 @@ class SimpleSerializationTestCase(unittest.TestCase):
 
     def test_basic_save(self):
         c = Circle(radius=5.0, name="c1", x=1.0, y=2.0)
-        c2 = sm.cPickle.loads(sm.cPickle.dumps(c))
+        c2 = pickle.loads(pickle.dumps(c))
         for attrib in ("tools", "filled", "color", "x", "radius"):
             self.assertTrue(getattr(c, attrib) == getattr(c2, attrib))
         self.assertEqual(c2.y, 2.0)
 
     def test_basic_save2(self):
         p = Poly(numside=3, name="poly", x=3.0, y=4.0)
-        p2 = sm.cPickle.loads(sm.cPickle.dumps(p))
+        p2 = pickle.loads(pickle.dumps(p))
         for attrib in ("tools", "filled", "color", "x", "numsides", "length"):
             self.assertTrue(getattr(p, attrib) == getattr(p2, attrib))
         self.assertEqual(p2.y, 4.0)

--- a/chaco/tests/test_serializable.py
+++ b/chaco/tests/test_serializable.py
@@ -1,6 +1,5 @@
 import warnings
 
-import six.moves as sm
 import unittest
 
 # pickling child classes doesn't work well in the unittest framework unless

--- a/chaco/text_box_overlay.py
+++ b/chaco/text_box_overlay.py
@@ -1,6 +1,6 @@
 """ Defines the TextBoxOverlay class.
 """
-from __future__ import with_statement
+
 
 # Enthought library imports
 from enable.api import ColorTrait

--- a/chaco/text_plot.py
+++ b/chaco/text_plot.py
@@ -5,8 +5,6 @@ A plot that renders text values in two dimensions
 
 from __future__ import absolute_import
 
-import six.moves as sm
-
 from numpy import array, column_stack, empty, isfinite
 
 # Enthought library imports

--- a/chaco/text_plot.py
+++ b/chaco/text_plot.py
@@ -137,7 +137,7 @@ class TextPlot(BaseXYPlot):
 
         with gc:
             gc.clip_to_rect(self.x, self.y, self.width, self.height)
-            for pt, label, box in sm.zip(pts, labels, boxes):
+            for pt, label, box in zip(pts, labels, boxes):
                 with gc:
                     if self.h_position == "center":
                         offset[0] = -box[0] / 2 + self.text_offset[0]

--- a/chaco/text_plot.py
+++ b/chaco/text_plot.py
@@ -3,7 +3,7 @@ A plot that renders text values in two dimensions
 
 """
 
-from __future__ import absolute_import
+
 
 from numpy import array, column_stack, empty, isfinite
 

--- a/chaco/text_plot_1d.py
+++ b/chaco/text_plot_1d.py
@@ -110,7 +110,7 @@ class TextPlot1D(Base1DPlot):
     def _render(self, gc, pts, labels):
         with gc:
             gc.clip_to_rect(self.x, self.y, self.width, self.height)
-            for pt, label in sm.zip(pts, labels):
+            for pt, label in zip(pts, labels):
                 with gc:
                     x, y = self._get_index_text_position(gc, pt, label)
                     gc.translate_ctm(x, y)

--- a/chaco/text_plot_1d.py
+++ b/chaco/text_plot_1d.py
@@ -6,9 +6,6 @@ A plot that renders text values along one dimension
 
 from __future__ import absolute_import
 
-
-import six.moves as sm
-
 from numpy import array, empty
 
 # Enthought library imports

--- a/chaco/text_plot_1d.py
+++ b/chaco/text_plot_1d.py
@@ -4,7 +4,7 @@ A plot that renders text values along one dimension
 """
 
 
-from __future__ import absolute_import
+
 
 from numpy import array, empty
 

--- a/chaco/ticks.py
+++ b/chaco/ticks.py
@@ -13,7 +13,6 @@ tick-related values (i.e., bounds and intervals).
 
 """
 # Major library imports
-import six
 
 from numpy import arange, argsort, array, ceil, concatenate, equal, finfo, \
     float64, floor, linspace, log10, minimum, ndarray, newaxis, \

--- a/chaco/ticks.py
+++ b/chaco/ticks.py
@@ -161,12 +161,12 @@ def auto_ticks ( data_low, data_high, bound_low, bound_high, tick_interval,
     is_auto_low  = (bound_low  == 'auto')
     is_auto_high = (bound_high == 'auto')
 
-    if isinstance(bound_low, six.string_types):
+    if isinstance(bound_low, str):
         lower = data_low
     else:
         lower = float( bound_low )
 
-    if isinstance(bound_high, six.string_types):
+    if isinstance(bound_high, str):
         upper = data_high
     else:
         upper = float( bound_high )

--- a/chaco/tools/better_selecting_zoom.py
+++ b/chaco/tools/better_selecting_zoom.py
@@ -1,4 +1,4 @@
-from __future__ import with_statement
+
 
 import numpy
 

--- a/chaco/tools/cursor_tool.py
+++ b/chaco/tools/cursor_tool.py
@@ -13,7 +13,7 @@ TODO:
     plot component
 
 """
-from __future__ import with_statement
+
 
 # Major library imports
 import numpy

--- a/chaco/tools/dataprinter.py
+++ b/chaco/tools/dataprinter.py
@@ -1,7 +1,7 @@
 """ Defines the DataPrinter tool class.
 """
 
-from __future__ import print_function
+
 
 # Enthought library imports
 from traits.api import Str

--- a/chaco/tools/line_inspector.py
+++ b/chaco/tools/line_inspector.py
@@ -1,6 +1,6 @@
 """ Defines the LineInspector tool class.
 """
-from __future__ import with_statement
+
 
 # Enthought library imports
 from enable.api import BaseTool, ColorTrait, LineStyle

--- a/chaco/tools/line_segment_tool.py
+++ b/chaco/tools/line_segment_tool.py
@@ -1,6 +1,6 @@
 """ Defines the LineSegmentTool class.
 """
-from __future__ import with_statement
+
 
 # Major library imports
 from numpy import array

--- a/chaco/tools/point_marker.py
+++ b/chaco/tools/point_marker.py
@@ -1,6 +1,6 @@
 """ Defines the PointMarker tool class.
 """
-from __future__ import with_statement
+
 
 # Major library imports
 from numpy import array, take, transpose

--- a/chaco/tools/range_selection_overlay.py
+++ b/chaco/tools/range_selection_overlay.py
@@ -1,6 +1,6 @@
 """ Defines the RangeSelectionOverlay class.
 """
-from __future__ import with_statement
+
 
 # Major library imports
 from numpy import arange, array

--- a/chaco/tools/regression_lasso.py
+++ b/chaco/tools/regression_lasso.py
@@ -1,6 +1,6 @@
 """ Defines the RegressionLasso class.
 """
-from __future__ import with_statement
+
 
 # Major library imports
 from numpy import compress, polyfit

--- a/chaco/tools/simple_zoom.py
+++ b/chaco/tools/simple_zoom.py
@@ -1,6 +1,6 @@
 """ Defines the SimpleZoom class.
 """
-from __future__ import with_statement
+
 
 import warnings
 warnings.warn("SimpleZoom has been deprecated, use ZoomTool", DeprecationWarning)

--- a/chaco/tools/toolbars/plot_toolbar.py
+++ b/chaco/tools/toolbars/plot_toolbar.py
@@ -1,4 +1,4 @@
-from __future__ import with_statement
+
 
 import numpy
 

--- a/chaco/tools/toolbars/toolbar_buttons.py
+++ b/chaco/tools/toolbars/toolbar_buttons.py
@@ -1,5 +1,3 @@
-import six
-
 import numpy
 
 from traits.etsconfig.api import ETSConfig

--- a/chaco/tooltip.py
+++ b/chaco/tooltip.py
@@ -1,7 +1,7 @@
 """ Defines the ToolTip class.
 """
 
-from __future__ import with_statement
+
 
 from numpy import array
 

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -75,7 +75,6 @@ supported_combinations = {
 }
 
 dependencies = {
-    "six",
     "mock",
     "numpy",
     "pandas",

--- a/examples/demo/advanced/asynchronous_updates.py
+++ b/examples/demo/advanced/asynchronous_updates.py
@@ -11,8 +11,6 @@ thread and interrupts the movement of the slider.
 # Major library imports
 from numpy import ogrid, pi, sin
 
-import six.moves as sm
-
 # Enthought library imports
 from enable.api import Component, ComponentEditor
 from traits.api import (Array, Bool, DelegatesTo, HasTraits, Instance, Range,
@@ -157,7 +155,7 @@ def blur_image(image, blur_level):
     """ Blur the image using a potentially time-consuming algorithm """
 
     blurred_image = image.copy()
-    for _ in sm.xrange(blur_level**2):
+    for _ in range(blur_level**2):
         blurred_image[1:-1, 1:-1] += (
             blurred_image[:-2, 1:-1] +  # top
             blurred_image[2:, 1:-1] +  # bottom

--- a/examples/demo/advanced/data_cube.py
+++ b/examples/demo/advanced/data_cube.py
@@ -3,7 +3,7 @@ Allows isometric viewing of a 3D data cube.
 
 Click or click-drag in any data window to set the slice to view.
 """
-from __future__ import print_function
+
 import warnings
 
 # Outstanding TODOs:

--- a/examples/demo/advanced/data_cube.py
+++ b/examples/demo/advanced/data_cube.py
@@ -18,8 +18,6 @@ from numpy import amin, amax, zeros, fromfile, transpose, uint8
 # Standard library imports
 import os, sys, shutil
 
-import six.moves as sm
-
 # Major library imports
 from numpy import arange, linspace, nanmin, nanmax, newaxis, pi, sin, cos
 
@@ -319,7 +317,7 @@ def download_data():
     print('Please enter the location of the "voldata" subdirectory containing')
     print('the data files for this demo, or enter a path to download to (7.8MB).')
     print('Press <ENTER> to download to the current directory.')
-    dl_path = sm.input('Path: ').strip().rstrip("/").rstrip("\\")
+    dl_path = input('Path: ').strip().rstrip("/").rstrip("\\")
 
     if not dl_path.endswith("voldata"):
         voldata_path = os.path.join(dl_path, 'voldata')
@@ -383,7 +381,7 @@ def download_data():
 def cleanup_data():
     global dl_path
 
-    answer = sm.input('Remove downloaded files? [Y/N]: ')
+    answer = input('Remove downloaded files? [Y/N]: ')
     if answer.lower() == 'y':
         try:
             shutil.rmtree(os.path.join(dl_path, 'voldata'))

--- a/examples/demo/basic/image_lasso.py
+++ b/examples/demo/basic/image_lasso.py
@@ -5,7 +5,7 @@ plot.  The underlying plot is similar to the one in cmap_image_plot.py.
 
 Use Shift-drag to select multiple disjoint regions.
 """
-from __future__ import print_function
+
 
 # Major library imports
 from numpy import linspace, meshgrid, pi, sin

--- a/examples/demo/basic/line_drawing.py
+++ b/examples/demo/basic/line_drawing.py
@@ -16,7 +16,7 @@ Line segment drawing:
       drawn points will be reset.  By default, _finalize_selection() does nothing,
       but subclasses can customize this.
 """
-from __future__ import print_function
+
 
 # Major library imports
 from numpy import sort

--- a/examples/demo/basic/scatter_toggle.py
+++ b/examples/demo/basic/scatter_toggle.py
@@ -10,7 +10,7 @@ select or unselect them.
     - Mouse wheel to zoom
 
 """
-from __future__ import print_function
+
 
 # FIXME: the 'z' zoom interaction is ill-behaved.
 

--- a/examples/demo/canvas/data_source_button.py
+++ b/examples/demo/canvas/data_source_button.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 
 from random import choice
 from traits.api import Any, Enum, HasTraits, Instance, Int, List, Str

--- a/examples/demo/noninteractive.py
+++ b/examples/demo/noninteractive.py
@@ -3,7 +3,7 @@
 This demonstrates how to create a plot offscreen and save it to an image
 file on disk.
 """
-from __future__ import print_function
+
 
 # Standard library imports
 import os

--- a/examples/demo/world_map.py
+++ b/examples/demo/world_map.py
@@ -12,7 +12,7 @@ negative values.
 
 # Standard library imports
 import os.path
-from six.moves.urllib import request
+from urllib import request
 
 # Major library imports
 import numpy

--- a/examples/tutorials/scipy2008/custom_tool.py
+++ b/examples/tutorials/scipy2008/custom_tool.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 
 from numpy import linspace, sin
 

--- a/examples/tutorials/scipy2008/custom_tool_click.py
+++ b/examples/tutorials/scipy2008/custom_tool_click.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 
 from numpy import linspace, sin
 

--- a/examples/tutorials/scipy2008/custom_tool_screen.py
+++ b/examples/tutorials/scipy2008/custom_tool_screen.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 
 from numpy import linspace, sin
 

--- a/examples/tutorials/tutorial6.py
+++ b/examples/tutorials/tutorial6.py
@@ -2,7 +2,7 @@
 
 We write an interactor tha prints out all the events it receives.
 """
-from __future__ import print_function
+
 
 from chaco.api import AbstractController
 

--- a/examples/tutorials/tutorial7.py
+++ b/examples/tutorials/tutorial7.py
@@ -1,5 +1,5 @@
 """Tutorial 7. Writing a tool (cont.) - Looking at data space"""
-from __future__ import print_function
+
 
 from chaco.api import AbstractController
 

--- a/examples/user_guide/plot_types/create_plot_snapshots.py
+++ b/examples/user_guide/plot_types/create_plot_snapshots.py
@@ -2,7 +2,7 @@
 
 Relies on sklearn for the datasets.
 """
-from __future__ import print_function
+
 
 import argparse
 from functools import partial


### PR DESCRIPTION
Part of #483 

This PR removes all use of `six` and also removes all `__future__` imports (only imports were for `with_statement`, `print_function`, and `absolute_import`).

It also drive by removes a few lines of commented out code