### PR TITLE
return correct sized tuples of all 0s not None if image plot resized too small

### DIFF
--- a/chaco/image_plot.py
+++ b/chaco/image_plot.py
@@ -302,7 +302,7 @@ class ImagePlot(Base2DPlot):
         """
         ix, iy, image_width, image_height = image_rect
         if 0 in (image_width, image_height) or 0 in self.bounds:
-            return ((0,0,0,0), (0,0,0,0))
+            return ((0, 0, 0, 0), (0, 0, 0, 0))
 
         array_bounds = self._array_bounds_from_screen_rect(image_rect)
         col_min, col_max, row_min, row_max = array_bounds

--- a/chaco/image_plot.py
+++ b/chaco/image_plot.py
@@ -302,7 +302,7 @@ class ImagePlot(Base2DPlot):
         """
         ix, iy, image_width, image_height = image_rect
         if 0 in (image_width, image_height) or 0 in self.bounds:
-            return (None, None)
+            return ((0,0,0,0), (0,0,0,0))
 
         array_bounds = self._array_bounds_from_screen_rect(image_rect)
         col_min, col_max, row_min, row_max = array_bounds

--- a/chaco/tests/test_image_plot.py
+++ b/chaco/tests/test_image_plot.py
@@ -2,7 +2,6 @@ import os
 
 import tempfile
 from contextlib import contextmanager
-from scipy.misc import face
 
 import unittest
 
@@ -181,7 +180,7 @@ class TestResultImage(unittest.TestCase):
             )
 
             def _plot_default(self):
-                pd = ArrayPlotData(image=face())
+                pd = ArrayPlotData(image=RGB)
                 plot = Plot(pd)
                 plot.img_plot('image')
 

--- a/chaco/tests/test_image_plot.py
+++ b/chaco/tests/test_image_plot.py
@@ -166,6 +166,7 @@ class TestResultImage(unittest.TestCase):
                                  origin='bottom right', orientation='v')
 
     # regression test for enthought/chaco#528
+    @unittest.skipIf(ETSConfig.toolkit=='null', "Skip on 'null' toolkit")
     def test_resize_to_zero(self):
         class TestResize(HasTraits):
             plot = Instance(Component)


### PR DESCRIPTION
fixes #528 (I think)

With the change made in this PR I no longer see the crash described here: https://github.com/enthought/chaco/issues/528#issuecomment-809297495


This PR simply updates `_calc_zoom_coords` to return what it claims to return:
```
Returns
-------
    index_bounds : 4-tuple
        The column and row indices (col_min, col_max, row_min, row_max) of
        the sub-image to be extracted and drawn into `screen_rect`.
    screen_rect : 4-tuple
        (x, y, width, height) rectangle describing the pixels bounds where
        the image will be rendered in the plot.
```

In this particular case if we have zoomed in so far that the image has either length or width 0, the the screen rect showing it is effectively non-existent, and there is no data to show in it.  
Technically `((0, 0, 0, 0), (0, 0, 0, 0))` isn't really the exactly correct thing to return here (instead you could think that screen_rect should be a 0x0 rectangle at the point where the image should be on screen, not at x=0, y=0).  However, there is actually nothing to draw so it effectively doesn't matter.

The only place this method is called is by ` _compute_cached_image`.  If `_compute_cached_image` gets ``((0, 0, 0, 0), (0, 0, 0, 0))`` everything works out as expected as we end up with `data=data[0:0, 0:0]` making `data.shape = (0, 0, 3)` and a screen_rect that is 0x0.



Note: now when I slowly shrink the window once I hit the critical point rather than the example crashing, I see:
```
/Users/aayres/Desktop/chaco/chaco/axis.py:613: RuntimeWarning: invalid value encountered in true_divide
  self._axis_pixel_vector = self._axis_vector/sqrt(dot(self._axis_vector,self._axis_vector))
  ```
This is not new from the changes in this PR (was masked by the crash previously), but occurs because we end up with an `_axis_vector` of (0, 0) when we shrink that far