### PR TITLE
Update api docs

### DIFF
--- a/docs/source/api/axis.rst
+++ b/docs/source/api/axis.rst
@@ -3,7 +3,7 @@
 Axis and Grid
 --------------
 
-.. currentmodule:: chaco.api
+.. currentmodule:: chaco.axis
 
 :class:`PlotAxis`
 ==========================
@@ -11,17 +11,28 @@ Axis and Grid
     :members:
     :show-inheritance:
 
+:class:`MinorPlotAxis`
+==========================
+.. autoclass:: MinorPlotAxis
+    :members:
+    :show-inheritance:
+.. currentmodule:: chaco.label_axis
+
 :class:`LabelAxis`
 ==========================
 .. autoclass:: LabelAxis
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.grid
+
 :class:`PlotGrid`
 ==========================
 .. autoclass:: PlotGrid
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.ticks
 
 :class:`AbstractTickGenerator`
 ===============================

--- a/docs/source/api/containers.rst
+++ b/docs/source/api/containers.rst
@@ -4,13 +4,15 @@
 Containers
 ----------
 
-.. currentmodule:: chaco.api
+.. currentmodule:: chaco.base_plot_container
 
 :class:`BasePlotContainer`
 ==========================
 .. autoclass:: BasePlotContainer
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.plot_containers
 
 :class:`OverlayPlotContainer`
 =============================
@@ -35,6 +37,14 @@ Containers
 .. autoclass:: GridPlotContainer
     :members:
     :show-inheritance:
+
+:class:`StackedPlotContainer`
+=============================
+.. autoclass:: StackedPlotContainer
+    :members:
+    :show-inheritance:
+
+.. currentmodule:: chaco.selectable_overlay_container
 
 :class:`SelectableOverlayPlotContainer`
 =======================================

--- a/docs/source/api/data_ranges.rst
+++ b/docs/source/api/data_ranges.rst
@@ -1,10 +1,10 @@
 
-.. _data_ranges:
+.. _data_ranges_api:
 
 Data Ranges
 -----------
 
-.. currentmodule:: chaco.api
+.. currentmodule:: chaco.abstract_data_range
 
 :class:`AbstractDataRange`
 ==========================
@@ -12,17 +12,23 @@ Data Ranges
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.base_data_range
+
 :class:`BaseDataRange`
 ======================
 .. autoclass:: BaseDataRange
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.data_range_1d
+
 :class:`DataRange1D`
 ====================
 .. autoclass:: DataRange1D
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.data_range_2d
 
 :class:`DataRange2D`
 ====================

--- a/docs/source/api/data_sources.rst
+++ b/docs/source/api/data_sources.rst
@@ -1,10 +1,10 @@
 
-.. _data_sources:
+.. _data_sources_api:
 
 Data Sources
 ------------
 
-.. currentmodule:: chaco.api
+.. currentmodule:: chaco.abstract_data_source
 
 :class:`AbstractDataSource`
 ===========================
@@ -12,11 +12,15 @@ Data Sources
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.array_data_source
+
 :class:`ArrayDataSource`
 ========================
 .. autoclass:: ArrayDataSource
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.multi_array_data_source
 
 :class:`MultiArrayDataSource`
 =============================
@@ -24,17 +28,23 @@ Data Sources
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.point_data_source
+
 :class:`PointDataSource`
 ========================
 .. autoclass:: PointDataSource
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.grid_data_source
+
 :class:`GridDataSource`
 =======================
 .. autoclass:: GridDataSource
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.image_data
 
 :class:`ImageData`
 ==================

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -1,0 +1,24 @@
+:orphan:
+
+.. _api_reference:
+
+=============
+API Reference
+=============
+
+This guide provides in-depth API documentation for the main classes and
+objects in the Chaco package.
+
+.. toctree::
+    :maxdepth: 2
+
+    visual_components.rst
+    containers.rst
+    data_sources.rst
+    mappers.rst
+    data_ranges.rst
+    renderers.rst
+    plot_factories.rst
+    tools.rst
+    axis.rst
+

--- a/docs/source/api/mappers.rst
+++ b/docs/source/api/mappers.rst
@@ -4,7 +4,7 @@
 Mappers
 -------
 
-.. currentmodule:: chaco.api
+.. currentmodule:: chaco.abstract_mapper
 
 :class:`AbstractMapper`
 =======================
@@ -12,11 +12,15 @@ Mappers
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.base_1d_mapper
+
 :class:`Base1DMapper`
 =====================
 .. autoclass:: Base1DMapper
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.linear_mapper
 
 :class:`LinearMapper`
 =====================
@@ -24,11 +28,15 @@ Mappers
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.log_mapper
+
 :class:`LogMapper`
 ==================
 .. autoclass:: LogMapper
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.grid_mapper
 
 :class:`GridMapper`
 ===================
@@ -36,11 +44,15 @@ Mappers
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.color_mapper
+
 :class:`ColorMapper`
 ====================
 .. autoclass:: ColorMapper
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.color_mapper
 
 :class:`ColorMapTemplate`
 =========================
@@ -48,9 +60,10 @@ Mappers
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.transform_color_mapper
+
 :class:`TransformColorMapper`
 =============================
 .. autoclass:: TransformColorMapper
     :members:
     :show-inheritance:
-

--- a/docs/source/api/plot_factories.rst
+++ b/docs/source/api/plot_factories.rst
@@ -3,7 +3,7 @@
 Plot Factories
 --------------
 
-.. currentmodule:: chaco.api
+.. currentmodule:: chaco.plot_factory
 
 `create_bar_plot`
 =================
@@ -30,11 +30,15 @@ Plot Factories
 .. autofunction:: add_default_grids
 
 
+.. currentmodule:: chaco.abstract_plot_data
+
 :class:`AbstractPlotData`
 =========================
 .. autoclass:: AbstractPlotData
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.array_plot_data
 
 :class:`ArrayPlotData`
 ======================
@@ -42,11 +46,15 @@ Plot Factories
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.plot
+
 :class:`Plot`
 =============
 .. autoclass:: Plot
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.toolbar_plot
 
 :class:`ToolbarPlot`
 ====================

--- a/docs/source/api/renderers.rst
+++ b/docs/source/api/renderers.rst
@@ -4,7 +4,7 @@
 Renderers
 ----------
 
-.. currentmodule:: chaco.api
+.. currentmodule:: chaco.barplot
 
 :class:`BarPlot`
 ================
@@ -12,11 +12,15 @@ Renderers
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.base_1d_plot
+
 :class:`Base1DPlot`
 ===================
 .. autoclass:: Base1DPlot
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.base_2d_plot
 
 :class:`Base2DPlot`
 ===================
@@ -24,11 +28,15 @@ Renderers
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.base_xy_plot
+
 :class:`BaseXYPlot`
 ===================
 .. autoclass:: BaseXYPlot
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.scatterplot
 
 :class:`ScatterPlot`
 ====================
@@ -36,11 +44,15 @@ Renderers
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.image_plot
+
 :class:`ImagePlot`
 ==================
 .. autoclass:: ImagePlot
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.cmap_image_plot
 
 :class:`CMapImagePlot`
 ======================
@@ -48,11 +60,15 @@ Renderers
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.contour_line_plot
+
 :class:`ContourLinePlot`
 ========================
 .. autoclass:: ContourLinePlot
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.lineplot
 
 :class:`LinePlot`
 ========================
@@ -60,11 +76,15 @@ Renderers
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.colormapped_scatterplot
+
 :class:`ColormappedScatterPlot`
 ===============================
 .. autoclass:: ColormappedScatterPlot
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.colormapped_selection_overlay
 
 :class:`ColormappedSelectionOverlay`
 ====================================
@@ -72,11 +92,15 @@ Renderers
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.polygon_plot
+
 :class:`PolygonPlot`
 ====================
 .. autoclass:: PolygonPlot
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.errorbar_plot
 
 :class:`ErrorBarPlot`
 =====================
@@ -84,11 +108,15 @@ Renderers
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.filled_line_plot
+
 :class:`FilledLinePlot`
 =======================
 .. autoclass:: FilledLinePlot
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.quiverplot
 
 :class:`QuiverPlot`
 ===================
@@ -96,11 +124,31 @@ Renderers
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.candle_plot
+
 :class:`CandlePlot`
 ===================
 .. autoclass:: CandlePlot
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.segment_plot
+
+:class:`SegmentPlot`
+====================
+.. autoclass:: SegmentPlot
+    :members:
+    :show-inheritance:
+
+.. currentmodule:: chaco.text_plot
+
+:class:`TextPlot`
+=================
+.. autoclass:: TextPlot
+    :members:
+    :show-inheritance:
+
+.. currentmodule:: chaco.multi_line_plot
 
 :class:`MultiLinePlot`
 ======================
@@ -108,35 +156,47 @@ Renderers
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.scatterplot_1d
+
 :class:`ScatterPlot1D`
 ======================
-.. autoclass:: ScatterPlot
+.. autoclass:: ScatterPlot1D
     :members:
     :show-inheritance:
 
-..:class:`JitterPlot`
-..===================
-.... autoclass:: JitterPlot
-..    :members:
-..    :show-inheritance:
+.. currentmodule:: chaco.jitterplot
 
-..:class:`LineScatterPlot1D`
-..===================
-.... autoclass:: LineScatterPlot1D
-..    :members:
-..    :show-inheritance:
+:class:`JitterPlot`
+=====================
+.. autoclass:: JitterPlot
+    :members:
+    :show-inheritance:
 
-..:class:`TextPlot1D`
-..===================
-.... autoclass:: TextPlot1D
-..    :members:
-..    :show-inheritance:
+.. currentmodule:: chaco.line_scatterplot_1d
+
+:class:`LineScatterPlot1D`
+============================
+.. autoclass:: LineScatterPlot1D
+    :members:
+    :show-inheritance:
+
+.. currentmodule:: chaco.text_plot_1d
+
+:class:`TextPlot1D`
+=====================
+.. autoclass:: TextPlot1D
+    :members:
+    :show-inheritance:
+
+.. currentmodule:: chaco.variable_size_scatterplot
 
 :class:`VariableSizeScatterPlot`
 ================================
 .. autoclass:: VariableSizeScatterPlot
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.horizon_plot
 
 :class:`HorizonPlot`
 ====================

--- a/docs/source/api/tools.rst
+++ b/docs/source/api/tools.rst
@@ -3,7 +3,7 @@
 Tools
 ------
 
-.. currentmodule:: chaco.tools.api
+.. currentmodule:: chaco.tools.better_zoom
 
 :class:`BetterZoom`
 ==========================
@@ -11,11 +11,15 @@ Tools
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.better_selecting_zoom
+
 :class:`BetterSelectingZoom`
 ============================
 .. autoclass:: BetterSelectingZoom
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.tools.broadcaster
 
 :class:`BroadcasterTool`
 ==========================
@@ -23,11 +27,15 @@ Tools
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.dataprinter
+
 :class:`DataPrinter`
 ==========================
 .. autoclass:: DataPrinter
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.tools.data_label_tool
 
 :class:`DataLabelTool`
 ==========================
@@ -35,11 +43,15 @@ Tools
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.drag_tool
+
 :class:`DragTool`
 ==========================
 .. autoclass:: DragTool
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.tools.draw_points_tool
 
 :class:`DrawPointsTool`
 ==========================
@@ -47,17 +59,23 @@ Tools
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.drag_zoom
+
 :class:`DragZoom`
 ==========================
 .. autoclass:: DragZoom
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.highlight_tool
+
 :class:`HighlightTool`
 ==========================
 .. autoclass:: HighlightTool
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.tools.image_inspector_tool
 
 :class:`ImageInspectorTool`
 ===========================
@@ -71,11 +89,15 @@ Tools
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.lasso_selection
+
 :class:`LassoSelection`
 ==========================
 .. autoclass:: LassoSelection
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.tools.legend_tool
 
 :class:`LegendTool`
 ==========================
@@ -83,11 +105,15 @@ Tools
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.legend_highlighter
+
 :class:`LegendHighlighter`
 ==========================
 .. autoclass:: LegendHighlighter
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.tools.line_inspector
 
 :class:`LineInspector`
 ==========================
@@ -95,11 +121,15 @@ Tools
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.line_segment_tool
+
 :class:`LineSegmentTool`
 ==========================
 .. autoclass:: LineSegmentTool
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.tools.move_tool
 
 :class:`MoveTool`
 ==========================
@@ -107,11 +137,15 @@ Tools
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.pan_tool
+
 :class:`PanTool`
 ==========================
 .. autoclass:: PanTool
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.tools.point_marker
 
 :class:`PointMarker`
 ==========================
@@ -119,11 +153,15 @@ Tools
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.range_selection
+
 :class:`RangeSelection`
 ==========================
 .. autoclass:: RangeSelection
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.tools.range_selection_2d
 
 :class:`RangeSelection2D`
 ==========================
@@ -131,11 +169,15 @@ Tools
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.range_selection_overlay
+
 :class:`RangeSelectionOverlay`
 ==============================
 .. autoclass:: RangeSelectionOverlay
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.tools.regression_lasso
 
 :class:`RegressionLasso`
 ==========================
@@ -149,11 +191,15 @@ Tools
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.save_tool
+
 :class:`SaveTool`
 ==========================
 .. autoclass:: SaveTool
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.tools.scatter_inspector
 
 :class:`ScatterInspector`
 ==========================
@@ -161,17 +207,23 @@ Tools
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.select_tool
+
 :class:`SelectTool`
 ==========================
 .. autoclass:: SelectTool
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.simple_inspector
+
 :class:`SimpleInspectorTool`
 ============================
 .. autoclass:: SimpleInspectorTool
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.tools.tool_states
 
 :class:`ZoomState`
 ==========================
@@ -197,11 +249,15 @@ Tools
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.tracking_pan_tool
+
 :class:`TrackingPanTool`
 ==========================
 .. autoclass:: TrackingPanTool
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.tools.tracking_zoom
 
 :class:`TrackingZoom`
 ==========================
@@ -209,11 +265,15 @@ Tools
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.traits_tool
+
 :class:`TraitsTool`
 ==========================
 .. autoclass:: TraitsTool
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.tools.zoom_tool
 
 :class:`ZoomTool`
 ==========================
@@ -221,4 +281,26 @@ Tools
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.tools.cursor_tool
 
+:class:`BaseCursorTool`
+==========================
+.. autoclass:: BaseCursorTool
+    :members:
+    :show-inheritance:
+
+`CursorTool`
+============
+.. autofunction:: CursorTool
+
+:class:`CursorTool1D`
+==========================
+.. autoclass:: CursorTool1D
+    :members:
+    :show-inheritance:
+
+:class:`CursorTool2D`
+==========================
+.. autoclass:: CursorTool2D
+    :members:
+    :show-inheritance:

--- a/docs/source/api/visual_components.rst
+++ b/docs/source/api/visual_components.rst
@@ -3,7 +3,7 @@
 Visual Components
 -----------------
 
-.. currentmodule:: chaco.api
+.. currentmodule:: chaco.abstract_plot_renderer
 
 :class:`AbstractPlotRenderer`
 =============================
@@ -11,11 +11,15 @@ Visual Components
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.abstract_overlay
+
 :class:`AbstractOverlay`
 ========================
 .. autoclass:: AbstractOverlay
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.base_plot_frame
 
 :class:`BasePlotFrame`
 ======================
@@ -23,11 +27,15 @@ Visual Components
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.cross_plot_frame
+
 :class:`CrossPlotFrame`
 =======================
 .. autoclass:: CrossPlotFrame
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.data_view
 
 :class:`DataView`
 =================
@@ -35,11 +43,15 @@ Visual Components
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.simple_plot_frame
+
 :class:`SimplePlotFrame`
 ========================
 .. autoclass:: SimplePlotFrame
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.plot_component
 
 :class:`PlotComponent`
 ======================
@@ -47,11 +59,15 @@ Visual Components
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.plot_graphics_context
+
 :class:`PlotGraphicsContext`
 ============================
 .. autoclass:: PlotGraphicsContext
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.label
 
 :class:`Label`
 ==============
@@ -59,17 +75,31 @@ Visual Components
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.plot_label
+
 :class:`PlotLabel`
 ==================
 .. autoclass:: PlotLabel
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.legend
+
 :class:`Legend`
 ===============
 .. autoclass:: Legend
     :members:
     :show-inheritance:
+    
+.. currentmodule:: chaco.selectable_legend
+
+:class:`SelectableLegend`
+=========================
+.. autoclass:: SelectableLegend
+    :members:
+    :show-inheritance:
+
+.. currentmodule:: chaco.tooltip
 
 :class:`ToolTip`
 ================
@@ -77,11 +107,15 @@ Visual Components
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.data_label
+
 :class:`DataLabel`
 ==================
 .. autoclass:: DataLabel
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.lasso_overlay
 
 :class:`LassoOverlay`
 =====================
@@ -89,17 +123,23 @@ Visual Components
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.color_bar
+
 :class:`ColorBar`
 =================
 .. autoclass:: ColorBar
     :members:
     :show-inheritance:
 
+.. currentmodule:: chaco.text_box_overlay
+
 :class:`TextBoxOverlay`
 =======================
 .. autoclass:: TextBoxOverlay
     :members:
     :show-inheritance:
+
+.. currentmodule:: chaco.scatter_inspector_overlay
 
 :class:`ScatterInspectorOverlay`
 ================================


### PR DESCRIPTION
part of an effort to break #462 down into various smaller PRs

This PR cleans up and adds to the existing api documentation.  It also adds an `index.rst` file for the api docs that is currently unused here.  It will be used in 462, but I figured is fine to go in alone for now.  

The api docs are currently manually constructed / organized, which may very well be what we want to do.  We could instead auto build the api docs entirely, however then the organization will mirror that of the package itself.  This may be more confusing for documentation purposes.  However, if it is more confusing, that may suggest that the modules in the codebase could use some reorganization?  In any case, this is not relevant to this PR, and can be addressed later.