### PR TITLE
Replace on_trait_change decorators with observe

### DIFF
--- a/chaco/barplot.py
+++ b/chaco/barplot.py
@@ -4,7 +4,7 @@ import logging
 
 from numpy import array, compress, column_stack, invert, isnan, transpose, zeros
 from traits.api import Any, Bool, Enum, Float, Instance, Property, \
-        Range, Tuple, cached_property, observe
+        Range, Tuple, cached_property
 from enable.api import black_color_trait
 from kiva.constants import FILL_STROKE
 
@@ -69,11 +69,11 @@ class BarPlot(AbstractPlotRenderer):
     antialias = Bool(True)
 
     #: Width of the border of the bars.
-    line_width = Float(1.0)
+    line_width = Float(1.0, requires_redraw=True)
     #: Color of the border of the bars.
-    line_color = black_color_trait
+    line_color = black_color_trait(requires_redraw=True)
     #: Color to fill the bars.
-    fill_color = black_color_trait
+    fill_color = black_color_trait(requires_redraw=True)
 
     #: The RGBA tuple for rendering lines. It is always a tuple of length 4.
     #: It has the same RGB values as :attr:`line_color`, and its alpha value
@@ -86,7 +86,7 @@ class BarPlot(AbstractPlotRenderer):
     effective_fill_color = Property(Tuple, depends_on=['fill_color', 'alpha'])
 
     #: Overall alpha value of the image. Ranges from 0.0 for transparent to 1.0
-    alpha = Range(0.0, 1.0, 1.0)
+    alpha = Range(0.0, 1.0, 1.0, requires_redraw=True)
 
 
     #use_draw_order = False
@@ -414,11 +414,6 @@ class BarPlot(AbstractPlotRenderer):
 
         self.invalidate_draw()
         self._cache_valid = False
-
-    @observe('line_color, line_width, fill_color, alpha')
-    def _attributes_changed(self, event):
-        self.invalidate_draw()
-        self.request_redraw()
 
     def _bounds_changed(self, old, new):
         super(BarPlot, self)._bounds_changed(old, new)

--- a/chaco/barplot.py
+++ b/chaco/barplot.py
@@ -4,7 +4,7 @@ import logging
 
 from numpy import array, compress, column_stack, invert, isnan, transpose, zeros
 from traits.api import Any, Bool, Enum, Float, Instance, Property, \
-        Range, Tuple, cached_property, on_trait_change
+        Range, Tuple, cached_property, observe
 from enable.api import black_color_trait
 from kiva.constants import FILL_STROKE
 
@@ -415,8 +415,8 @@ class BarPlot(AbstractPlotRenderer):
         self.invalidate_draw()
         self._cache_valid = False
 
-    @on_trait_change('line_color, line_width, fill_color, alpha')
-    def _attributes_changed(self):
+    @observe('line_color, line_width, fill_color, alpha')
+    def _attributes_changed(self, event):
         self.invalidate_draw()
         self.request_redraw()
 

--- a/chaco/base_1d_plot.py
+++ b/chaco/base_1d_plot.py
@@ -5,8 +5,9 @@ Abstract base class for 1-D plots which only use one axis
 from numpy import argsort, asarray
 
 # Enthought library imports
-from traits.api import (Any, Bool, Enum, Instance, Property, cached_property,
-                        on_trait_change)
+from traits.api import (
+    Any, Bool, Enum, Instance, Property, cached_property, observe
+)
 
 # local imports
 from .abstract_plot_renderer import AbstractPlotRenderer
@@ -306,13 +307,13 @@ class Base1DPlot(AbstractPlotRenderer):
     # Event handlers
     #------------------------------------------------------------------------
 
-    @on_trait_change("index.data_changed")
-    def _invalidate(self):
+    @observe("index.data_changed")
+    def _invalidate(self, event):
         self._cache_valid = False
         self._screen_cache_valid = False
 
-    @on_trait_change("index_mapper.updated")
-    def _invalidate_screen(self):
+    @observe("index_mapper.updated")
+    def _invalidate_screen(self, event):
         self._screen_cache_valid = False
 
     def _bounds_changed(self, old, new):

--- a/chaco/base_xy_plot.py
+++ b/chaco/base_xy_plot.py
@@ -75,7 +75,7 @@ class BaseXYPlot(AbstractPlotRenderer):
     orientation = Enum("h", "v")
 
     #: Overall alpha value of the image. Ranges from 0.0 for transparent to 1.0
-    alpha = Range(0.0, 1.0, 1.0)
+    alpha = Range(0.0, 1.0, 1.0, requires_redraw=True)
 
     #------------------------------------------------------------------------
     # Convenience readonly properties for common annotations

--- a/chaco/color_bar.py
+++ b/chaco/color_bar.py
@@ -4,8 +4,10 @@
 from numpy import array, arange, ascontiguousarray, ones, transpose, uint8
 
 # Enthought library imports
-from traits.api import Any, Bool, Enum, Instance, Property, \
-                                 cached_property, on_trait_change
+from traits.api import (
+    Any, Bool, Enum, Instance, Property, cached_property, observe
+)
+from traits.observation.api import parse
 from kiva.image import GraphicsContext
 
 # Local imports
@@ -217,8 +219,8 @@ class ColorBar(AbstractPlotRenderer):
     def _updated_changed_for_color_mapper(self):
         self._update_mappers()
 
-    @on_trait_change('[index_mapper,color_mapper].+')
-    def _either_mapper_changed(self):
+    @observe(parse('[index_mapper,color_mapper]').match(lambda n, t: True))
+    def _either_mapper_changed(self, event=None):
         self.invalidate_draw()
         self.request_redraw()
 

--- a/chaco/color_bar.py
+++ b/chaco/color_bar.py
@@ -220,7 +220,7 @@ class ColorBar(AbstractPlotRenderer):
         self._update_mappers()
 
     @observe(parse('[index_mapper,color_mapper]').match(lambda n, t: True))
-    def _either_mapper_changed(self, event=None):
+    def _either_mapper_updated(self, event=None):
         self.invalidate_draw()
         self.request_redraw()
 
@@ -230,10 +230,10 @@ class ColorBar(AbstractPlotRenderer):
             self._grid.mapper = self.index_mapper
         if self._axis is not None:
             self._axis.mapper = self.index_mapper
-        self._either_mapper_changed()
+        self._either_mapper_updated()
 
     def _color_mapper_changed(self):
-        self._either_mapper_changed()
+        self._either_mapper_updated()
 
     def _value_mapper_changed(self):
         self._color_mapper_changed()

--- a/chaco/colormapped_scatterplot.py
+++ b/chaco/colormapped_scatterplot.py
@@ -1,15 +1,13 @@
 """ Defines the ColormappedScatterPlot and ColormappedScatterPlotView classes.
 """
 
-from __future__ import with_statement
-
 # Major library imports
 from numpy import argsort, array, concatenate, nonzero, invert, take, \
                   isnan, transpose, newaxis, zeros, ndarray
 
 # Enthought library imports
 from kiva.constants import STROKE
-from traits.api import Dict, Enum, Float, Instance, on_trait_change
+from traits.api import Dict, Enum, Float, Instance, observe
 from traitsui.api import Item, RangeEditor
 
 # Local, relative imports
@@ -413,8 +411,8 @@ class ColormappedScatterPlot(ScatterPlot):
 
         return
 
-    @on_trait_change('color_mapper:updated')
-    def _color_mapper_updated(self):
+    @observe('color_mapper:updated')
+    def _color_mapper_updated(self, event):
         self.invalidate_draw()
         self.request_redraw()
 

--- a/chaco/data_label.py
+++ b/chaco/data_label.py
@@ -549,7 +549,7 @@ class DataLabel(ToolTip):
         self._cached_arrow = None
         self._layout_needed = True
 
-    @observe("label_position,position:items,bounds:items")
+    @observe("label_position,position.items,bounds.items")
     def _invalidate_layout(self, event):
         self._layout_needed = True
 

--- a/chaco/data_label.py
+++ b/chaco/data_label.py
@@ -7,7 +7,7 @@ from numpy.linalg import norm
 
 # Enthought library imports
 from traits.api import Any, ArrayOrNone, Bool, Enum, Float, Int, List, \
-     Str, Tuple, Trait, on_trait_change, Property
+     Str, Tuple, Trait, observe, Property
 from enable.api import ColorTrait, MarkerTrait
 
 # Local, relative imports
@@ -544,15 +544,13 @@ class DataLabel(ToolTip):
         # 'updated' event.
         self._layout_needed = True
 
-    @on_trait_change("arrow_size,arrow_root,arrow_min_length," +
-                     "arrow_max_length")
-    def _invalidate_arrow(self):
+    @observe("arrow_size,arrow_root,arrow_min_length,arrow_max_length")
+    def _invalidate_arrow(self, event):
         self._cached_arrow = None
         self._layout_needed = True
 
-    @on_trait_change("label_position,position,position_items,bounds," +
-                     "bounds_items")
-    def _invalidate_layout(self):
+    @observe("label_position,position:items,bounds:items")
+    def _invalidate_layout(self, event):
         self._layout_needed = True
 
     def _get_xmid(self):

--- a/chaco/data_range_2d.py
+++ b/chaco/data_range_2d.py
@@ -228,5 +228,5 @@ class DataRange2D(BaseDataRange):
         self.refresh()
 
     @observe("_xrange.updated,_yrange.updated")
-    def _subranges_updated(self, event):
+    def _set_updated(self, event):
         self.updated = True

--- a/chaco/data_range_2d.py
+++ b/chaco/data_range_2d.py
@@ -6,7 +6,7 @@ from numpy import compress, inf, transpose
 
 # Enthought library imports
 from traits.api import Any, Bool, CFloat, Instance, Property, Trait, \
-    Tuple, on_trait_change
+    Tuple, observe
 
 # Local relative imports
 from .base_data_range import BaseDataRange
@@ -227,6 +227,6 @@ class DataRange2D(BaseDataRange):
         self._yrange.sources = [s._ydata for s in self.sources]
         self.refresh()
 
-    @on_trait_change("_xrange.updated,_yrange.updated")
-    def _subranges_updated(self):
+    @observe("_xrange.updated,_yrange.updated")
+    def _subranges_updated(self, event):
         self.updated = True

--- a/chaco/discrete_color_mapper.py
+++ b/chaco/discrete_color_mapper.py
@@ -1,7 +1,7 @@
 
 from numpy import asarray, floor, ones
 
-from traits.api import Array, Str, on_trait_change
+from traits.api import Array, Str, observe
 from chaco.abstract_colormap import AbstractColormap
 from chaco.data_range_1d import DataRange1D
 
@@ -65,8 +65,8 @@ class DiscreteColorMapper(AbstractColormap):
         """ Reverses the palette of this colormap. """
         self.palette = self.palette[::-1]
 
-    @on_trait_change('palette, color_depth')
-    def _update_palettes(self):
+    @observe('palette, color_depth')
+    def _update_palettes(self, event):
         """ Generate palette adjusted for color depth and fire update event"""
         n_colors, n_components = self.palette.shape
         if self.color_depth == 'rgba':

--- a/chaco/function_data_source.py
+++ b/chaco/function_data_source.py
@@ -5,7 +5,7 @@ callable.
 from numpy import array
 
 # Enthought library imports
-from traits.api import Callable, Instance, on_trait_change
+from traits.api import Callable, Instance, observe
 
 # Local, relative imports
 from .abstract_data_source import AbstractDataSource
@@ -36,8 +36,8 @@ class FunctionDataSource(ArrayDataSource):
         AbstractDataSource.__init__(self, **kw)
         self.recalculate()
 
-    @on_trait_change('data_range.updated')
-    def recalculate(self):
+    @observe('data_range.updated')
+    def recalculate(self, event=None):
         if self.func is not None and self.data_range is not None:
             newarray = self.func(self.data_range.low, self.data_range.high)
             ArrayDataSource.set_data(self, newarray)

--- a/chaco/function_image_data.py
+++ b/chaco/function_image_data.py
@@ -1,5 +1,5 @@
 from numpy import array
-from traits.api import Instance, Callable, on_trait_change
+from traits.api import Instance, Callable, observe
 from .data_range_2d import DataRange2D
 from .image_data import ImageData
 
@@ -31,8 +31,8 @@ class FunctionImageData(ImageData):
         # Explicitly construct the initial data set for ImageData
         self.recalculate()
 
-    @on_trait_change('data_range.updated')
-    def recalculate(self):
+    @observe('data_range.updated')
+    def recalculate(self, event=None):
         if self.func is not None and self.data_range is not None:
             newarray = self.func(
                 self.data_range.x_range.low,

--- a/chaco/grid.py
+++ b/chaco/grid.py
@@ -156,7 +156,7 @@ class PlotGrid(AbstractOverlay):
         self.bgcolor = "none" #make sure we're transparent
         return
 
-    @observe("bounds:items,position:items")
+    @observe("bounds.items,position.items")
     def invalidate(self, event=None):
         """ Invalidate cached information about the grid.
         """

--- a/chaco/grid.py
+++ b/chaco/grid.py
@@ -9,7 +9,7 @@ from numpy import around, array, asarray, column_stack, float64, inf, zeros, zer
 # Enthought library imports
 from enable.api import black_color_trait, LineStyle
 from traits.api import Any, Bool, Callable, Enum, Float, Instance, \
-        CInt, Trait, Property, TraitError, Tuple, on_trait_change
+        CInt, Trait, Property, TraitError, Tuple, observe
 from traitsui.api import HGroup, Item, VGroup, View, TextEditor
 
 # Local, relative imports
@@ -156,8 +156,8 @@ class PlotGrid(AbstractOverlay):
         self.bgcolor = "none" #make sure we're transparent
         return
 
-    @on_trait_change("bounds,bounds_items,position,position_items")
-    def invalidate(self):
+    @observe("bounds:items,position:items")
+    def invalidate(self, event=None):
         """ Invalidate cached information about the grid.
         """
         self._reset_cache()
@@ -384,8 +384,8 @@ class PlotGrid(AbstractOverlay):
     # Event handlers for visual attributes.  These mostly just call request_redraw()
     #------------------------------------------------------------------------
 
-    @on_trait_change("visible,line_color,line_style,line_weight")
-    def visual_attr_changed(self):
+    @observe("visible,line_color,line_style,line_weight")
+    def visual_attr_changed(self, event=None):
         """ Called when an attribute that affects the appearance of the grid
         is changed.
         """

--- a/chaco/label.py
+++ b/chaco/label.py
@@ -11,8 +11,9 @@ from numpy import array, dot
 from enable.api import black_color_trait, transparent_color_trait
 from kiva.constants import FILL
 from kiva.trait_defs.kiva_font_trait import KivaFont
-from traits.api import (Any, Bool, Float, HasTraits, Int, List, Str,
-                        on_trait_change)
+from traits.api import (
+    Any, Bool, Float, HasTraits, Int, List, Str, observe
+)
 
 
 class Label(HasTraits):
@@ -192,8 +193,8 @@ class Label(HasTraits):
     def _text_changed(self):
         self._text_needs_fitting = (self.max_width > 0.0)
 
-    @on_trait_change("font,margin,text,rotate_angle")
-    def _invalidate_position_cache(self):
+    @observe("font,margin,text,rotate_angle")
+    def _invalidate_position_cache(self, event):
         self._position_cache_valid = False
 
     #------------------------------------------------------------------------

--- a/chaco/overlays/databox.py
+++ b/chaco/overlays/databox.py
@@ -1,8 +1,4 @@
-
-
-
-from traits.api import (Bool, Enum, Float, Int, CList, Property, Trait,
-        on_trait_change)
+from traits.api import Bool, Enum, Float, Int, CList, Property, Trait, observe
 from enable.api import ColorTrait
 from chaco.abstract_overlay import AbstractOverlay
 
@@ -141,8 +137,8 @@ class DataBox(AbstractOverlay):
         self._bounds_valid = False
         self.trait_property_changed("data_bounds", self._data_bounds)
 
-    @on_trait_change('position,position_items')
-    def _update_position(self):
+    @observe('position.items')
+    def _update_position(self, event=None):
         if self._updating:
             return
         tmp = self.component.map_data(self.position)
@@ -151,8 +147,8 @@ class DataBox(AbstractOverlay):
         self._data_position = tmp
         self.trait_property_changed("data_position", self._data_position)
 
-    @on_trait_change('bounds,bounds_items')
-    def _update_bounds(self):
+    @observe('bounds.items')
+    def _update_bounds(self, event=None):
         if self._updating:
             return
         data_x2, data_y2 = self.component.map_data((self.x2, self.y2))

--- a/chaco/plot_component.py
+++ b/chaco/plot_component.py
@@ -3,7 +3,7 @@
 # Enthought library imports
 from enable.api import Component
 from enable.kiva_graphics_context import GraphicsContext
-from traits.api import Bool, Instance, Str
+from traits.api import Bool, Instance, observe, Str
 
 
 DEFAULT_DRAWING_ORDER = ["background", "image", "underlay",      "plot",
@@ -61,4 +61,6 @@ class PlotComponent(Component):
             raise RuntimeError("The old-style drawing mechanism is no longer " \
                     "supported in Chaco.")
 
-
+    @observe('+requires_redraw')
+    def _plot_component_invalidated(self, event):
+        self.invalidate_and_redraw()

--- a/chaco/plot_component.py
+++ b/chaco/plot_component.py
@@ -19,6 +19,11 @@ class PlotComponent(Component):
     Several of these top-level layout and draw methods have implementations
     that must not be overridden; instead, subclasses implement various
     protected stub methods.
+
+    Additionally, this class sets up the machinery for having changes to
+    specific traits trigger a call to the invalidate_and_redraw method (defined
+    on the Component base class).  To use this, simply set the metadata
+    requires_redraw=True in the definition of the trait.
     """
 
     #------------------------------------------------------------------------

--- a/chaco/polygon_plot.py
+++ b/chaco/polygon_plot.py
@@ -10,8 +10,7 @@ import numpy as np
 from enable.api import LineStyle, black_color_trait, \
                                   transparent_color_trait
 from kiva.api import points_in_polygon
-from traits.api import Enum, Float, Tuple, Property, cached_property, \
-                        on_trait_change
+from traits.api import Enum, Float, Tuple, Property, cached_property, observe
 
 # Local imports.
 from .base_xy_plot import BaseXYPlot
@@ -144,8 +143,8 @@ class PolygonPlot(BaseXYPlot):
     # Event handlers
     #------------------------------------------------------------------------
 
-    @on_trait_change('edge_color, edge_width, edge_style, face_color, alpha')
-    def _attributes_changed(self):
+    @observe('edge_color, edge_width, edge_style, face_color, alpha')
+    def _attributes_changed(self, event):
         self.invalidate_draw()
         self.request_redraw()
 

--- a/chaco/polygon_plot.py
+++ b/chaco/polygon_plot.py
@@ -37,16 +37,16 @@ class PolygonPlot(BaseXYPlot):
     """
 
     #: The color of the line on the edge of the polygon.
-    edge_color = black_color_trait
+    edge_color = black_color_trait(requires_redraw=True)
 
     #: The thickness of the edge of the polygon.
-    edge_width = Float(1.0)
+    edge_width = Float(1.0, requires_redraw=True)
 
     #: The line dash style for the edge of the polygon.
-    edge_style = LineStyle
+    edge_style = LineStyle(requires_redraw=True)
 
     #: The color of the face of the polygon.
-    face_color = transparent_color_trait
+    face_color = transparent_color_trait(requires_redraw=True)
 
     #: Override the hittest_type trait inherited from BaseXYPlot
     hittest_type = Enum("poly", "point", "line")
@@ -138,15 +138,6 @@ class PolygonPlot(BaseXYPlot):
             return True
         else:
             return False
-
-    #------------------------------------------------------------------------
-    # Event handlers
-    #------------------------------------------------------------------------
-
-    @observe('edge_color, edge_width, edge_style, face_color, alpha')
-    def _attributes_changed(self, event):
-        self.invalidate_draw()
-        self.request_redraw()
 
     #------------------------------------------------------------------------
     # Property getters

--- a/chaco/segment_plot.py
+++ b/chaco/segment_plot.py
@@ -3,8 +3,7 @@ import numpy as np
 from enable.api import ColorTrait, LineStyle, black_color_trait
 from kiva.api import CAP_ROUND
 from traits.api import (
-    Array, Bool, Enum, Float, Instance, Property, Str, cached_property,
-    on_trait_change
+    Array, Bool, Enum, Float, Instance, Property, Str, cached_property, observe
 )
 
 from chaco.abstract_colormap import AbstractColormap
@@ -351,11 +350,11 @@ class SegmentPlot(BaseXYPlot):
             gc.move_to(x, y)
             gc.line_to(width, height)
 
-    @on_trait_change(
+    @observe(
         'alpha, color_data:data_changed, color_mapper:updated, '
         'width_data:data_changed, width_mapper.updated, +redraw'
     )
-    def _attributes_changed(self):
+    def _attributes_changed(self, event):
         self.invalidate_draw()
         self.request_redraw()
 

--- a/chaco/segment_plot.py
+++ b/chaco/segment_plot.py
@@ -354,7 +354,7 @@ class SegmentPlot(BaseXYPlot):
         'alpha, color_data:data_changed, color_mapper:updated, '
         'width_data:data_changed, width_mapper.updated, +redraw'
     )
-    def _attributes_changed(self, event):
+    def _attributes_updated(self, event):
         self.invalidate_draw()
         self.request_redraw()
 

--- a/chaco/tests/test_array_plot_data.py
+++ b/chaco/tests/test_array_plot_data.py
@@ -4,7 +4,7 @@ import unittest
 import numpy
 
 from chaco.api import ArrayPlotData
-from traits.api import HasTraits, Instance, List, on_trait_change
+from traits.api import HasTraits, Instance, List, observe
 
 
 class ArrayPlotDataEventsCollector(HasTraits):
@@ -12,9 +12,9 @@ class ArrayPlotDataEventsCollector(HasTraits):
 
     data_changed_events = List
 
-    @on_trait_change('plot_data:data_changed')
+    @observe('plot_data:data_changed')
     def _got_data_changed_event(self, event):
-        self.data_changed_events.append(event)
+        self.data_changed_events.append(event.new)
 
 
 class ArrayPlotDataTestCase(unittest.TestCase):

--- a/chaco/tests/test_data_frame_plot_data.py
+++ b/chaco/tests/test_data_frame_plot_data.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from chaco.api import DataFramePlotData
-from traits.api import HasTraits, Instance, List, on_trait_change
+from traits.api import HasTraits, Instance, List, observe
 
 try:
     from pandas import DataFrame
@@ -20,9 +20,9 @@ class DataFramePlotDataEventsCollector(HasTraits):
 
     data_changed_events = List
 
-    @on_trait_change('plot_data:data_changed')
+    @observe('plot_data:data_changed')
     def _got_data_changed_event(self, event):
-        self.data_changed_events.append(event)
+        self.data_changed_events.append(event.new)
 
 
 @contextlib.contextmanager

--- a/chaco/tests/test_datarange_1d.py
+++ b/chaco/tests/test_datarange_1d.py
@@ -3,7 +3,7 @@ import unittest
 from numpy import arange, array, zeros, inf
 from numpy.testing import assert_equal
 
-from traits.api import HasTraits, Instance, Bool, on_trait_change
+from traits.api import HasTraits, Instance, Bool, observe
 
 from chaco.api import DataRange1D, ArrayDataSource
 
@@ -17,8 +17,8 @@ class Foo(HasTraits):
 
     range_updated = Bool(False)
 
-    @on_trait_change('range.updated')
-    def range_changed(self):
+    @observe('range.updated')
+    def range_changed(self, event):
         self.range_updated = True
 
 

--- a/chaco/text_plot.py
+++ b/chaco/text_plot.py
@@ -11,7 +11,7 @@ from numpy import array, column_stack, empty, isfinite
 from enable.api import black_color_trait
 from kiva.trait_defs.kiva_font_trait import KivaFont
 from traits.api import (
-    Bool, Enum, Float, Int, Instance, List, Tuple, on_trait_change
+    Bool, Enum, Float, Int, Instance, List, Tuple, observe
 )
 
 # local imports
@@ -159,12 +159,12 @@ class TextPlot(BaseXYPlot):
     # Trait events
     #------------------------------------------------------------------------
 
-    @on_trait_change("index.data_changed")
-    def _invalidate(self):
+    @observe("index.data_changed")
+    def _invalidate(self, event):
         self._cache_valid = False
         self._screen_cache_valid = False
         self._label_cache_valid = False
 
-    @on_trait_change("value.data_changed")
-    def _invalidate_labels(self):
+    @observe("value.data_changed")
+    def _invalidate_labels(self, event):
         self._label_cache_valid = False

--- a/chaco/text_plot_1d.py
+++ b/chaco/text_plot_1d.py
@@ -11,7 +11,7 @@ from numpy import array, empty
 # Enthought library imports
 from enable.api import black_color_trait
 from kiva.trait_defs.kiva_font_trait import KivaFont
-from traits.api import Bool, Enum, Float, Int, Instance, List, on_trait_change
+from traits.api import Bool, Enum, Float, Int, Instance, List, observe
 
 # local imports
 from .array_data_source import ArrayDataSource
@@ -164,14 +164,14 @@ class TextPlot1D(Base1DPlot):
     # Trait events
     #------------------------------------------------------------------------
 
-    @on_trait_change("index.data_changed")
-    def _invalidate(self):
+    @observe("index.data_changed")
+    def _invalidate(self, event):
         self._cache_valid = False
         self._screen_cache_valid = False
         self._label_cache_valid = False
 
-    @on_trait_change("value.data_changed")
-    def _invalidate_labels(self):
+    @observe("value.data_changed")
+    def _invalidate_labels(self, event):
         self._label_cache_valid = False
 
     def _bounds_changed(self, old, new):

--- a/chaco/toolbar_plot.py
+++ b/chaco/toolbar_plot.py
@@ -51,12 +51,13 @@ class ToolbarPlot(Plot):
         super(ToolbarPlot, self)._bounds_changed(old, new)
 
     @observe('toolbar')
-    def _on_toolbar_changed(self, event):
+    def _update_toolbar(self, event):
+        new, old = event.new, event.old
 
         if self.toolbar_added:
             # fixup the new toolbar's component to match the old one
-            event.new.component = event.old.component
+            new.component = old.component
 
-            self.overlays.remove(event.old)
+            self.overlays.remove(old)
             self.toolbar_added = False
             self.add_toolbar()

--- a/chaco/toolbar_plot.py
+++ b/chaco/toolbar_plot.py
@@ -1,7 +1,6 @@
 from chaco.plot import Plot
 from chaco.tools.toolbars.plot_toolbar import PlotToolbar
-from traits.api import Type, DelegatesTo, Instance, Enum, \
-        on_trait_change
+from traits.api import Type, DelegatesTo, Instance, Enum, observe
 
 class ToolbarPlot(Plot):
     #: Should we turn on the auto-hide feature on the toolbar?
@@ -51,12 +50,13 @@ class ToolbarPlot(Plot):
         self.toolbar.do_layout(force=True)
         super(ToolbarPlot, self)._bounds_changed(old, new)
 
-    @on_trait_change('toolbar')
-    def _toolbar_changed(self, name, obj, old, new):
+    @observe('toolbar')
+    def _on_toolbar_changed(self, event):
+
         if self.toolbar_added:
             # fixup the new toolbar's component to match the old one
-            new.component = old.component
+            event.new.component = event.old.component
 
-            self.overlays.remove(old)
+            self.overlays.remove(event.old)
             self.toolbar_added = False
             self.add_toolbar()

--- a/chaco/tools/toolbars/plot_toolbar.py
+++ b/chaco/tools/toolbars/plot_toolbar.py
@@ -8,8 +8,7 @@ from chaco.tools.toolbars.toolbar_buttons import ToolbarButton, \
         CopyToClipboardButton, ZoomResetButton, ExportDataToClipboardButton
 from enable.api import Container
 from enable.tools.api import HoverTool
-from traits.api import Bool, Float, on_trait_change, List, \
-        Tuple, Type, Enum
+from traits.api import Bool, Float, observe, List, Tuple, Type, Enum
 
 
 class PlotToolbarHover(HoverTool):
@@ -260,8 +259,8 @@ class PlotToolbar(Container, AbstractOverlay):
     # Trait handlers
     ############################################################
 
-    @on_trait_change('components, location')
-    def _calculate_width(self):
+    @observe('components, location')
+    def _calculate_width(self, event=None):
         if self.location in ['top', 'bottom']:
             width = self.horizontal_padding * 2
             for button in self.components:
@@ -271,8 +270,8 @@ class PlotToolbar(Container, AbstractOverlay):
             self._layout_needed = True
             self.request_redraw()
 
-    @on_trait_change('components, location')
-    def _calculate_height(self):
+    @observe('components, location')
+    def _calculate_height(self, event=None):
         if self.location in ['left', 'right']:
             height = self.vertical_padding * 2
             for button in self.components:
@@ -282,12 +281,12 @@ class PlotToolbar(Container, AbstractOverlay):
             self._layout_needed = True
             self.request_redraw()
 
-    @on_trait_change('hiding')
-    def _hiding_changed(self):
+    @observe('hiding')
+    def _on_hiding_changed(self, event):
         self._layout_needed = True
         self.request_redraw()
 
-    @on_trait_change('auto_hide')
-    def _auto_hide_changed(self):
+    @observe('auto_hide')
+    def _on_auto_hide_changed(self, event):
         self.hiding = self.auto_hide
         self.request_redraw()

--- a/chaco/tools/toolbars/plot_toolbar.py
+++ b/chaco/tools/toolbars/plot_toolbar.py
@@ -282,11 +282,11 @@ class PlotToolbar(Container, AbstractOverlay):
             self.request_redraw()
 
     @observe('hiding')
-    def _on_hiding_changed(self, event):
+    def _set_layout_needed_and_redraw(self, event):
         self._layout_needed = True
         self.request_redraw()
 
     @observe('auto_hide')
-    def _on_auto_hide_changed(self, event):
+    def _set_hiding_and_redraw(self, event):
         self.hiding = self.auto_hide
         self.request_redraw()

--- a/chaco/tooltip.py
+++ b/chaco/tooltip.py
@@ -159,12 +159,12 @@ class ToolTip(AbstractOverlay):
     def __font_metrics_provider_default(self):
         return font_metrics_provider()
 
-    @observe("font,text_color,lines:items")
+    @observe("font,text_color,lines.items")
     def _invalidate_text_props(self, event):
         self._text_props_valid = False
         self._layout_needed = True
 
-    @observe("border_padding,line_spacing,lines:items,padding")
+    @observe("border_padding,line_spacing,lines.items,padding")
     def _invalidate_layout(self, event):
         self._layout_needed = True
         self.request_redraw()

--- a/chaco/tooltip.py
+++ b/chaco/tooltip.py
@@ -9,7 +9,7 @@ from numpy import array
 from enable.api import black_color_trait, white_color_trait
 from enable.font_metrics_provider import font_metrics_provider
 from kiva.trait_defs.kiva_font_trait import KivaFont
-from traits.api import Any, Bool, List, Int, Float, on_trait_change
+from traits.api import Any, Bool, List, Int, Float, observe
 
 
 # Local imports
@@ -159,12 +159,12 @@ class ToolTip(AbstractOverlay):
     def __font_metrics_provider_default(self):
         return font_metrics_provider()
 
-    @on_trait_change("font,text_color,lines,lines_items")
-    def _invalidate_text_props(self):
+    @observe("font,text_color,lines:items")
+    def _invalidate_text_props(self, event):
         self._text_props_valid = False
         self._layout_needed = True
 
-    @on_trait_change("border_padding,line_spacing,lines,lines_items,padding")
-    def _invalidate_layout(self):
+    @observe("border_padding,line_spacing,lines:items,padding")
+    def _invalidate_layout(self, event):
         self._layout_needed = True
         self.request_redraw()

--- a/chaco/transform_color_mapper.py
+++ b/chaco/transform_color_mapper.py
@@ -1,7 +1,7 @@
 from numpy import clip, isinf, ones_like, empty
 
 from chaco.color_mapper import ColorMapper
-from traits.api import Trait, Callable, Tuple, Float, on_trait_change
+from traits.api import Trait, Callable, Tuple, Float, observe
 
 from .speedups import map_colors, map_colors_uint8
 
@@ -35,8 +35,8 @@ class TransformColorMapper(ColorMapper):
     # Trait handlers
     #-------------------------------------------------------------------       
 
-    @on_trait_change('data_func, range.updated')
-    def _update_transformed_bounds(self):
+    @observe('data_func, range.updated')
+    def _update_transformed_bounds(self, event):
 
         if self.range is None:
             # The ColorMapper doesn't have a range yet, so don't do anything.

--- a/examples/demo/advanced/asynchronous_updates.py
+++ b/examples/demo/advanced/asynchronous_updates.py
@@ -13,8 +13,9 @@ from numpy import ogrid, pi, sin
 
 # Enthought library imports
 from enable.api import Component, ComponentEditor
-from traits.api import (Array, Bool, DelegatesTo, HasTraits, Instance, Range,
-                        on_trait_change)
+from traits.api import (
+    Array, Bool, DelegatesTo, HasTraits, Instance, Range, observe
+)
 from traits.trait_notifiers import ui_dispatch
 from traitsui.api import Item, Group, View
 
@@ -59,8 +60,8 @@ class BlurPlotController(HasTraits):
         # its own asynchronizer.
         return Asynchronizer(self._executor)
 
-    @on_trait_change('blur_level, image', post_init=True)
-    def _recalculate_blurred_image(self):
+    @observe('blur_level, image', post_init=True)
+    def _recalculate_blurred_image(self, event):
         """ Blur the image either synchronously or with the asynchronizer """
         image = self.image
         blur_level = self.blur_level

--- a/examples/demo/advanced/data_cube.py
+++ b/examples/demo/advanced/data_cube.py
@@ -29,7 +29,8 @@ from chaco.tools.api import LineInspector, ZoomTool
 from enable.example_support import DemoFrame, demo_main
 from enable.api import Window
 from traits.api import Any, Array, Bool, Callable, CFloat, CInt, \
-        Event, Float, HasTraits, Int, Trait, on_trait_change
+        Event, Float, HasTraits, Int, Trait, observe
+from traits.observation.api import match
 
 # Will hold the path that the user chooses to download to. Will be an empty
 # string if the user decides to download to the current directory.
@@ -66,7 +67,15 @@ class Model(HasTraits):
         super(Model, self).__init__(*args, **kwargs)
         self.compute_model()
 
-    @on_trait_change("npts_+, min_+, max_+")
+    @observe(
+        match(
+            lambda name, trait: (
+                name.startswith("npts_") or
+                name.startswith("min_") or
+                name.startswith("max_")
+                )
+            )
+    )
     def compute_model(self):
         def vfunc(x, y, z):
             return sin(x*z) * cos(y)*sin(z) + sin(0.5*z)
@@ -222,7 +231,7 @@ class PlotFrame(DemoFrame):
         self.bottom.invalidate_and_redraw()
         return
 
-    def _create_window(self):
+    def _create_component(self):
         # Create the model
         self.model = model = Model()
         cmap = viridis
@@ -272,7 +281,7 @@ class PlotFrame(DemoFrame):
         container.add(bottomplot)
 
         self.container = container
-        return Window(self, -1, component=container)
+        return container
 
     def _add_plot_tools(self, imgplot, token):
         """ Add LineInspectors, ImageIndexTool, and ZoomTool to the image plots. """

--- a/examples/demo/advanced/data_cube.py
+++ b/examples/demo/advanced/data_cube.py
@@ -76,7 +76,7 @@ class Model(HasTraits):
                 )
             )
     )
-    def compute_model(self):
+    def compute_model(self, event=None):
         def vfunc(x, y, z):
             return sin(x*z) * cos(y)*sin(z) + sin(0.5*z)
 
@@ -396,4 +396,3 @@ if __name__ == "__main__":
     demo = demo_main(PlotFrame, size=(800,700), title="Cube analyzer")
     if run_cleanup:
         cleanup_data()
-

--- a/examples/demo/advanced/scalar_image_function_inspector.py
+++ b/examples/demo/advanced/scalar_image_function_inspector.py
@@ -30,7 +30,7 @@ from chaco import default_colormaps
 from enable.component_editor import ComponentEditor
 from chaco.tools.api import LineInspector, PanTool, ZoomTool
 from traits.api import Array, Callable, CFloat, CInt, Enum, Event, Float, \
-    HasTraits, Int, Instance, Str, Trait, on_trait_change, Button, Bool, \
+    HasTraits, Int, Instance, Str, Trait, observe, Button, Bool, \
     DelegatesTo
 from traitsui.api import Group, HGroup, Item, View, UItem, spring
 
@@ -500,8 +500,8 @@ class ModelView(HasTraits):
                        title = "Function Inspector",
                        resizable=True)
 
-    @on_trait_change('model, model.model_changed, view')
-    def update_view(self):
+    @observe('model, model.model_changed, view')
+    def update_view(self, event):
         if self.model is not None and self.view is not None:
             self.view.update(self.model)
             

--- a/examples/demo/advanced/scalar_image_function_inspector_old.py
+++ b/examples/demo/advanced/scalar_image_function_inspector_old.py
@@ -23,7 +23,7 @@ from chaco.tools.api import LineInspector, PanTool, RangeSelection, \
                                    RangeSelectionOverlay, ZoomTool
 from enable.api import Window
 from traits.api import Any, Array, Callable, CFloat, CInt, Enum, Event, Float, HasTraits, \
-                             Int, Instance, Str, Trait, on_trait_change
+                             Int, Instance, Str, Trait, observe
 from traitsui.api import Group, Handler, HGroup, Item, View
 from traitsui.menu import Action, CloseAction, Menu, \
                                      MenuBar, NoButtons, Separator
@@ -391,8 +391,8 @@ class ModelView(HasTraits):
                        title = "Function Inspector",
                        resizable=True)
 
-    @on_trait_change('model, view')
-    def update_view(self):
+    @observe('model, view')
+    def update_view(self, event):
         if self.model is not None and self.view is not None:
             self.view.update(self.model)
 

--- a/examples/demo/basic/scatter_inspector2.py
+++ b/examples/demo/basic/scatter_inspector2.py
@@ -3,8 +3,7 @@
 import pandas as pd
 import numpy as np
 
-from traits.api import Callable, Enum, HasTraits, Instance, on_trait_change, \
-    Str
+from traits.api import Callable, Enum, HasTraits, Instance, observe, Str
 from traitsui.api import View, Item
 from enable.api import ComponentEditor
 from chaco.api import Plot, ArrayPlotData, ScatterInspectorOverlay, \
@@ -27,9 +26,10 @@ class DataframeScatterOverlay(TextBoxOverlay):
     #: Function which takes and index and returns an info string.
     message_for_data = Callable
 
-    @on_trait_change('inspector:inspector_event')
+    @observe('inspector:inspector_event')
     def scatter_point_found(self, event):
-        data_idx = event.event_index
+        inspector_event = event.new 
+        data_idx = inspector_event.event_index
         if data_idx is not None:
             self.text = self.message_for_data(data_idx)
         else:

--- a/examples/demo/financial/correlations.py
+++ b/examples/demo/financial/correlations.py
@@ -5,7 +5,7 @@ import time
 # ETS imports (non-chaco)
 from enable.component_editor import ComponentEditor
 from traits.api import HasTraits, Instance, Int, List, Str, Enum, \
-        on_trait_change, Any, DelegatesTo
+        observe, Any, DelegatesTo
 from traitsui.api import Item, View, HSplit, VGroup, EnumEditor
 
 # Chaco imports
@@ -141,8 +141,8 @@ class PlotApp(HasTraits):
             corr_index.metadata["selections"] = arange(low_ndx, high_ndx+1, 1, dtype=int)
             self.corr_plot.request_redraw()
 
-    @on_trait_change("sym1,sym2")
-    def _update_corr_symbols(self):
+    @observe("sym1,sym2")
+    def _update_corr_symbols(self, event):
         plot = self.corr_plot
         if self.corr_renderer is not None:
             # Remove the old one

--- a/examples/user_guide/plot_types/plot_window.py
+++ b/examples/user_guide/plot_types/plot_window.py
@@ -1,7 +1,7 @@
 from chaco.api import PlotComponent
 from chaco.data_view import DataView
 from enable.component_editor import ComponentEditor
-from traits.api import HasTraits, Instance, on_trait_change
+from traits.api import HasTraits, Instance, observe
 from traitsui.api import Item, View
 
 class PlotWindow(HasTraits):
@@ -9,8 +9,8 @@ class PlotWindow(HasTraits):
     plot = Instance(PlotComponent)
     container = Instance(DataView)
 
-    @on_trait_change('plot')
-    def _update_container(self):
+    @observe('plot')
+    def _update_container(self, event):
         self.container = DataView(
             padding=(80,20,20,60),  # make some space for axis labels
             border_visible=False


### PR DESCRIPTION
This PR replaces uses of the `@on_trait_change` decorator with the equivalent form using `observe`.

I made changes one file at a time and ran test suite / tested examples after each change.  However, it is possible certain changed code is not under test.