### PR TITLE
Replace all jet color map use in examples with viridis

### DIFF
--- a/examples/demo/advanced/cmap_variable_sized_scatter.py
+++ b/examples/demo/advanced/cmap_variable_sized_scatter.py
@@ -19,7 +19,7 @@ from traitsui.api import Item, Group, View
 
 # Chaco imports
 from chaco.api import ArrayPlotData, Plot, ColormappedScatterPlot, \
-        LinearMapper, ArrayDataSource, jet, DataRange1D
+        LinearMapper, ArrayDataSource, viridis, DataRange1D
 from chaco.tools.api import PanTool, ZoomTool
 
 #===============================================================================
@@ -61,7 +61,7 @@ def _create_plot_component():
                     index=index_ds,
                     value=value_ds,
                     color_data=color_ds,
-                    color_mapper=jet(range=DataRange1D(low=0.0, high=1.0)),
+                    color_mapper=viridis(range=DataRange1D(low=0.0, high=1.0)),
                     fill_alpha=0.4,
                     index_mapper = imapper,
                     value_mapper = vmapper,

--- a/examples/demo/advanced/data_cube.py
+++ b/examples/demo/advanced/data_cube.py
@@ -182,7 +182,7 @@ class PlotFrame(DemoFrame):
     # Private Traits
     #---------------------------------------------------------------------------
 
-    _cmap = Trait(jet, Callable)
+    _cmap = Trait(viridis, Callable)
 
     def _index_callback(self, tool, x_index, y_index):
         plane = tool.token
@@ -226,15 +226,8 @@ class PlotFrame(DemoFrame):
 
     def _create_window(self):
         # Create the model
-        #try:
-        #    self.model = model = BrainModel()
-        #    cmap = bone
-        #except SystemExit:
-        #    sys.exit()
-        #except:
-        #    print "Unable to load BrainModel, using generated data cube."
         self.model = model = Model()
-        cmap = jet
+        cmap = viridis
         self._update_model(cmap)
 
         datacube = self.colorcube

--- a/examples/demo/advanced/scalar_image_function_inspector.py
+++ b/examples/demo/advanced/scalar_image_function_inspector.py
@@ -157,7 +157,7 @@ class PlotUI(HasTraits):
     _image_index = Instance(GridDataSource)
     _image_value = Instance(ImageData)
 
-    _cmap = Trait(default_colormaps.jet, Callable)
+    _cmap = Trait(default_colormaps.viridis, Callable)
 
     #---------------------------------------------------------------------------
     # Public View interface
@@ -542,7 +542,7 @@ def main(argv=None):
     parser = OptionParser(usage=usage, version="%prog 1.0")
 
     parser.add_option("-c", "--colormap",
-                  action="store", type="string", dest="colormap", default="jet",
+                  action="store", type="string", dest="colormap", default="viridis",
                   metavar="CMAP", help="choose a default colormapper")
 
     parser.add_option("-n", "--nlevels",

--- a/examples/demo/advanced/scalar_image_function_inspector_old.py
+++ b/examples/demo/advanced/scalar_image_function_inspector_old.py
@@ -123,7 +123,7 @@ class PlotUI(HasTraits):
     _image_index = Instance(GridDataSource)
     _image_value = Instance(ImageData)
 
-    _cmap = Trait(jet, Callable)
+    _cmap = Trait(viridis, Callable)
 
     #---------------------------------------------------------------------------
     # Public View interface
@@ -396,7 +396,7 @@ class ModelView(HasTraits):
         if self.model is not None and self.view is not None:
             self.view.update(self.model)
 
-options_dict = {'colormap' : "jet",
+options_dict = {'colormap' : "viridis",
                 'num_levels' : 15,
                 'function' : "tanh(x**2+y)*cos(y)*jn(0,x+y*2)"}
 model=Model(**options_dict)
@@ -418,7 +418,7 @@ def main(argv=None):
     parser = OptionParser(usage=usage, version="%prog 1.0")
 
     parser.add_option("-c", "--colormap",
-                  action="store", type="string", dest="colormap", default="jet",
+                  action="store", type="string", dest="colormap", default="viridis",
                   metavar="CMAP", help="choose a default colormapper")
 
     parser.add_option("-n", "--nlevels",

--- a/examples/demo/basic/cmap_image_aspect_ratio.py
+++ b/examples/demo/basic/cmap_image_aspect_ratio.py
@@ -18,7 +18,7 @@ from traits.api import HasTraits, Instance
 from traitsui.api import Item, Group, View
 
 # Chaco imports
-from chaco.api import ArrayPlotData, jet, Plot
+from chaco.api import ArrayPlotData, viridis, Plot
 from chaco.tools.api import PanTool, ZoomTool
 
 #===============================================================================
@@ -40,7 +40,7 @@ def _create_plot_component():
     img_plot = plot.img_plot("imagedata",
                              xbounds=(0, 10),
                              ybounds=(0, 5),
-                             colormap=jet)[0]
+                             colormap=viridis)[0]
     img_plot.index_mapper.aspect_ratio = 0.5
     img_plot.index_mapper.maintain_aspect_ratio = True
 

--- a/examples/demo/basic/cmap_image_plot.py
+++ b/examples/demo/basic/cmap_image_plot.py
@@ -18,7 +18,7 @@ from traits.api import HasTraits, Instance
 from traitsui.api import Item, Group, View
 
 # Chaco imports
-from chaco.api import ArrayPlotData, jet, Plot
+from chaco.api import ArrayPlotData, viridis, Plot
 from chaco.tools.api import PanTool, ZoomTool
 
 #===============================================================================
@@ -40,7 +40,7 @@ def _create_plot_component():
     img_plot = plot.img_plot("imagedata",
                              xbounds=(0, 10),
                              ybounds=(0, 5),
-                             colormap=jet)[0]
+                             colormap=viridis)[0]
 
     # Tweak some of the plot properties
     plot.title = "My First Image Plot"

--- a/examples/demo/basic/cmap_image_select.py
+++ b/examples/demo/basic/cmap_image_select.py
@@ -19,7 +19,7 @@ from traits.api import HasTraits, Instance
 from traitsui.api import Item, Group, View
 
 # Chaco imports
-from chaco.api import ArrayPlotData, ColorBar, HPlotContainer, jet, \
+from chaco.api import ArrayPlotData, ColorBar, HPlotContainer, viridis, \
                                  LinearMapper, Plot
 from chaco.tools.api import PanTool, RangeSelection, \
                                        RangeSelectionOverlay, ZoomTool
@@ -46,7 +46,7 @@ def _create_plot_component():
                   name="my_plot",
                   xbounds=xbounds[:2],
                   ybounds=ybounds[:2],
-                  colormap=jet)
+                  colormap=viridis)
 
     # Tweak some of the plot properties
     plot.title = "Selectable Image Plot"

--- a/examples/demo/basic/cmap_scatter.py
+++ b/examples/demo/basic/cmap_scatter.py
@@ -21,7 +21,7 @@ from traitsui.api import Item, VGroup, View, Label
 # Chaco imports
 from chaco.api import ArrayPlotData, ColorBar, \
                                  ColormappedSelectionOverlay, HPlotContainer, \
-                                 jet, LinearMapper, Plot
+                                 viridis, LinearMapper, Plot
 from chaco.tools.api import PanTool, ZoomTool, RangeSelection, \
                                        RangeSelectionOverlay
 
@@ -47,7 +47,7 @@ def _create_plot_component():
     plot.plot(("index", "value", "color"),
               type="cmap_scatter",
               name="my_plot",
-              color_mapper=jet,
+              color_mapper=viridis,
               marker = "square",
               fill_alpha = 0.5,
               marker_size = 6,

--- a/examples/demo/basic/contour_plot.py
+++ b/examples/demo/basic/contour_plot.py
@@ -19,7 +19,7 @@ from traits.api import HasTraits, Instance
 from traitsui.api import Item, Group, View
 
 # Chaco imports
-from chaco.api import ArrayPlotData, jet, Plot
+from chaco.api import ArrayPlotData, viridis, Plot
 from chaco.tools.api import PanTool, ZoomTool
 
 #===============================================================================
@@ -49,7 +49,7 @@ def _create_plot_component():
     plot = Plot(pd, default_origin="bottom left")
     plot.contour_plot("imagedata",
                       type="poly",
-                      poly_cmap=jet,
+                      poly_cmap=viridis,
                       xbounds=x,
                       ybounds=y)
 

--- a/examples/demo/basic/discrete_cmap_image_plot.py
+++ b/examples/demo/basic/discrete_cmap_image_plot.py
@@ -19,7 +19,6 @@ from traitsui.api import Item, Group, View
 
 # Chaco imports
 from chaco.api import ArrayPlotData, viridis, Plot
-from chaco.default_colormaps import accent
 from chaco.tools.api import PanTool, ZoomTool
 
 #===============================================================================
@@ -41,7 +40,7 @@ def _create_plot_component():
     img_plot = plot.img_plot("imagedata",
                              xbounds=(0, 10),
                              ybounds=(0, 5),
-                             colormap=accent)[0]
+                             colormap=viridis)[0]
 
     # Tweak some of the plot properties
     plot.title = "My First Image Plot"

--- a/examples/demo/basic/discrete_cmap_image_plot.py
+++ b/examples/demo/basic/discrete_cmap_image_plot.py
@@ -18,7 +18,7 @@ from traits.api import HasTraits, Instance
 from traitsui.api import Item, Group, View
 
 # Chaco imports
-from chaco.api import ArrayPlotData, jet, Plot
+from chaco.api import ArrayPlotData, viridis, Plot
 from chaco.default_colormaps import accent
 from chaco.tools.api import PanTool, ZoomTool
 

--- a/examples/demo/basic/image_inspector.py
+++ b/examples/demo/basic/image_inspector.py
@@ -22,7 +22,7 @@ from traits.api import HasTraits, Instance
 from traitsui.api import Item, Group, View
 
 # Chaco imports
-from chaco.api import ArrayPlotData, jet, Plot
+from chaco.api import ArrayPlotData, viridis, Plot
 from chaco.tools.api import PanTool, ZoomTool
 from chaco.tools.image_inspector_tool import ImageInspectorTool, \
      ImageInspectorOverlay
@@ -47,7 +47,7 @@ def _create_plot_component():# Create a scalar field to colormap
     img_plot = plot.img_plot("imagedata",
                              xbounds = xbounds[:2],
                              ybounds = ybounds[:2],
-                             colormap=jet)[0]
+                             colormap=viridis)[0]
 
     # Tweak some of the plot properties
     plot.title = "My First Image Plot"

--- a/examples/demo/basic/image_lasso.py
+++ b/examples/demo/basic/image_lasso.py
@@ -16,7 +16,7 @@ from traits.api import HasTraits, Instance
 from traitsui.api import Item, Group, View
 
 # Chaco imports
-from chaco.api import ArrayPlotData, jet, Plot, LassoOverlay
+from chaco.api import ArrayPlotData, viridis, Plot, LassoOverlay
 from chaco.tools.api import LassoSelection, LassoSelection
 
 #===============================================================================
@@ -55,7 +55,7 @@ def _create_plot_component():# Create a scalar field to colormap
     img_plot = plot.img_plot("imagedata",
                              xbounds=xbounds[:2],
                              ybounds=ybounds[:2],
-                             colormap=jet)[0]
+                             colormap=viridis)[0]
 
     # Tweak some of the plot properties
     plot.title = "Image Plot with Lasso"

--- a/examples/demo/canvas/canvas.py
+++ b/examples/demo/canvas/canvas.py
@@ -25,7 +25,7 @@ from traits.api import Any, Bool, Enum, Float, HasTraits, Instance, \
 
 # Chaco imports
 from chaco.api import AbstractOverlay, ArrayPlotData, \
-        Plot, jet, ScatterPlot, LinePlot, LinearMapper
+        Plot, viridis, ScatterPlot, LinePlot, LinearMapper
 from chaco.tools.api import PanTool, ZoomTool , LegendTool
 
 # Canvas imports

--- a/examples/demo/canvas/canvas.py
+++ b/examples/demo/canvas/canvas.py
@@ -25,7 +25,7 @@ from traits.api import Any, Bool, Enum, Float, HasTraits, Instance, \
 
 # Chaco imports
 from chaco.api import AbstractOverlay, ArrayPlotData, \
-        Plot, viridis, ScatterPlot, LinePlot, LinearMapper
+        Plot, ScatterPlot, LinePlot, LinearMapper
 from chaco.tools.api import PanTool, ZoomTool , LegendTool
 
 # Canvas imports

--- a/examples/demo/cursor_tool_demo.py
+++ b/examples/demo/cursor_tool_demo.py
@@ -14,7 +14,7 @@ import numpy
 
 # Enthought library imports
 from chaco.api import create_line_plot, OverlayPlotContainer, \
-             HPlotContainer, Plot, ArrayPlotData, jet
+             HPlotContainer, Plot, ArrayPlotData, viridis
 from chaco.tools.api import PanTool, ZoomTool
 from chaco.tools.cursor_tool import CursorTool, BaseCursorTool
 from enable.component_editor import ComponentEditor
@@ -81,7 +81,7 @@ class CursorTest(HasTraits):
         cmapImgPlot = img.img_plot("img",
                      xbounds = xy_range,
                      ybounds = xy_range,
-                     colormap = jet)[0]
+                     colormap = viridis)[0]
 
         container.add(img)
 

--- a/examples/demo/nonlinear_color_mapping.py
+++ b/examples/demo/nonlinear_color_mapping.py
@@ -16,7 +16,7 @@ from traitsui.api import Item, UItem, HGroup, View, RangeEditor
 # Chaco imports
 from chaco.api import ArrayPlotData, Plot, ColorBar, HPlotContainer, \
                       LinearMapper, LogMapper, CMapImagePlot, \
-                      TransformColorMapper, jet
+                      TransformColorMapper, viridis
 from chaco.tools.api import PanTool, ZoomTool
 
 
@@ -103,7 +103,7 @@ def _create_plot_component(model):
     plot = Plot(pd, padding=50)
 
     # Use a TransformColorMapper for the color map.
-    tcm = TransformColorMapper.from_color_map(jet)
+    tcm = TransformColorMapper.from_color_map(viridis)
 
     # Create the image plot renderer in the main plot.
     renderer = plot.img_plot("imagedata", 

--- a/examples/demo/shell/add_tool.py
+++ b/examples/demo/shell/add_tool.py
@@ -11,7 +11,7 @@ from numpy import linspace, meshgrid, sin
 
 # Enthought library imports
 from chaco.shell import show, title, pcolor, colormap, curplot
-from chaco.default_colormaps import jet
+from chaco.default_colormaps import viridis
 
 # Crate some scalar data
 xs = linspace(0,10,200)
@@ -23,7 +23,7 @@ z = sin(x)*y
 pcolor(x, y, z, name='sin_x_times_y')
 
 # Change the color mapping
-colormap(jet)
+colormap(viridis)
 
 # Add some titles
 title("pseudo colormap image plot")

--- a/examples/demo/shell/contourf.py
+++ b/examples/demo/shell/contourf.py
@@ -8,7 +8,7 @@ from numpy import linspace, meshgrid, tanh
 
 # Enthought Library Imports
 from chaco.shell import contourf, colormap, title, show
-from chaco.default_colormaps import jet
+from chaco.default_colormaps import viridis
 
 
 # Crate some scalar data
@@ -19,7 +19,7 @@ z = x * tanh(y)
 
 # Create a filled contour plot
 contourf(x,y,z)
-colormap(jet)
+colormap(viridis)
 
 # Add some titles
 title("filled contour plot")

--- a/examples/demo/shell/pcolor.py
+++ b/examples/demo/shell/pcolor.py
@@ -10,7 +10,7 @@ from numpy import linspace, meshgrid, sin
 
 # Enthought library imports
 from chaco.shell import show, title, pcolor, colormap
-from chaco.default_colormaps import jet
+from chaco.default_colormaps import viridis
 
 
 # Crate some scalar data
@@ -23,7 +23,7 @@ z = sin(x) * y
 pcolor(x,y,z)
 
 #change the color mapping
-colormap(jet)
+colormap(viridis)
 
 # Add some titles
 title("pseudo colormap image plot")

--- a/examples/demo/vtk/cmap_scatter.py
+++ b/examples/demo/vtk/cmap_scatter.py
@@ -22,7 +22,7 @@ from enable.vtk_backend.vtk_window import EnableVTKWindow
 # Chaco imports
 from chaco.api import ArrayPlotData, ColorBar, \
     ColormappedSelectionOverlay, OverlayPlotContainer, \
-    jet, LinearMapper, Plot
+    viridis, LinearMapper, Plot
 from chaco.tools.api import PanTool, ZoomTool, RangeSelection, \
     RangeSelectionOverlay, MoveTool
 
@@ -48,7 +48,7 @@ def create_plot():
     plot.plot(("index", "value", "color"),
               type="cmap_scatter",
               name="my_plot",
-              color_mapper=jet,
+              color_mapper=viridis,
               marker = "square",
               fill_alpha = 0.5,
               marker_size = 6,

--- a/examples/demo/vtk/spectrum.py
+++ b/examples/demo/vtk/spectrum.py
@@ -11,7 +11,7 @@ from numpy import zeros, linspace, short, fromstring, hstack, transpose
 from scipy import fft
 
 # Enthought library imports
-from chaco.default_colormaps import jet
+from chaco.default_colormaps import viridis
 from traits.api import HasTraits, Any
 
 # Chaco imports
@@ -72,7 +72,7 @@ def create_plot_component(obj):
                               name='Spectrogram',
                               xbounds=xbounds,
                               ybounds=ybounds,
-                              colormap=jet,
+                              colormap=viridis,
                               )
     range_obj = spectrogram_plot.plots['Spectrogram'][0].value_mapper.range
     range_obj.high = 5

--- a/examples/tutorials/scipy2008/image.py
+++ b/examples/tutorials/scipy2008/image.py
@@ -1,7 +1,7 @@
 
 from numpy import linspace, meshgrid, exp
 
-from chaco.api import ArrayPlotData, Plot, jet
+from chaco.api import ArrayPlotData, Plot, viridis
 from enable.component_editor import ComponentEditor
 from traits.api import HasTraits, Instance
 from traitsui.api import Item, View
@@ -27,7 +27,7 @@ class ImagePlot(HasTraits):
         # Create a Plot and associate it with the PlotData
         plot = Plot(plotdata)
         # Create an image plot in the Plot
-        plot.img_plot("imagedata", colormap=jet)
+        plot.img_plot("imagedata", colormap=viridis)
         self.plot = plot
 
 #===============================================================================

--- a/examples/tutorials/scipy2008/traits_image.py
+++ b/examples/tutorials/scipy2008/traits_image.py
@@ -1,7 +1,7 @@
 
 from numpy import linspace, meshgrid, exp
 
-from chaco.api import ArrayPlotData, Plot, jet
+from chaco.api import ArrayPlotData, Plot, viridis
 from enable.component_editor import ComponentEditor
 from traits.api import Enum, HasTraits, Instance
 from traitsui.api import Group, Item, View
@@ -33,7 +33,7 @@ class ImagePlotTraits(HasTraits):
         plot = Plot(plotdata)
         # Create an image plot in the Plot
         self.renderer = plot.img_plot("imagedata", name="plot1",
-                                      xbounds=xgrid, ybounds=ygrid, colormap=jet)[0]
+                                      xbounds=xgrid, ybounds=ygrid, colormap=viridis)[0]
         self.plot = plot
 
     def _origin_changed(self):

--- a/examples/user_guide/h_plot_container_colorbar.py
+++ b/examples/user_guide/h_plot_container_colorbar.py
@@ -1,4 +1,4 @@
-from chaco.api import ArrayPlotData, HPlotContainer, Plot, jet, ColorBar
+from chaco.api import ArrayPlotData, HPlotContainer, Plot, viridis, ColorBar
 from enable.component_editor import ComponentEditor
 from traits.api import HasTraits, Instance
 from traitsui.api import Item, View
@@ -27,7 +27,7 @@ class ColorbarExample(HasTraits):
         # Create the plot
         plot = Plot(data)
         plot.plot(("index", "value", "color"), type="cmap_scatter",
-                  color_mapper=jet)
+                  color_mapper=viridis)
 
         # Create the colorbar, handing in the appropriate range and colormap
         colormap = plot.color_mapper


### PR DESCRIPTION
fixes #552 

This PR replaces all uses of the jet color map in the examples with viridis.  To do this VS Code replace all was used with
jet->viridis on all files in the examples sub module.  
Some examples may be better suited with a color map different from viridis, but I did not take the time to chose a color map on a per example basis.  I figured at the very least viridis should be better than jet.

If it is needed for particular examples to use a different color map they can be handled specifically