### PR TITLE
Replace dynamic on_trait_change with observe

### DIFF
--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -630,12 +630,12 @@ class PlotAxis(AbstractOverlay):
 
     def _mapper_changed(self, old, new):
         if old is not None:
-            old.on_trait_change(self.mapper_updated, "updated", remove=True)
+            old.observe(self.mapper_updated, "updated", remove=True)
         if new is not None:
-            new.on_trait_change(self.mapper_updated, "updated")
+            new.observe(self.mapper_updated, "updated")
         self._invalidate()
 
-    def mapper_updated(self):
+    def mapper_updated(self, event):
         """
         Event handler that is bound to this axis's mapper's **updated** event
         """

--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -635,7 +635,7 @@ class PlotAxis(AbstractOverlay):
             new.observe(self.mapper_updated, "updated")
         self._invalidate()
 
-    def mapper_updated(self, event):
+    def mapper_updated(self, event=None):
         """
         Event handler that is bound to this axis's mapper's **updated** event
         """

--- a/chaco/barplot.py
+++ b/chaco/barplot.py
@@ -433,10 +433,10 @@ class BarPlot(AbstractPlotRenderer):
 
     def _index_changed(self, old, new):
         if old is not None:
-            old.on_trait_change(self._either_data_changed, "data_changed", remove=True)
+            old.observe(self._either_data_updated, "data_changed", remove=True)
         if new is not None:
-            new.on_trait_change(self._either_data_changed, "data_changed")
-        self._either_data_changed()
+            new.observe(self._either_data_updated, "data_changed")
+        self._either_data_updated()
 
     def _index_direction_changed(self):
         m = self.index_mapper
@@ -448,17 +448,17 @@ class BarPlot(AbstractPlotRenderer):
         m.low_pos, m.high_pos = m.high_pos, m.low_pos
         self.invalidate_draw()
 
-    def _either_data_changed(self):
+    def _either_data_updated(self, event=None):
         self.invalidate_draw()
         self._cache_valid = False
         self.request_redraw()
 
     def _value_changed(self, old, new):
         if old is not None:
-            old.on_trait_change(self._either_data_changed, "data_changed", remove=True)
+            old.observe(self._either_data_updated, "data_changed", remove=True)
         if new is not None:
-            new.on_trait_change(self._either_data_changed, "data_changed")
-        self._either_data_changed()
+            new.observe(self._either_data_updated, "data_changed")
+        self._either_data_updated()
 
     def _index_mapper_changed(self, old, new):
         return self._either_mapper_changed(old, new)
@@ -468,12 +468,12 @@ class BarPlot(AbstractPlotRenderer):
 
     def _either_mapper_changed(self, old, new):
         if old is not None:
-            old.on_trait_change(self._mapper_updated_handler, "updated", remove=True)
+            old.observe(self._mapper_updated_handler, "updated", remove=True)
         if new is not None:
-            new.on_trait_change(self._mapper_updated_handler, "updated")
+            new.observe(self._mapper_updated_handler, "updated")
         self.invalidate_draw()
 
-    def _mapper_updated_handler(self):
+    def _mapper_updated_handler(self, event):
         self._cache_valid = False
         self.invalidate_draw()
         self.request_redraw()

--- a/chaco/base_1d_mapper.py
+++ b/chaco/base_1d_mapper.py
@@ -64,19 +64,19 @@ class Base1DMapper(AbstractMapper):
 
     def _range_changed(self, old, new):
         if old is not None:
-            old.on_trait_change(self._range_change_handler, "updated",
+            old.observe(self._range_change_handler, "updated",
                                 remove = True)
         if new is not None:
-            new.on_trait_change(self._range_change_handler, "updated")
+            new.observe(self._range_change_handler, "updated")
 
         self._cache_valid = False
         self.updated = new
         return
 
-    def _range_change_handler(self, obj, name, new):
+    def _range_change_handler(self, event):
         "Handles the range changing; dynamically attached to our ranges"
         self._cache_valid = False
-        self.updated = obj
+        self.updated = event.object
         return
 
     def _get_screen_bounds(self):

--- a/chaco/base_1d_mapper.py
+++ b/chaco/base_1d_mapper.py
@@ -64,8 +64,7 @@ class Base1DMapper(AbstractMapper):
 
     def _range_changed(self, old, new):
         if old is not None:
-            old.observe(self._range_change_handler, "updated",
-                                remove = True)
+            old.observe(self._range_change_handler, "updated", remove=True)
         if new is not None:
             new.observe(self._range_change_handler, "updated")
 

--- a/chaco/base_2d_plot.py
+++ b/chaco/base_2d_plot.py
@@ -325,10 +325,10 @@ class Base2DPlot(AbstractPlotRenderer):
 
     def _value_changed(self, old, new):
         if old is not None:
-            old.on_trait_change(self._update_value_data,
+            old.observe(self._update_value_data,
                                 "data_changed", remove=True)
         if new is not None:
-            new.on_trait_change(self._update_value_data, "data_changed")
+            new.observe(self._update_value_data, "data_changed")
         self._update_value_data()
 
     def _index_mapper_changed(self, old, new):

--- a/chaco/base_2d_plot.py
+++ b/chaco/base_2d_plot.py
@@ -89,14 +89,11 @@ class Base2DPlot(AbstractPlotRenderer):
         self.trait_set(**kwargs_tmp)
         super(Base2DPlot, self).__init__(**kwargs)
         if self.index is not None:
-            self.index.observe(self._update_index_data,
-                                       "data_changed")
+            self.index.observe(self._update_index_data, "data_changed")
         if self.index_mapper:
-            self.index_mapper.observe(self._update_index_mapper,
-                                              "updated")
+            self.index_mapper.observe(self._update_index_mapper, "updated")
         if self.value is not None:
-            self.value.observe(self._update_value_data,
-                                       "data_changed")
+            self.value.observe(self._update_value_data, "data_changed")
         # If we are not resizable, we will not get a bounds update upon layout,
         # so we have to manually update our mappers
         if self.resizable == "":
@@ -317,25 +314,21 @@ class Base2DPlot(AbstractPlotRenderer):
 
     def _index_changed(self, old, new):
         if old is not None:
-            old.obseve(self._update_index_data,
-                                "data_changed", remove=True)
+            old.obseve(self._update_index_data, "data_changed", remove=True)
         if new is not None:
             new.obseve(self._update_index_data, "data_changed")
         self._update_index_data()
 
     def _value_changed(self, old, new):
         if old is not None:
-            old.observe(self._update_value_data,
-                                "data_changed", remove=True)
+            old.observe(self._update_value_data, "data_changed", remove=True)
         if new is not None:
             new.observe(self._update_value_data, "data_changed")
         self._update_value_data()
 
     def _index_mapper_changed(self, old, new):
         if old is not None:
-            old.observe(self._update_index_mapper,
-                                "updated", remove=True)
+            old.observe(self._update_index_mapper, "updated", remove=True)
         if new is not None:
             new.observe(self._update_index_mapper, "updated")
         self._update_index_mapper()
-

--- a/chaco/base_2d_plot.py
+++ b/chaco/base_2d_plot.py
@@ -89,13 +89,13 @@ class Base2DPlot(AbstractPlotRenderer):
         self.trait_set(**kwargs_tmp)
         super(Base2DPlot, self).__init__(**kwargs)
         if self.index is not None:
-            self.index.on_trait_change(self._update_index_data,
+            self.index.observe(self._update_index_data,
                                        "data_changed")
         if self.index_mapper:
-            self.index_mapper.on_trait_change(self._update_index_mapper,
+            self.index_mapper.observe(self._update_index_mapper,
                                               "updated")
         if self.value is not None:
-            self.value.on_trait_change(self._update_value_data,
+            self.value.observe(self._update_value_data,
                                        "data_changed")
         # If we are not resizable, we will not get a bounds update upon layout,
         # so we have to manually update our mappers
@@ -247,7 +247,7 @@ class Base2DPlot(AbstractPlotRenderer):
     # Private methods
     #------------------------------------------------------------------------
 
-    def _update_index_mapper(self):
+    def _update_index_mapper(self, event=None):
         """ Updates the index mapper.
 
         Called by various trait change handlers.
@@ -280,7 +280,7 @@ class Base2DPlot(AbstractPlotRenderer):
             self.index_mapper_changed = True
             self.invalidate_draw()
 
-    def _update_index_data(self):
+    def _update_index_data(self, event=None):
         """ Updates the index data.
 
         Called by various trait change handlers.
@@ -288,7 +288,7 @@ class Base2DPlot(AbstractPlotRenderer):
         self.index_data_changed = True
         self.invalidate_draw()
 
-    def _update_value_data(self):
+    def _update_value_data(self, event=None):
         """ Updates the value data.
 
         Called by various trait change handlers.
@@ -317,10 +317,10 @@ class Base2DPlot(AbstractPlotRenderer):
 
     def _index_changed(self, old, new):
         if old is not None:
-            old.on_trait_change(self._update_index_data,
+            old.obseve(self._update_index_data,
                                 "data_changed", remove=True)
         if new is not None:
-            new.on_trait_change(self._update_index_data, "data_changed")
+            new.obseve(self._update_index_data, "data_changed")
         self._update_index_data()
 
     def _value_changed(self, old, new):
@@ -333,9 +333,9 @@ class Base2DPlot(AbstractPlotRenderer):
 
     def _index_mapper_changed(self, old, new):
         if old is not None:
-            old.on_trait_change(self._update_index_mapper,
+            old.observe(self._update_index_mapper,
                                 "updated", remove=True)
         if new is not None:
-            new.on_trait_change(self._update_index_mapper, "updated")
+            new.observe(self._update_index_mapper, "updated")
         self._update_index_mapper()
 

--- a/chaco/base_contour_plot.py
+++ b/chaco/base_contour_plot.py
@@ -65,7 +65,7 @@ class BaseContourPlot(Base2DPlot):
     def __init__(self, *args, **kwargs):
         super(BaseContourPlot, self).__init__(*args, **kwargs)
         if self.color_mapper:
-            self.color_mapper.on_trait_change(self._update_color_mapper, "updated")
+            self.color_mapper.observe(self._update_color_mapper, "updated")
         return
 
     def _update_levels(self):
@@ -152,7 +152,7 @@ class BaseContourPlot(Base2DPlot):
         # If the index mapper has changed, then we need to redraw
         self.invalidate_and_redraw()
 
-    def _update_color_mapper(self):
+    def _update_color_mapper(self, event=None):
         # If the color mapper has changed, then we need to recompute the
         # levels and cached data associated with that.
         self._level_cache_valid = False
@@ -180,7 +180,7 @@ class BaseContourPlot(Base2DPlot):
     def _set_color_mapper(self, color_mapper):
         # Remove the dynamic event handler from the old color mapper
         if self.colors is not None and isinstance(self.colors, ColorMapper):
-            self.colors.on_trait_change(self._update_color_mapper, "updated", remove=True)
+            self.colors.observe(self._update_color_mapper, "updated", remove=True)
 
             # Check to see if we should copy over the range as well
             if color_mapper is not None:
@@ -189,7 +189,7 @@ class BaseContourPlot(Base2DPlot):
 
         # Attach the dynamic event handler to the new color mapper
         if color_mapper is not None:
-            color_mapper.on_trait_change(self._update_color_mapper, "updated")
+            color_mapper.observe(self._update_color_mapper, "updated")
 
         self.colors = color_mapper
         self._update_color_mapper()

--- a/chaco/base_xy_plot.py
+++ b/chaco/base_xy_plot.py
@@ -622,7 +622,7 @@ class BaseXYPlot(AbstractPlotRenderer):
         if old is not None:
             old.observe(self._either_data_updated, "data_changed", remove=True)
             old.observe(self._either_metadata_updated, "metadata_changed",
-                                remove=True)
+                        remove=True)
         if new is not None:
             new.observe(self._either_data_updated, "data_changed")
             new.observe(self._either_metadata_updated, "metadata_changed")
@@ -644,7 +644,7 @@ class BaseXYPlot(AbstractPlotRenderer):
         if old is not None:
             old.observe(self._either_data_updated, "data_changed", remove=True)
             old.observe(self._either_metadata_updated, "metadata_changed",
-                                remove=True)
+                        remove=True)
         if new is not None:
             new.observe(self._either_data_updated, "data_changed")
             new.observe(self._either_metadata_updated, "metadata_changed")

--- a/chaco/base_xy_plot.py
+++ b/chaco/base_xy_plot.py
@@ -183,15 +183,15 @@ class BaseXYPlot(AbstractPlotRenderer):
         self.trait_set(**kwargs_tmp)
         AbstractPlotRenderer.__init__(self, **kwtraits)
         if self.index is not None:
-            self.index.on_trait_change(self._either_data_changed, "data_changed")
-            self.index.on_trait_change(self._either_metadata_changed, "metadata_changed")
+            self.index.observe(self._either_data_updated, "data_changed")
+            self.index.observe(self._either_metadata_updated, "metadata_changed")
         if self.index_mapper:
-            self.index_mapper.on_trait_change(self._mapper_updated_handler, "updated")
+            self.index_mapper.observe(self._mapper_updated_handler, "updated")
         if self.value is not None:
-            self.value.on_trait_change(self._either_data_changed, "data_changed")
-            self.value.on_trait_change(self._either_metadata_changed, "metadata_changed")
+            self.value.observe(self._either_data_updated, "data_changed")
+            self.value.observe(self._either_metadata_updated, "metadata_changed")
         if self.value_mapper:
-            self.value_mapper.on_trait_change(self._mapper_updated_handler, "updated")
+            self.value_mapper.observe(self._mapper_updated_handler, "updated")
 
         # If we are not resizable, we will not get a bounds update upon layout,
         # so we have to manually update our mappers
@@ -620,35 +620,35 @@ class BaseXYPlot(AbstractPlotRenderer):
 
     def _index_changed(self, old, new):
         if old is not None:
-            old.on_trait_change(self._either_data_changed, "data_changed", remove=True)
-            old.on_trait_change(self._either_metadata_changed, "metadata_changed",
+            old.observe(self._either_data_updated, "data_changed", remove=True)
+            old.observe(self._either_metadata_updated, "metadata_changed",
                                 remove=True)
         if new is not None:
-            new.on_trait_change(self._either_data_changed, "data_changed")
-            new.on_trait_change(self._either_metadata_changed, "metadata_changed")
-        self._either_data_changed()
+            new.observe(self._either_data_updated, "data_changed")
+            new.observe(self._either_metadata_updated, "metadata_changed")
+        self._either_data_updated()
         return
 
-    def _either_data_changed(self):
+    def _either_data_updated(self, event=None):
         self.invalidate_draw()
         self._cache_valid = False
         self._screen_cache_valid = False
         self.request_redraw()
         return
 
-    def _either_metadata_changed(self):
+    def _either_metadata_updated(self, event):
         # By default, don't respond to metadata change events.
         pass
 
     def _value_changed(self, old, new):
         if old is not None:
-            old.on_trait_change(self._either_data_changed, "data_changed", remove=True)
-            old.on_trait_change(self._either_metadata_changed, "metadata_changed",
+            old.observe(self._either_data_updated, "data_changed", remove=True)
+            old.observe(self._either_metadata_updated, "metadata_changed",
                                 remove=True)
         if new is not None:
-            new.on_trait_change(self._either_data_changed, "data_changed")
-            new.on_trait_change(self._either_metadata_changed, "metadata_changed")
-        self._either_data_changed()
+            new.observe(self._either_data_updated, "data_changed")
+            new.observe(self._either_metadata_updated, "metadata_changed")
+        self._either_data_updated()
         return
 
     def _origin_changed(self, old, new):
@@ -683,14 +683,14 @@ class BaseXYPlot(AbstractPlotRenderer):
 
     def _either_mapper_changed(self, obj, name, old, new):
         if old is not None:
-            old.on_trait_change(self._mapper_updated_handler, "updated", remove=True)
+            old.observe(self._mapper_updated_handler, "updated", remove=True)
         if new is not None:
-            new.on_trait_change(self._mapper_updated_handler, "updated")
+            new.observe(self._mapper_updated_handler, "updated")
         self.invalidate_draw()
         self._screen_cache_valid = False
         return
 
-    def _mapper_updated_handler(self):
+    def _mapper_updated_handler(self, event):
         self._cache_valid = False
         self._screen_cache_valid = False
         self.invalidate_draw()
@@ -725,9 +725,9 @@ class BaseXYPlot(AbstractPlotRenderer):
     def __setstate__(self, state):
         super(BaseXYPlot, self).__setstate__(state)
         if self.index is not None:
-            self.index.on_trait_change(self._either_data_changed, "data_changed")
+            self.index.observe(self._either_data_updated, "data_changed")
         if self.value is not None:
-            self.value.on_trait_change(self._either_data_changed, "data_changed")
+            self.value.observe(self._either_data_updated, "data_changed")
 
         self.invalidate_draw()
         self._cache_valid = False

--- a/chaco/chaco_plot_editor.py
+++ b/chaco/chaco_plot_editor.py
@@ -245,11 +245,11 @@ class ChacoPlotEditor ( Editor ):
         object = self.object
         if USE_DATA_UPDATE == 1:
             for name in (plotitem.index, plotitem.value):
-                object.on_trait_change( self._update_data, name)
+                object.observe( self._update_data, name)
         for name in (plotitem.x_label_trait, plotitem.y_label_trait):
-            object.on_trait_change(lambda s: self._update_axis_grids(), name)
+            object.observe(lambda s: self._update_axis_grids(), name)
         if plotitem.type_trait not in ("", None):
-            object.on_trait_change(self.update_editor, plotitem.type_trait)
+            object.observe(self.update_editor, plotitem.type_trait)
         return
 
     #---------------------------------------------------------------------------
@@ -264,9 +264,9 @@ class ChacoPlotEditor ( Editor ):
 
         if USE_DATA_UPDATE == 1:
             for name in (plotitem.index, plotitem.value):
-                object.on_trait_change( self._update_data, name, remove = True )
+                object.observe( self._update_data, name, remove = True )
         for name in (plotitem.type_trait,):
-            object.on_trait_change( self.update_editor, name, remove = True )
+            object.observe( self.update_editor, name, remove = True )
         self._destroy_plot()
         super(ChacoPlotEditor, self).dispose()
 
@@ -287,7 +287,7 @@ class ChacoPlotEditor ( Editor ):
     #  Updates the editor when the object trait changes externally to the editor:
     #---------------------------------------------------------------------------
 
-    def update_editor(self):
+    def update_editor(self, event=None):
         """ Updates the editor when the object trait changes externally to the
             editor.
         """
@@ -345,7 +345,7 @@ class ChacoPlotEditor ( Editor ):
         self._container.request_redraw()
         return
 
-    def _update_data(self):
+    def _update_data(self, event):
         """ Updates the editor when the object trait changes externally to the
             editor.
         """

--- a/chaco/cmap_image_plot.py
+++ b/chaco/cmap_image_plot.py
@@ -64,11 +64,9 @@ class CMapImagePlot(ImagePlot):
     def __init__(self, **kwargs):
         super(CMapImagePlot, self).__init__(**kwargs)
         if self.value_mapper:
-            self.value_mapper.observe(self._update_value_mapper,
-                                              "updated")
+            self.value_mapper.observe(self._update_value_mapper, "updated")
         if self.value:
-            self.value.observe(self._update_selections,
-                                       "metadata_changed")
+            self.value.observe(self._update_selections, "metadata_changed")
 
     def set_value_selection(self, val):
         """ Sets a range of values in the value data source as selected.
@@ -171,8 +169,7 @@ class CMapImagePlot(ImagePlot):
 
     def _value_mapper_changed(self, old, new):
         if old is not None:
-            old.observe(self._update_value_mapper,
-                                "updated", remove=True)
+            old.observe(self._update_value_mapper, "updated", remove=True)
         if new is not None:
             new.observe(self._update_value_mapper, "updated")
 
@@ -194,4 +191,3 @@ class CMapImagePlot(ImagePlot):
     def _cache_full_map_changed(self):
         self._mapped_image_cache_valid = False
         
-

--- a/chaco/cmap_image_plot.py
+++ b/chaco/cmap_image_plot.py
@@ -64,10 +64,10 @@ class CMapImagePlot(ImagePlot):
     def __init__(self, **kwargs):
         super(CMapImagePlot, self).__init__(**kwargs)
         if self.value_mapper:
-            self.value_mapper.on_trait_change(self._update_value_mapper,
+            self.value_mapper.observe(self._update_value_mapper,
                                               "updated")
         if self.value:
-            self.value.on_trait_change(self._update_selections,
+            self.value.observe(self._update_selections,
                                        "metadata_changed")
 
     def set_value_selection(self, val):
@@ -139,12 +139,12 @@ class CMapImagePlot(ImagePlot):
             ImagePlot._compute_cached_image(self, self.value.data, mapper=lambda data:
                 self._cmap_values(data))
             
-    def _update_value_mapper(self):
+    def _update_value_mapper(self, event=None):
         self._mapped_image_cache_valid = False
         self._image_cache_valid = False
         self.invalidate_and_redraw()
 
-    def _update_selections(self):
+    def _update_selections(self, event=None):
         self._mapped_image_cache_valid = False
         self._image_cache_valid = False
         self.invalidate_and_redraw()
@@ -171,10 +171,10 @@ class CMapImagePlot(ImagePlot):
 
     def _value_mapper_changed(self, old, new):
         if old is not None:
-            old.on_trait_change(self._update_value_mapper,
+            old.observe(self._update_value_mapper,
                                 "updated", remove=True)
         if new is not None:
-            new.on_trait_change(self._update_value_mapper, "updated")
+            new.observe(self._update_value_mapper, "updated")
 
         if old and new:
             if new.range is None and old.range is not None:

--- a/chaco/color_mapper.py
+++ b/chaco/color_mapper.py
@@ -430,8 +430,7 @@ class ColorMapper(AbstractColormap):
 
     def _range_changed(self, old, new):
         if old is not None:
-            old.observe(self._range_change_handler, "updated",
-                                remove = True)
+            old.observe(self._range_change_handler, "updated", remove=True)
         if new is not None:
             new.observe(self._range_change_handler, "updated")
 

--- a/chaco/color_mapper.py
+++ b/chaco/color_mapper.py
@@ -430,13 +430,13 @@ class ColorMapper(AbstractColormap):
 
     def _range_changed(self, old, new):
         if old is not None:
-            old.on_trait_change(self._range_change_handler, "updated",
+            old.observe(self._range_change_handler, "updated",
                                 remove = True)
         if new is not None:
-            new.on_trait_change(self._range_change_handler, "updated")
+            new.observe(self._range_change_handler, "updated")
 
         self.updated = new
 
-    def _range_change_handler(self, obj, name, new):
+    def _range_change_handler(self, event):
         "Handles the range changing; dynamically attached to our ranges"
-        self.updated = obj
+        self.updated = event.object

--- a/chaco/colormapped_scatterplot.py
+++ b/chaco/colormapped_scatterplot.py
@@ -394,10 +394,10 @@ class ColormappedScatterPlot(ScatterPlot):
 
     def _color_data_changed(self, old, new):
         if old is not None:
-            old.on_trait_change(self._either_data_changed, "data_changed", remove=True)
+            old.observe(self._either_data_updated, "data_changed", remove=True)
         if new is not None:
-            new.on_trait_change(self._either_data_changed, "data_changed")
-        self._either_data_changed()
+            new.observe(self._either_data_updated, "data_changed")
+        self._either_data_updated()
         return
 
     def _color_mapper_changed(self, old, new):

--- a/chaco/colormapped_selection_overlay.py
+++ b/chaco/colormapped_selection_overlay.py
@@ -6,6 +6,7 @@ from numpy import logical_and
 
 # Enthought library imports
 from traits.api import Any, Bool, Float, Instance, Property, Enum
+from traits.observation.events import TraitChangeEvent
 
 # Local imports
 from .abstract_overlay import AbstractOverlay
@@ -102,24 +103,43 @@ class ColormappedSelectionOverlay(AbstractOverlay):
 
     def _component_changed(self, old, new):
         if old:
-            old.on_trait_change(self.datasource_change_handler, "color_data", remove=True)
+            old.observe(self.datasource_change_handler, "color_data", remove=True)
         if new:
-            new.on_trait_change(self.datasource_change_handler, "color_data")
+            new.observe(self.datasource_change_handler, "color_data")
             self._old_alpha = new.fill_alpha
             self._old_outline_color = new.outline_color
             self._old_line_width = new.line_width
-            self.datasource_change_handler(new, "color_data", None, new.color_data)
+            
+            self.datasource_change_handler(
+                TraitChangeEvent(
+                    object=new,
+                    name="color_data",
+                    old=None,
+                    new=new.color_data
+                )
+            )
         return
 
-    def datasource_change_handler(self, obj, name, old, new):
+    def datasource_change_handler(self, event):
+        obj, name, old, new = (event.object, event.name, event.old, event.new)
+
         if old:
-            old.on_trait_change(self.selection_change_handler, "metadata_changed", remove=True)
+            old.observe(self.selection_change_handler, "metadata_changed", remove=True)
         if new:
-            new.on_trait_change(self.selection_change_handler, "metadata_changed")
-            self.selection_change_handler(new, "metadata_changed", None, new.metadata)
+            new.observe(self.selection_change_handler, "metadata_changed")
+            self.selection_change_handler(
+                TraitChangeEvent(
+                    object=new,
+                    name="metadata_changed",
+                    old=None,
+                    new=new.metadata
+                )
+        )
         return
 
-    def selection_change_handler(self, obj, name, old, new):
+    def selection_change_handler(self, event):
+        obj, name, old, new = (event.object, event.name, event.old, event.new)
+
         if self.selection_type == 'range':
             selection_key = 'selections'
         elif self.selection_type == 'mask':

--- a/chaco/data_label.py
+++ b/chaco/data_label.py
@@ -535,8 +535,7 @@ class DataLabel(ToolTip):
 
     def _modify_mapper_listeners(self, mapper, attach=True):
         if mapper is not None:
-            mapper.observe(self._handle_mapper, 'updated',
-                                   remove=not attach)
+            mapper.observe(self._handle_mapper, 'updated', remove=not attach)
         return
 
     def _handle_mapper(self, event):

--- a/chaco/data_label.py
+++ b/chaco/data_label.py
@@ -535,11 +535,11 @@ class DataLabel(ToolTip):
 
     def _modify_mapper_listeners(self, mapper, attach=True):
         if mapper is not None:
-            mapper.on_trait_change(self._handle_mapper, 'updated',
+            mapper.observe(self._handle_mapper, 'updated',
                                    remove=not attach)
         return
 
-    def _handle_mapper(self):
+    def _handle_mapper(self, event):
         # This gets fired whenever a mapper on our plot fires its
         # 'updated' event.
         self._layout_needed = True

--- a/chaco/data_range_1d.py
+++ b/chaco/data_range_1d.py
@@ -189,7 +189,7 @@ class DataRange1D(BaseDataRange):
         self._refresh_bounds()
         self.tracking_amount = self.default_tracking_amount
 
-    def refresh(self):
+    def refresh(self, event=None):
         """ If any of the bounds is 'auto', this method refreshes the actual
         low and high values from the set of the view filters' data sources.
         """
@@ -373,16 +373,16 @@ class DataRange1D(BaseDataRange):
     def _sources_items_changed(self, event):
         self.refresh()
         for source in event.removed:
-            source.on_trait_change(self.refresh, "data_changed", remove=True)
+            source.observe(self.refresh, "data_changed", remove=True)
         for source in event.added:
-            source.on_trait_change(self.refresh, "data_changed")
+            source.observe(self.refresh, "data_changed")
 
     def _sources_changed(self, old, new):
         self.refresh()
         for source in old:
-            source.on_trait_change(self.refresh, "data_changed", remove=True)
+            source.observe(self.refresh, "data_changed", remove=True)
         for source in new:
-            source.on_trait_change(self.refresh, "data_changed")
+            source.observe(self.refresh, "data_changed")
 
     #------------------------------------------------------------------------
     # Serialization interface

--- a/chaco/data_range_2d.py
+++ b/chaco/data_range_2d.py
@@ -117,7 +117,7 @@ class DataRange2D(BaseDataRange):
         self.low_setting = ('auto', 'auto')
         self.refresh()
 
-    def refresh(self):
+    def refresh(self, event=None):
         """ If any of the bounds is 'auto', this method refreshes the actual
         low and high values from the set of the view filters' data sources.
         """
@@ -205,9 +205,9 @@ class DataRange2D(BaseDataRange):
 
     def _sources_items_changed(self, event):
         for source in event.removed:
-            source.on_trait_change(self.refresh, "data_changed", remove=True)
+            source.observe(self.refresh, "data_changed", remove=True)
         for source in event.added:
-            source.on_trait_change(self.refresh, "data_changed")
+            source.observe(self.refresh, "data_changed")
         # the _xdata and _ydata of the sources may be created anew on every
         # access, so we can't just add/delete from _xrange and _yrange sources
         # based on object identity. So recreate lists each time:
@@ -217,9 +217,9 @@ class DataRange2D(BaseDataRange):
 
     def _sources_changed(self, old, new):
         for source in old:
-            source.on_trait_change(self.refresh, "data_changed", remove=True)
+            source.observe(self.refresh, "data_changed", remove=True)
         for source in new:
-            source.on_trait_change(self.refresh, "data_changed")
+            source.observe(self.refresh, "data_changed")
         # the _xdata and _ydata of the sources may be created anew on every
         # access, so we can't just add/delete from _xrange and _yrange sources
         # based on object identity. So recreate lists each time:

--- a/chaco/grid.py
+++ b/chaco/grid.py
@@ -355,13 +355,13 @@ class PlotGrid(AbstractOverlay):
 
     def _mapper_changed(self, old, new):
         if old is not None:
-            old.on_trait_change(self.mapper_updated, "updated", remove=True)
+            old.observe(self.mapper_updated, "updated", remove=True)
         if new is not None:
-            new.on_trait_change(self.mapper_updated, "updated")
+            new.observe(self.mapper_updated, "updated")
         self.invalidate()
         return
 
-    def mapper_updated(self):
+    def mapper_updated(self, event):
         """
         Event handler that is bound to this mapper's **updated** event.
         """

--- a/chaco/grid.py
+++ b/chaco/grid.py
@@ -361,7 +361,7 @@ class PlotGrid(AbstractOverlay):
         self.invalidate()
         return
 
-    def mapper_updated(self, event):
+    def mapper_updated(self, event=None):
         """
         Event handler that is bound to this mapper's **updated** event.
         """

--- a/chaco/grid_mapper.py
+++ b/chaco/grid_mapper.py
@@ -146,7 +146,7 @@ class GridMapper(AbstractMapper):
             self._ymapper.screen_bounds = (self.y_low_pos, self.y_high_pos)
         self.updated = True
 
-    def _update_range(self):
+    def _update_range(self, event=None):
         self.updated = True
 
     def _update_aspect_x(self):
@@ -185,9 +185,9 @@ class GridMapper(AbstractMapper):
 
     def _range_changed(self, old, new):
         if old is not None:
-            old.on_trait_change(self._update_range, "updated", remove=True)
+            old.observe(self._update_range, "updated", remove=True)
         if new is not None:
-            new.on_trait_change(self._update_range, "updated")
+            new.observe(self._update_range, "updated")
             if self._xmapper is not None:
                 self._xmapper.range = new.x_range
             if self._ymapper is not None:

--- a/chaco/overlays/databox.py
+++ b/chaco/overlays/databox.py
@@ -62,16 +62,14 @@ class DataBox(AbstractOverlay):
     def __init__(self, *args, **kw):
         super(DataBox, self).__init__(*args, **kw)
         if hasattr(self.component, "range2d"):
-            self.component.range2d._xrange.on_trait_change(self.my_component_moved, "updated")
-            self.component.range2d._yrange.on_trait_change(self.my_component_moved, "updated")
+            self.component.range2d._xrange.observe(self.my_component_moved, "updated")
+            self.component.range2d._yrange.observe(self.my_component_moved, "updated")
         elif hasattr(self.component, "x_mapper") and hasattr(self.component, "y_mapper"):
-            self.component.x_mapper.range.on_trait_change(self.my_component_moved, "updated")
-            self.component.y_mapper.range.on_trait_change(self.my_component_moved, "updated")
+            self.component.x_mapper.range.observe(self.my_component_moved, "updated")
+            self.component.y_mapper.range.observe(self.my_component_moved, "updated")
         else:
             raise RuntimeError("DataBox cannot find a suitable mapper on its component.")
-        self.component.on_trait_change(self.my_component_resized, "bounds")
-        self.component.on_trait_change(self.my_component_resized, "bounds_items")
-
+        self.component.observe(self.my_component_resized, "bounds.items")
 
     def overlay(self, component, gc, view_bounds=None, mode="normal"):
         if not self._position_valid:
@@ -160,7 +158,7 @@ class DataBox(AbstractOverlay):
         self._data_bounds = [data_x2 - data_pos[0], data_y2 - data_pos[1]]
         self.trait_property_changed("data_bounds", self._data_bounds)
 
-    def my_component_moved(self):
+    def my_component_moved(self, event):
         if self.affinity == "screen":
             # If we have screen affinity, then we need to take our current position
             # and map that back down into data coords
@@ -169,7 +167,7 @@ class DataBox(AbstractOverlay):
         self._bounds_valid = False
         self._position_valid = False
 
-    def my_component_resized(self):
+    def my_component_resized(self, event):
         self._bounds_valid = False
         self._position_valid = False
 

--- a/chaco/overlays/databox.py
+++ b/chaco/overlays/databox.py
@@ -158,7 +158,7 @@ class DataBox(AbstractOverlay):
         self._data_bounds = [data_x2 - data_pos[0], data_y2 - data_pos[1]]
         self.trait_property_changed("data_bounds", self._data_bounds)
 
-    def my_component_moved(self, event):
+    def my_component_moved(self, event=None):
         if self.affinity == "screen":
             # If we have screen affinity, then we need to take our current position
             # and map that back down into data coords
@@ -167,9 +167,8 @@ class DataBox(AbstractOverlay):
         self._bounds_valid = False
         self._position_valid = False
 
-    def my_component_resized(self, event):
+    def my_component_resized(self, event=None):
         self._bounds_valid = False
         self._position_valid = False
-
 
 

--- a/chaco/overlays/simple_inspector_overlay.py
+++ b/chaco/overlays/simple_inspector_overlay.py
@@ -155,7 +155,8 @@ class SimpleInspectorOverlay(TextGridOverlay):
         return [[basic_formatter('x', 2)], [basic_formatter('y', 2)]]
 
     def _new_value_updated(self, event):
-        if event is None:
+        new_value_event = event.new
+        if new_value_event is None:
             self.text_grid = array()
             if self.visibility == "auto":
                 self.visibility = False
@@ -165,7 +166,7 @@ class SimpleInspectorOverlay(TextGridOverlay):
         if self.tooltip_mode:
             self.alternate_position = self.inspector.last_mouse_position
 
-        d = event
+        d = new_value_event
         text = []
         self.text_grid.string_array = array([[formatter(**d) for formatter in row]
             for row in self.field_formatters])
@@ -178,14 +179,14 @@ class SimpleInspectorOverlay(TextGridOverlay):
 
     def _inspector_changed(self, old, new):
         if old:
-            old.on_trait_event(self._new_value_updated, 'new_value', remove=True)
-            old.on_trait_change(self._tool_visible_changed, "visible", remove=True)
+            old.observe(self._new_value_updated, 'new_value', remove=True)
+            old.observe(self._tool_visible_changed, "visible", remove=True)
         if new:
-            new.on_trait_event(self._new_value_updated, 'new_value')
-            new.on_trait_change(self._tool_visible_changed, "visible")
+            new.observe(self._new_value_updated, 'new_value')
+            new.observe(self._tool_visible_changed, "visible")
             self._tool_visible_changed()
 
-    def _tool_visible_changed(self):
+    def _tool_visible_changed(self, event=None):
         self.visibility = self.inspector.visible
         if self.visibility != "auto":
             self.visible = self.visibility

--- a/chaco/plot.py
+++ b/chaco/plot.py
@@ -1244,24 +1244,26 @@ class Plot(DataView):
 
     def _data_changed(self, old, new):
         if old:
-            old.on_trait_change(self._data_update_handler, "data_changed",
+            old.observe(self._data_update_handler, "data_changed",
                                 remove=True)
         if new:
-            new.on_trait_change(self._data_update_handler, "data_changed")
+            new.observe(self._data_update_handler, "data_changed")
 
-    def _data_update_handler(self, name, event):
+    def _data_update_handler(self, event):
+        name = event.name
+        data_changed_event = event.new
         # event should be a dict with keys "added", "removed", and "changed",
         # per the comments in AbstractPlotData.
-        if "removed" in event:
-            for name in event["removed"]:
+        if "removed" in data_changed_event:
+            for name in data_changed_event["removed"]:
                 del self.datasources[name]
 
-        if "added" in event:
-            for name in event["added"]:
+        if "added" in data_changed_event:
+            for name in data_changed_event["added"]:
                 self._get_or_create_datasource(name)
 
-        if "changed" in event:
-            for name in event["changed"]:
+        if "changed" in data_changed_event:
+            for name in data_changed_event["changed"]:
                 if name in self.datasources:
                     source = self.datasources[name]
                     source.set_data(self.data.get_data(name))

--- a/chaco/plot.py
+++ b/chaco/plot.py
@@ -1244,8 +1244,7 @@ class Plot(DataView):
 
     def _data_changed(self, old, new):
         if old:
-            old.observe(self._data_update_handler, "data_changed",
-                                remove=True)
+            old.observe(self._data_update_handler, "data_changed", remove=True)
         if new:
             new.observe(self._data_update_handler, "data_changed")
 

--- a/chaco/plotscrollbar.py
+++ b/chaco/plotscrollbar.py
@@ -153,9 +153,9 @@ class PlotScrollBar(NativeScrollBar):
         else:
             remove=True
         plot.observe(self._component_bounds_handler,
-                             "bounds.items", remove=remove)
+                     "bounds.items", remove=remove)
         plot.observe(self._component_pos_handler,
-                             "position.items", remove=remove)
+                     "position.items", remove=remove)
         return
 
     def _component_bounds_handler(self, event):

--- a/chaco/plotscrollbar.py
+++ b/chaco/plotscrollbar.py
@@ -152,21 +152,17 @@ class PlotScrollBar(NativeScrollBar):
             remove=False
         else:
             remove=True
-        plot.on_trait_change(self._component_bounds_handler,
-                             "bounds", remove=remove)
-        plot.on_trait_change(self._component_bounds_handler,
-                             "bounds_items", remove=remove)
-        plot.on_trait_change(self._component_pos_handler,
-                             "position", remove=remove)
-        plot.on_trait_change(self._component_pos_handler,
-                             "position_items", remove=remove)
+        plot.observe(self._component_bounds_handler,
+                             "bounds.items", remove=remove)
+        plot.observe(self._component_pos_handler,
+                             "position.items", remove=remove)
         return
 
-    def _component_bounds_handler(self):
+    def _component_bounds_handler(self, event):
         self._handle_dataspace_update()
         self._widget_moved = True
 
-    def _component_pos_handler(self):
+    def _component_pos_handler(self, event):
         self._handle_dataspace_update()
         self._widget_moved = True
 

--- a/chaco/scatterplot.py
+++ b/chaco/scatterplot.py
@@ -526,7 +526,7 @@ class ScatterPlot(BaseXYPlot):
         self.invalidate_draw()
         self.request_redraw()
 
-    def _either_metadata_changed(self):
+    def _either_metadata_updated(self, event):
         if self.show_selection:
             # Only redraw when we are showing the selection. Otherwise, there
             # is nothing to update in response to this event.


### PR DESCRIPTION
This PR starts replacing the dynamic uses of on_trait_change with observe equivalents

I am going to arbitrarily stop here to keep this PR shorter to review.  After these changes, there are 18 files left containing `.on_trait_change` which can be addressed in a separate PR.