### PR TITLE
Remove python version checks

### DIFF
--- a/chaco/contour/cntr.c
+++ b/chaco/contour/cntr.c
@@ -1700,19 +1700,14 @@ static PyMethodDef module_methods[] = {
 };
 
 
-#if PY_MAJOR_VERSION >= 3
-    #define MOD_INIT(name) PyMODINIT_FUNC PyInit_##name(void)
-	#define RETURN_MODINIT return m
-#else
-    #define MOD_INIT(name) PyMODINIT_FUNC init##name(void)
-	#define RETURN_MODINIT return
-#endif
+#define MOD_INIT(name) PyMODINIT_FUNC PyInit_##name(void)
+#define RETURN_MODINIT return m
 
 
 MOD_INIT(contour)
 {
     PyObject* m = NULL;
-#if PY_MAJOR_VERSION >= 3    
+  
     static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         "contour",     /* m_name */
@@ -1724,16 +1719,12 @@ MOD_INIT(contour)
         NULL,                /* m_clear */
         NULL,                /* m_free */
     };
-#endif
+
     if (PyType_Ready(&CntrType) < 0)
         RETURN_MODINIT;
 
-#if PY_MAJOR_VERSION >= 3
+
     m = PyModule_Create(&moduledef);
-#else
-    m = Py_InitModule3("contour", module_methods,
-                       "Contouring engine as an extension type");
-#endif
 
     if (m == NULL)
     	RETURN_MODINIT;

--- a/examples/demo/noninteractive.py
+++ b/examples/demo/noninteractive.py
@@ -88,13 +88,7 @@ def get_directory(filename):
     print('Please enter a path in which to place generated plots.')
     print('Press <ENTER> to generate in the current directory.')
 
-    # If python 2.7, use raw_input to parse empty string correctly
-    try:
-        get_input = raw_input
-    except NameError:
-        get_input = input
-
-    path = get_input('Path: ').strip()
+    path = input('Path: ').strip()
 
     if len(path) > 0 and not os.path.exists(path):
         print('The given path does not exist.')


### PR DESCRIPTION
part of #483 

This PR removes a few checks for a specific python version and only keeps code specific to python 3+.


Based on this comment: https://github.com/enthought/chaco/blob/4a6683521cce012b5df4830d64f41518798fc817/docs/scipy_tutorial/Scripts/shBrushPython.js#L1
I suspect we Can remove this .js file entirely?