### PR TITLE
Remove unnecessary unittest.main calls in tests

### DIFF
--- a/chaco/shell/tests/test_tutorial_example.py
+++ b/chaco/shell/tests/test_tutorial_example.py
@@ -21,6 +21,3 @@ class InteractiveTestCase(unittest.TestCase):
         plot(x, y, "r-")
         title("First plot")
         ytitle("sin(x)")
-
-if __name__ == "__main__":
-    unittest.main()

--- a/chaco/tests/test_border.py
+++ b/chaco/tests/test_border.py
@@ -35,7 +35,3 @@ class DrawBorderTestCase(unittest.TestCase):
 
         actual = gc.bmp_array[:,:,0]
         self.assertRavelEqual(actual, desired)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/chaco/tests/test_cmap_image_plot.py
+++ b/chaco/tests/test_cmap_image_plot.py
@@ -40,6 +40,3 @@ class TestCMapImagePlot(unittest.TestCase):
 
         # Then
         window.redraw.assert_called_once_with()
-
-if __name__ == "__main__":
-    unittest.main()

--- a/chaco/tests/test_colormapped_scatterplot.py
+++ b/chaco/tests/test_colormapped_scatterplot.py
@@ -81,7 +81,3 @@ class TestColormappedScatterplot(unittest.TestCase):
         """ If colormapper updated then we need to redraw """
         self.color_mapper.updated = True
         self.assertFalse(self.scatterplot.draw_valid)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/chaco/tests/test_data_label.py
+++ b/chaco/tests/test_data_label.py
@@ -26,7 +26,3 @@ class DataLabelTestCase(unittest.TestCase):
         plot.outer_bounds = list(size)
         gc = PlotGraphicsContext(size)
         gc.render_component(plot)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/chaco/tests/test_plot.py
+++ b/chaco/tests/test_plot.py
@@ -90,7 +90,3 @@ class PlotTestCase(unittest.TestCase):
         gc.render_component(plot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/chaco/tests/test_scatterplot_renderers.py
+++ b/chaco/tests/test_scatterplot_renderers.py
@@ -72,7 +72,3 @@ class DrawScatterplotCase(unittest.TestCase):
         gc.render_component(scatterplot)
         actual = gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/chaco/tests/test_ticks.py
+++ b/chaco/tests/test_ticks.py
@@ -108,7 +108,3 @@ class TestAutoInterval(unittest.TestCase):
             num_ticks = int((data_high - data_low) / interval)
             self.assertGreaterEqual(num_ticks, 3)
             self.assertLessEqual(num_ticks, max_ticks)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/chaco/tools/tests/test_range_zoom.py
+++ b/chaco/tools/tests/test_range_zoom.py
@@ -64,8 +64,3 @@ class BackgroundColorTestCase(EnableTestAssistant, TestCase):
 
         self.assertEqual(gc.set_fill_color.call_args,
                          mock.call([1.0, 0.0, 0.0, 0.3]))
-
-
-if __name__ == '__main__':
-    from unittest import main
-    main()


### PR DESCRIPTION
This PR removes unnecessary calls to `unittest.main()` in the test modules.