### PR TITLE
Replace dynamic on_trait_change with observe part 2

### DIFF
--- a/chaco/scatter_inspector_overlay.py
+++ b/chaco/scatter_inspector_overlay.py
@@ -148,9 +148,10 @@ class ScatterInspectorOverlay(AbstractOverlay):
         return
 
     def _ds_changed(self, event):
-        if event.old:
+        old, new = event.old, event.new
+        if old:
             old.observe(self.metadata_changed, 'metadata_changed', remove=True)
-        if event.new:
+        if new:
             new.observe(self.metadata_changed, 'metadata_changed')
         return
 

--- a/chaco/scatter_inspector_overlay.py
+++ b/chaco/scatter_inspector_overlay.py
@@ -42,7 +42,7 @@ class ScatterInspectorOverlay(AbstractOverlay):
     # using a series of trait change handlers (defined at the end of the
     # class)
     #@on_trait_change('component.index.metadata_changed,component.value.metadata_changed')
-    def metadata_changed(self, object, name, old, new):
+    def metadata_updated(self, event):
         if self.component is not None:
             self.component.request_redraw()
         return
@@ -150,9 +150,9 @@ class ScatterInspectorOverlay(AbstractOverlay):
     def _ds_changed(self, event):
         old, new = event.old, event.new
         if old:
-            old.observe(self.metadata_changed, 'metadata_changed', remove=True)
+            old.observe(self.metadata_updated, 'metadata_changed', remove=True)
         if new:
-            new.observe(self.metadata_changed, 'metadata_changed')
+            new.observe(self.metadata_updated, 'metadata_changed')
         return
 
 

--- a/chaco/tools/image_inspector_tool.py
+++ b/chaco/tools/image_inspector_tool.py
@@ -127,17 +127,18 @@ class ImageInspectorOverlay(TextBoxOverlay):
 
     def _image_inspector_changed(self, old, new):
         if old:
-            old.on_trait_event(self._new_value_updated, 'new_value',
+            old.observe(self._new_value_updated, 'new_value',
                                remove=True)
-            old.on_trait_change(self._tool_visible_changed, "visible",
+            old.observe(self._tool_visible_updated, "visible",
                                 remove=True)
         if new:
-            new.on_trait_event(self._new_value_updated, 'new_value')
-            new.on_trait_change(self._tool_visible_changed, "visible")
-            self._tool_visible_changed()
+            new.observe(self._new_value_updated, 'new_value')
+            new.observe(self._tool_visible_updated, "visible")
+            self._tool_visible_updated()
 
     def _new_value_updated(self, event):
-        if event is None:
+        new_value_event = event.new
+        if new_value_event is None:
             self.text = ""
             if self.visibility == "auto":
                 self.visible = False
@@ -150,13 +151,13 @@ class ImageInspectorOverlay(TextBoxOverlay):
         else:
             self.alternate_position = None
 
-        self.text = self._build_text_from_event(event)
+        self.text = self._build_text_from_event(new_value_event)
         self.component.request_redraw()
 
     def _visible_changed(self):
         self.component.request_redraw()
 
-    def _tool_visible_changed(self):
+    def _tool_visible_updated(self, event=None):
         self.visibility = self.image_inspector.visible
         if self.visibility != "auto":
             self.visible = self.visibility

--- a/chaco/tools/range_selection.py
+++ b/chaco/tools/range_selection.py
@@ -685,9 +685,9 @@ class RangeSelection(AbstractController):
 
     def _axis_changed(self, old, new):
         if old is not None:
-            self.plot.observe(self.__mapper_changed,
-                                      old + "_mapper", remove=True)
+            self.plot.observe(
+                self.__mapper_changed, old + "_mapper", remove=True
+            )
         if new is not None:
-            self.plot.observe(self.__mapper_changed,
-                                      new + "_mapper")
+            self.plot.observe(self.__mapper_changed, new + "_mapper")
         return

--- a/chaco/tools/range_selection.py
+++ b/chaco/tools/range_selection.py
@@ -679,15 +679,15 @@ class RangeSelection(AbstractController):
             else:
                 return 0
 
-    def __mapper_changed(self):
+    def __mapper_changed(self, event):
         self.deselect()
         return
 
     def _axis_changed(self, old, new):
         if old is not None:
-            self.plot.on_trait_change(self.__mapper_changed,
+            self.plot.observe(self.__mapper_changed,
                                       old + "_mapper", remove=True)
         if new is not None:
-            self.plot.on_trait_change(self.__mapper_changed,
-                                      old + "_mapper", remove=True)
+            self.plot.observe(self.__mapper_changed,
+                                      new + "_mapper")
         return

--- a/chaco/tools/range_selection_overlay.py
+++ b/chaco/tools/range_selection_overlay.py
@@ -161,10 +161,10 @@ class RangeSelectionOverlay(AbstractOverlay):
 
         datasource = getattr(self.plot, self.axis)
         if old:
-            datasource.on_trait_change(self._metadata_change_handler, "metadata_changed",
+            datasource.observe(self._metadata_change_handler, "metadata_changed",
                                         remove=True)
         if new:
-            datasource.on_trait_change(self._metadata_change_handler, "metadata_changed")
+            datasource.observe(self._metadata_change_handler, "metadata_changed")
         return
 
     def _metadata_change_handler(self, event):

--- a/chaco/tools/simple_zoom.py
+++ b/chaco/tools/simple_zoom.py
@@ -149,7 +149,7 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
             self._orig_low_setting = (x_range.low_setting, y_range.low_setting)
             self._orig_high_setting = \
                 (x_range.high_setting, y_range.high_setting)
-        component.on_trait_change(self._reset_state_to_current,
+        component.observe(self._reset_state_to_current,
                                   "index_data_changed")
         return
 
@@ -594,7 +594,7 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
     # implementations of abstract methods on ToolHistoryMixin
     #------------------------------------------------------------------------
 
-    def _reset_state_to_current(self):
+    def _reset_state_to_current(self, event=None):
         """ Clears the tool history, and sets the current state to be the
         first state in the history.
         """

--- a/chaco/tools/tests/test_image_inspector.py
+++ b/chaco/tools/tests/test_image_inspector.py
@@ -57,7 +57,7 @@ class BaseImageInspectorTool(EnableTestAssistant, UnittestTools):
         tool = self.tool
 
         # Add a listener to catch the emitted event:
-        tool.on_trait_change(self.store_inspector_event, "new_value")
+        tool.observe(self.store_inspector_event, "new_value")
         try:
             self.assertIsNone(self.insp_event)
 
@@ -67,13 +67,13 @@ class BaseImageInspectorTool(EnableTestAssistant, UnittestTools):
 
             self.assertEqual(self.overlay2.text, 'Position: (0, 0)')
         finally:
-            tool.on_trait_change(self.store_inspector_event, "new_value",
+            tool.observe(self.store_inspector_event, "new_value",
                                  remove=True)
 
     # Helper methods ----------------------------------------------------------
 
     def store_inspector_event(self, event):
-        self.insp_event = event
+        self.insp_event = event.new
 
 
 class TestImageInspectorToolGray(BaseImageInspectorTool, TestCase):
@@ -89,7 +89,7 @@ class TestImageInspectorToolGray(BaseImageInspectorTool, TestCase):
         tool = self.tool
 
         # Add a listener to catch the emitted event:
-        tool.on_trait_change(self.store_inspector_event, "new_value")
+        tool.observe(self.store_inspector_event, "new_value")
         try:
             self.assertIsNone(self.insp_event)
 
@@ -136,7 +136,7 @@ class TestImageInspectorToolGray(BaseImageInspectorTool, TestCase):
                     self.assertEqual(self.overlay.text, '(1, 1)\n3')
 
         finally:
-            tool.on_trait_change(self.store_inspector_event, "new_value",
+            tool.observe(self.store_inspector_event, "new_value",
                                  remove=True)
 
 
@@ -153,7 +153,7 @@ class TestImageInspectorToolRGB(BaseImageInspectorTool, TestCase):
         tool = self.tool
 
         # Add a listener to catch the emitted event:
-        tool.on_trait_change(self.store_inspector_event, "new_value")
+        tool.observe(self.store_inspector_event, "new_value")
         try:
             self.assertIsNone(self.insp_event)
 
@@ -205,5 +205,5 @@ class TestImageInspectorToolRGB(BaseImageInspectorTool, TestCase):
                     self.assertEqual(self.overlay.text, '(1, 1)\n(9, 10, 11)')
 
         finally:
-            tool.on_trait_change(self.store_inspector_event, "new_value",
+            tool.observe(self.store_inspector_event, "new_value",
                                  remove=True)

--- a/chaco/tools/tests/test_scatter_inspector.py
+++ b/chaco/tools/tests/test_scatter_inspector.py
@@ -162,8 +162,9 @@ class TestScatterInspectorTool(EnableTestAssistant, TestCase, UnittestTools):
                 self.assertEqual(self.insp_event.event_type, "deselect")
                 self.assertEqual(self.insp_event.event_index, 1)
         finally:
-            tool.observe(self.store_inspector_event, "inspector_event",
-                                 remove=True)
+            tool.observe(
+                self.store_inspector_event, "inspector_event", remove=True
+            )
 
     # Helper methods ----------------------------------------------------------
 

--- a/chaco/tools/tests/test_scatter_inspector.py
+++ b/chaco/tools/tests/test_scatter_inspector.py
@@ -103,7 +103,7 @@ class TestScatterInspectorTool(EnableTestAssistant, TestCase, UnittestTools):
         tool = self.tool
 
         # Add a listener to catch the emitted event:
-        tool.on_trait_change(self.store_inspector_event, "inspector_event")
+        tool.observe(self.store_inspector_event, "inspector_event")
         try:
             self.assertIsNone(self.insp_event)
 
@@ -131,14 +131,14 @@ class TestScatterInspectorTool(EnableTestAssistant, TestCase, UnittestTools):
                 self.assertEqual(self.insp_event.event_type, "hover")
                 self.assertEqual(self.insp_event.event_index, 1)
         finally:
-            tool.on_trait_change(self.store_inspector_event, "inspector_event",
+            tool.observe(self.store_inspector_event, "inspector_event",
                                  remove=True)
 
     def test_select_triggers_event(self):
         tool = self.tool
 
         # Add a listener to catch the emitted event:
-        tool.on_trait_change(self.store_inspector_event, "inspector_event")
+        tool.observe(self.store_inspector_event, "inspector_event")
         try:
             self.assertIsNone(self.insp_event)
 
@@ -162,10 +162,10 @@ class TestScatterInspectorTool(EnableTestAssistant, TestCase, UnittestTools):
                 self.assertEqual(self.insp_event.event_type, "deselect")
                 self.assertEqual(self.insp_event.event_index, 1)
         finally:
-            tool.on_trait_change(self.store_inspector_event, "inspector_event",
+            tool.observe(self.store_inspector_event, "inspector_event",
                                  remove=True)
 
     # Helper methods ----------------------------------------------------------
 
     def store_inspector_event(self, event):
-        self.insp_event = event
+        self.insp_event = event.new

--- a/examples/demo/advanced/scalar_image_function_inspector.py
+++ b/examples/demo/advanced/scalar_image_function_inspector.py
@@ -178,8 +178,7 @@ class PlotUI(HasTraits):
                                           array([]),
                                           sort_order=("ascending","ascending"))
         image_index_range = DataRange2D(self._image_index)
-        self._image_index.observe(self._metadata_changed,
-                                          "metadata_changed")
+        self._image_index.observe(self._metadata_changed, "metadata_changed")
 
         self._image_value = ImageData(data=array([]), value_depth=1)
         image_value_range = DataRange1D(self._image_value)

--- a/examples/demo/advanced/scalar_image_function_inspector.py
+++ b/examples/demo/advanced/scalar_image_function_inspector.py
@@ -178,7 +178,7 @@ class PlotUI(HasTraits):
                                           array([]),
                                           sort_order=("ascending","ascending"))
         image_index_range = DataRange2D(self._image_index)
-        self._image_index.on_trait_change(self._metadata_changed,
+        self._image_index.observe(self._metadata_changed,
                                           "metadata_changed")
 
         self._image_value = ImageData(data=array([]), value_depth=1)
@@ -323,7 +323,8 @@ class PlotUI(HasTraits):
     # Event handlers
     #---------------------------------------------------------------------------
 
-    def _metadata_changed(self, old, new):
+    def _metadata_changed(self, event):
+        old, new = event.old, event.new
         """ This function takes out a cross section from the image data, based
         on the line inspector selections, and updates the line and scatter
         plots."""

--- a/examples/demo/advanced/scalar_image_function_inspector_old.py
+++ b/examples/demo/advanced/scalar_image_function_inspector_old.py
@@ -140,8 +140,7 @@ class PlotUI(HasTraits):
                                           array([]),
                                           sort_order=("ascending","ascending"))
         image_index_range = DataRange2D(self._image_index)
-        self._image_index.observe(self._metadata_changed,
-                                          "metadata_changed")
+        self._image_index.observe(self._metadata_changed, "metadata_changed")
 
         self._image_value = ImageData(data=array([]), value_depth=1)
         image_value_range = DataRange1D(self._image_value)

--- a/examples/demo/advanced/scalar_image_function_inspector_old.py
+++ b/examples/demo/advanced/scalar_image_function_inspector_old.py
@@ -140,7 +140,7 @@ class PlotUI(HasTraits):
                                           array([]),
                                           sort_order=("ascending","ascending"))
         image_index_range = DataRange2D(self._image_index)
-        self._image_index.on_trait_change(self._metadata_changed,
+        self._image_index.observe(self._metadata_changed,
                                           "metadata_changed")
 
         self._image_value = ImageData(data=array([]), value_depth=1)
@@ -283,7 +283,8 @@ class PlotUI(HasTraits):
     # Event handlers
     #---------------------------------------------------------------------------
 
-    def _metadata_changed(self, old, new):
+    def _metadata_changed(self, event):
+        old, new = event.old, event.new
         """ This function takes out a cross section from the image data, based
         on the line inspector selections, and updates the line and scatter
         plots."""
@@ -353,7 +354,7 @@ class Controller(Handler):
     def init(self, info):
         self.model = info.object.model
         self.view = info.object.view
-        self.model.on_trait_change(self._model_changed, "model_changed")
+        self.model.observe(self._model_changed, "model_changed")
 
 
     #---------------------------------------------------------------------------
@@ -371,7 +372,7 @@ class Controller(Handler):
     # Private Controller interface
     #---------------------------------------------------------------------------
 
-    def _model_changed(self):
+    def _model_changed(self, event):
         if self.view is not None:
             self.view.update(self.model)
 

--- a/examples/demo/basic/image_lasso.py
+++ b/examples/demo/basic/image_lasso.py
@@ -23,7 +23,11 @@ from chaco.tools.api import LassoSelection, LassoSelection
 # # Create the Chaco plot.
 #===============================================================================
 
-def lasso_updated(lasso_tool, name, old, new_selections):
+def lasso_updated(event):
+    lasso_tool = event.object
+    name = event.name
+    old = event.old
+    new_selections = event.new
     # new_selections is a list of arrays of coordinates in dataspace.  It is a
     # list because the LassoSelection supports multiple, disjoint selection regions.
     for i, selection in enumerate(new_selections):
@@ -62,7 +66,7 @@ def _create_plot_component():# Create a scalar field to colormap
     plot.padding = 50
 
     lasso_selection = LassoSelection(component=img_plot)
-    lasso_selection.on_trait_change(lasso_updated, "disjoint_selections")
+    lasso_selection.observe(lasso_updated, "disjoint_selections")
     lasso_overlay = LassoOverlay(lasso_selection = lasso_selection, component=img_plot)
     img_plot.tools.append(lasso_selection)
     img_plot.overlays.append(lasso_overlay)

--- a/examples/demo/basic/scatter_inspector.py
+++ b/examples/demo/basic/scatter_inspector.py
@@ -53,9 +53,10 @@ def _create_plot_component():
     scatter.overlays.append(overlay)
 
     # Optional: add a listener on inspector events:
-    def echo(new):
+    def echo(event):
+        new = event.new
         print("{} event on element {}".format(new.event_type, new.event_index))
-    inspector.on_trait_change(echo, "inspector_event")
+    inspector.observe(echo, "inspector_event")
 
     return plot
 

--- a/examples/demo/basic/scatter_rect_select.py
+++ b/examples/demo/basic/scatter_rect_select.py
@@ -123,8 +123,7 @@ class Demo(HasTraits):
 
         # Set up the trait handler for the selection
         self.index_datasource = my_plot.index
-        rect_selection.observe(self._selection_changed,
-                                       'selection_changed')
+        rect_selection.observe(self._selection_changed, 'selection_changed')
 
         return plot
 

--- a/examples/demo/basic/scatter_rect_select.py
+++ b/examples/demo/basic/scatter_rect_select.py
@@ -107,7 +107,7 @@ class Demo(HasTraits):
         resizable=True, title=title
     )
 
-    def _selection_changed(self):
+    def _selection_changed(self, event):
         mask = self.index_datasource.metadata['selections']
         print("New selection: ")
         print(compress(mask, arange(len(mask))))
@@ -123,7 +123,7 @@ class Demo(HasTraits):
 
         # Set up the trait handler for the selection
         self.index_datasource = my_plot.index
-        rect_selection.on_trait_change(self._selection_changed,
+        rect_selection.observe(self._selection_changed,
                                        'selection_changed')
 
         return plot

--- a/examples/demo/basic/scatter_select.py
+++ b/examples/demo/basic/scatter_select.py
@@ -115,8 +115,7 @@ class Demo(HasTraits):
 
          # Set up the trait handler for the selection
          self.index_datasource = my_plot.index
-         lasso_selection.observe(self._selection_changed,
-                                        'selection_changed')
+         lasso_selection.observe(self._selection_changed, 'selection_changed')
 
          return plot
 

--- a/examples/demo/basic/scatter_select.py
+++ b/examples/demo/basic/scatter_select.py
@@ -98,7 +98,7 @@ class Demo(HasTraits):
                     resizable=True, title=title
                     )
 
-    def _selection_changed(self):
+    def _selection_changed(self, event):
         mask = self.index_datasource.metadata['selection']
         print("New selection: ")
         print(compress(mask, arange(len(mask))))
@@ -115,7 +115,7 @@ class Demo(HasTraits):
 
          # Set up the trait handler for the selection
          self.index_datasource = my_plot.index
-         lasso_selection.on_trait_change(self._selection_changed,
+         lasso_selection.observe(self._selection_changed,
                                         'selection_changed')
 
          return plot

--- a/examples/demo/basic/scatter_toggle.py
+++ b/examples/demo/basic/scatter_toggle.py
@@ -104,7 +104,7 @@ class Demo(HasTraits):
                     resizable=True, title=title
                     )
 
-    def _metadata_handler(self):
+    def _metadata_handler(self, event):
         sel_indices = self.index_datasource.metadata.get('selections', [])
         print("Selection indices:", sel_indices)
 
@@ -119,7 +119,7 @@ class Demo(HasTraits):
 
         # Set up the trait handler for the selection
         self.index_datasource = my_plot.index
-        self.index_datasource.on_trait_change(self._metadata_handler,
+        self.index_datasource.observe(self._metadata_handler,
                                               "metadata_changed")
 
         return plot

--- a/examples/demo/basic/scatter_toggle.py
+++ b/examples/demo/basic/scatter_toggle.py
@@ -119,8 +119,9 @@ class Demo(HasTraits):
 
         # Set up the trait handler for the selection
         self.index_datasource = my_plot.index
-        self.index_datasource.observe(self._metadata_handler,
-                                              "metadata_changed")
+        self.index_datasource.observe(
+            self._metadata_handler, "metadata_changed"
+        )
 
         return plot
 

--- a/examples/demo/chaco_trait_editor.py
+++ b/examples/demo/chaco_trait_editor.py
@@ -125,7 +125,7 @@ class IntervalEditorImpl(Editor):
         # Do not allow the user to reset the range
         range_selection.event_state = "selected"
         range_selection.deselect = lambda x: None
-        range_selection.on_trait_change(self.update_interval, 'selection')
+        range_selection.observe(self.update_interval, 'selection')
 
         plot.tools.append(range_selection)
         plot.overlays.append(RangeKnobsOverlay(plot))
@@ -143,7 +143,8 @@ class IntervalEditorImpl(Editor):
         else:
             self.control.setMaximumSize(factory.width, factory.height)
 
-    def update_interval(self, value):
+    def update_interval(self, event):
+        value = event.new
         low, high = value
 
         low = max(low, 0)

--- a/examples/demo/financial/correlations.py
+++ b/examples/demo/financial/correlations.py
@@ -105,7 +105,7 @@ class PlotApp(HasTraits):
         # Grab a reference to the Time axis datasource and add a listener to its
         # selections metadata
         self.times_ds = renderer.index
-        self.times_ds.on_trait_change(self._selections_changed, 'metadata_changed')
+        self.times_ds.observe(self._selections_updated, 'metadata_changed')
         self.returns_plot = plot
 
     def _create_corr_plot(self):
@@ -123,13 +123,15 @@ class PlotApp(HasTraits):
             plotdata.set_data(name, cumprod(random.lognormal(0.0, 0.04, size=numpoints)))
         self.plotdata = plotdata
 
-    def _selections_changed(self, event):
+    def _selections_updated(self, event):
+        metadata_changed_event = event.new
         if self.corr_renderer is None:
             return
-        if not isinstance(event, dict) or "selections" not in event:
+        if not isinstance(metadata_changed_event, dict) \
+                or "selections" not in metadata_changed_event:
             return
         corr_index = self.corr_renderer.index
-        selections = event["selections"]
+        selections = metadata_changed_event["selections"]
         if selections is None:
             corr_index.metadata.pop("selections", None)
             return
@@ -138,7 +140,9 @@ class PlotApp(HasTraits):
             data = self.times_ds.get_data()
             low_ndx = data.searchsorted(low)
             high_ndx = data.searchsorted(high)
-            corr_index.metadata["selections"] = arange(low_ndx, high_ndx+1, 1, dtype=int)
+            corr_index.metadata["selections"] = arange(
+                low_ndx, high_ndx+1, 1, dtype=int
+            )
             self.corr_plot.request_redraw()
 
     @observe("sym1,sym2")

--- a/examples/demo/financial/stock_prices.py
+++ b/examples/demo/financial/stock_prices.py
@@ -93,26 +93,28 @@ class PlotFrame(DemoFrame):
         miniplot.tools.append(range_tool)
         range_overlay = RangeSelectionOverlay(miniplot, metadata_name="selections")
         miniplot.overlays.append(range_overlay)
-        range_tool.on_trait_change(self._range_selection_handler, "selection")
+        range_tool.observe(self._range_selection_handler, "selection")
 
         # Attach a handler that sets the tool when the plot's index range changes
         self.range_tool = range_tool
-        price_plot.index_range.on_trait_change(self._plot_range_handler, "updated")
+        price_plot.index_range.observe(self._plot_range_handler, "updated")
 
         return price_plot, miniplot
 
 
     def _range_selection_handler(self, event):
+        range_selection_event = event.new
         # The event obj should be a tuple (low, high) in data space
-        if event is not None:
-            low, high = event
+        if range_selection_event is not None:
+            low, high = range_selection_event
             self.price_plot.index_range.low = low
             self.price_plot.index_range.high = high
         else:
             self.price_plot.index_range.set_bounds("auto", "auto")
 
     def _plot_range_handler(self, event):
-        if event is not None:
+        plot_range_event = event.new
+        if plot_range_event is not None:
             low, high = event
             if "auto" not in (low, high):
                 self.range_tool.selection = (low, high)
@@ -136,7 +138,7 @@ class PlotFrame(DemoFrame):
                                       constrain_direction="x"))
         return vol_plot
 
-    def _create_window(self):
+    def _create_component(self):
 
         # Create the data and datasource objects
         # In order for the date axis to work, the index data points need to
@@ -179,7 +181,7 @@ class PlotFrame(DemoFrame):
                                    fill_padding=False)
         container.add(mini_plot, vol_plot, price_plot)
 
-        return Window(self, -1, component=container)
+        return container
 
 if __name__ == "__main__":
     # Save demo so that it doesn't get garbage collected when run within

--- a/examples/demo/zoomed_plot/zoom_overlay.py
+++ b/examples/demo/zoomed_plot/zoom_overlay.py
@@ -99,13 +99,14 @@ class ZoomOverlay(AbstractOverlay):
 
     def _source_changed(self, old, new):
         if old is not None and old.controller is not None:
-            old.controller.on_trait_change(self._selection_update_handler, "selection",
+            old.controller.observe(self._selection_update_handler, "selection",
                                            remove=True)
         if new is not None and new.controller is not None:
-            new.controller.on_trait_change(self._selection_update_handler, "selection")
+            new.controller.observe(self._selection_update_handler, "selection")
         return
 
-    def _selection_update_handler(self, value):
+    def _selection_update_handler(self, event):
+        value = event.new
         if value is not None and self.destination is not None:
             r = self.destination.index_mapper.range
             start, end = amin(value), amax(value)


### PR DESCRIPTION
This PR continues replacing the dynamic uses of on_trait_change with observe equivalents on top of #590 

