### PR TITLE
Remove dummy return statements in testsuite

### DIFF
--- a/chaco/scales/tests/test_scales.py
+++ b/chaco/scales/tests/test_scales.py
@@ -165,7 +165,6 @@ class BasicFormatterTestCase(TicksTestCase):
             actual = sum(map(len, labels))
             err = abs(estimate - actual) / actual
             self.assertLess(err, 0.5)
-        return
 
     def test_width_based_default_scale(self):
         scale = ScaleSystem()

--- a/chaco/scales/tests/test_time_scale_resolution.py
+++ b/chaco/scales/tests/test_time_scale_resolution.py
@@ -41,7 +41,6 @@ class TRangeTestCase(TicksTestCase):
             )
         for start, end, kw in ranges:
             self.assert_empty(trange(DTS(*start), DTS(*end), **kw))
-        return
 
     def test_microseconds(self):
         # Testing the microsecond scale is dicey--`base` is a 10 digit integer,

--- a/chaco/tests/test_base_utils.py
+++ b/chaco/tests/test_base_utils.py
@@ -64,7 +64,6 @@ class ReverseMap1DTestCase(unittest.TestCase):
         self.assertEqual(rmap(3.4), 3)
         self.assertEqual(rmap(3.5), 3)
         self.assertEqual(rmap(3.6), 4)
-        return
 
     def test_ascending_floor(self):
         ary = arange(10.0)
@@ -74,7 +73,6 @@ class ReverseMap1DTestCase(unittest.TestCase):
         self.assertEqual(rmap(3.4), 3)
         self.assertEqual(rmap(3.5), 3)
         self.assertEqual(rmap(3.6), 3)
-        return
 
     def test_descending(self):
         ary = arange(10.0, 0.0, -1.0)
@@ -93,7 +91,6 @@ class ReverseMap1DTestCase(unittest.TestCase):
         self.assertEqual(rmap(8.6), 1)
         self.assertEqual(rmap(8.5), 1)
         self.assertEqual(rmap(8.4), 2)
-        return
 
     def test_descending_floor(self):
         ary = arange(10.0, 0.0, -1.0)
@@ -103,7 +100,6 @@ class ReverseMap1DTestCase(unittest.TestCase):
         self.assertEqual(rmap(8.6), 1)
         self.assertEqual(rmap(8.5), 1)
         self.assertEqual(rmap(8.4), 1)
-        return
 
 
 class FindRunsTestCase(unittest.TestCase):

--- a/chaco/tests/test_colormapper.py
+++ b/chaco/tests/test_colormapper.py
@@ -30,8 +30,6 @@ class LinearSegmentedColormapTestCase(unittest.TestCase):
         self.assertTrue(close,
             "Simple map failed.  Expected %s.  Got %s" % (expected, b[:,:1]))
 
-        return
-
     def test_change_min_max(self):
         """ Test that changing min_value and max_value does not break map. """
 
@@ -70,9 +68,6 @@ class LinearSegmentedColormapTestCase(unittest.TestCase):
         self.assertTrue(close,
             "Changing min value broke map.  Expected %s.  Got %s" % (expected, b[:,:1]))
 
-
-        return
-
     def test_array_factory(self):
         """ Test that the array factory creates valid colormap. """
 
@@ -89,8 +84,6 @@ class LinearSegmentedColormapTestCase(unittest.TestCase):
 
         self.assertTrue(allclose(ravel(b[:,:1]), expected, atol=0.02),
             "Array factory failed.  Expected %s.  Got %s" % (expected, b[:,:1]))
-
-        return
 
     def test_alpha_palette(self):
         """ Create a colormap with a varying alpha channel from a palette array.

--- a/chaco/tests/test_datarange_1d.py
+++ b/chaco/tests/test_datarange_1d.py
@@ -36,7 +36,6 @@ class DataRangeTestCase(unittest.TestCase):
         self.assertEqual(r.high_setting, 10.0)
         self.assertEqual(r.low, 5.0)
         self.assertEqual(r.high, 10.0)
-        return
 
     def test_set_bounds1(self):
         """Change both low and high with set_bounds()."""
@@ -175,7 +174,6 @@ class DataRangeTestCase(unittest.TestCase):
         r.low = "auto"
         self.assertEqual(r.low_setting, "auto")
         self.assertEqual(r.low, 0.0)
-        return
 
     def test_constant_value(self):
         r = DataRange1D()
@@ -204,8 +202,6 @@ class DataRangeTestCase(unittest.TestCase):
         r.add(ds)
         self.assertEqual(r.low, -0.25)
         self.assertEqual(r.high, 0.0)
-        return
-
 
     def test_multi_source(self):
         ds1 = ArrayDataSource(array([3, 4, 5, 6, 7]))
@@ -213,7 +209,6 @@ class DataRangeTestCase(unittest.TestCase):
         r = DataRange1D(ds1, ds2)
         self.assertEqual(r.low, 3.0)
         self.assertEqual(r.high, 20.0)
-        return
 
     def test_clip_data(self):
         r = DataRange1D(low=2.0, high=10.0)
@@ -227,7 +222,6 @@ class DataRangeTestCase(unittest.TestCase):
 
         r = DataRange1D(low=2.0, high=2.5)
         assert_equal(len(r.clip_data(ary)) , 0)
-        return
 
     def test_mask_data(self):
         r = DataRange1D(low=2.0, high=10.0)
@@ -242,7 +236,6 @@ class DataRangeTestCase(unittest.TestCase):
 
         r = DataRange1D(low=2.0, high=2.5)
         assert_equal(r.mask_data(ary) , zeros(len(ary)))
-        return
 
     def test_bound_data(self):
         r = DataRange1D(low=2.9, high=6.1)
@@ -253,7 +246,6 @@ class DataRangeTestCase(unittest.TestCase):
         ary = array([-5,-4,-7,-8,-2,1,2,3,4,5,4,3,8,9,10,9,8])
         bounds = r.bound_data(ary)
         assert_equal(bounds , (7,11))
-        return
 
     def test_custom_bounds_func(self):
         def custom_func(low, high, margin, tight_bounds):

--- a/chaco/tests/test_datarange_2d.py
+++ b/chaco/tests/test_datarange_2d.py
@@ -21,7 +21,6 @@ class DataRange2DTestCase(unittest.TestCase):
         assert_ary_(r.high_setting, array([10.0,10.0]))
         assert_ary_(r.low,array([5.0,5.0]))
         assert_ary_(r.high, array([10.0,10.0]))
-        return
 
     def test_single_source(self):
         r = DataRange2D()
@@ -48,7 +47,6 @@ class DataRange2DTestCase(unittest.TestCase):
         r.low = ('auto', 'auto')
         self.assertTrue(r.low_setting == ('auto', 'auto'))
         assert_ary_(r.low, array([0.0,0.0]))
-        return
 
     def test_constant_values(self):
         r = DataRange2D()
@@ -77,8 +75,6 @@ class DataRange2DTestCase(unittest.TestCase):
         r.add(ds)
         assert_ary_(r.low, array([-0.25, -0.25]))
         assert_ary_(r.high, array([0.0, 0.0]))
-        return
-
 
     def test_multi_source(self):
         x = arange(10.)
@@ -90,7 +86,6 @@ class DataRange2DTestCase(unittest.TestCase):
         r = DataRange2D(ds1, ds2)
         assert_ary_(r.low, [0.0,0.0])
         assert_ary_(r.high, [90.,90.])
-        return
 
     def test_grid_source(self):
         test_xd1 = array([1,2,3])
@@ -181,8 +176,6 @@ class DataRange2DTestCase(unittest.TestCase):
         assert_equal(r.clip_data(ary) , array([[16.,12.],[18.,16.],[20.,20.]]))
         assert_equal(r.clip_data(ary[::-1]) , array([[20,20], [18,16], [16,12]]))
 
-        return
-
     def test_mask_data(self):
         r = DataRange2D(low=[2.0,5.0], high=[10.0,18.0])
         x = array([1, 3, 4, 9.8, 10.2, 12])
@@ -200,7 +193,7 @@ class DataRange2DTestCase(unittest.TestCase):
 
         r = DataRange2D(low=[2.0,5.0], high=[2.5,9.0])
         assert_equal(r.mask_data(ary) , zeros(len(ary)))
-        return
+
 
 def assert_close_(desired,actual):
     diff_allowed = 1e-5

--- a/chaco/tests/test_linearmapper.py
+++ b/chaco/tests/test_linearmapper.py
@@ -21,7 +21,6 @@ class LinearMapperTestCase(unittest.TestCase):
         self.assertTrue(mapper._high_bound_initialized)
         result = mapper.map_screen(ary)
         assert_equal(result , array([50, 60, 70, 80, 90, 100]))
-        return
 
     def test_reversed(self):
         ary = array([5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
@@ -36,7 +35,6 @@ class LinearMapperTestCase(unittest.TestCase):
         self.assertTrue(mapper._high_bound_initialized)
         result = mapper.map_screen(ary)
         assert_equal(result , array([100, 80, 60, 40, 20, 0]))
-        return
 
     def test_set_screen_bounds(self):
         ary = array([5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
@@ -50,7 +48,6 @@ class LinearMapperTestCase(unittest.TestCase):
         self.assertTrue(mapper._high_bound_initialized)
         result = mapper.map_screen(ary)
         assert_equal(result , array([50, 60, 70, 80, 90, 100]))
-        return
 
     def test_reversed_set_screen_bounds(self):
         ary = array([5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
@@ -64,7 +61,6 @@ class LinearMapperTestCase(unittest.TestCase):
         self.assertTrue(mapper._high_bound_initialized)
         result = mapper.map_screen(ary)
         assert_equal(result , array([100, 80, 60, 40, 20, 0]))
-        return
 
     def test_update_screen_bounds_stretch_data(self):
         ary = array([5.0, 6.0, 7.0, 8.0, 9.0, 10.0])

--- a/chaco/tests/test_plotcontainer.py
+++ b/chaco/tests/test_plotcontainer.py
@@ -23,7 +23,6 @@ class StaticPlotComponent(PlotComponent):
         if "resizable" not in kw:
             kw["resizable"] = ""
         PlotComponent.__init__(self, *args, **kw)
-        return
 
 class ResizablePlotComponent(PlotComponent):
     """ A resizable PlotComponent with a fixed preferred size. """
@@ -55,7 +54,6 @@ class OverlayPlotContainerTestCase(ContainerTestCase):
         self.assertEqual(container._layout_needed, True)
         container.do_layout()
         self.assertEqual(container._layout_needed, False)
-        return
 
     def test_fixed_size_component(self):
         container = OverlayPlotContainer(resizable='', bounds=[200.0,300.0])
@@ -72,7 +70,6 @@ class OverlayPlotContainerTestCase(ContainerTestCase):
         self.assert_tuple(container.get_preferred_size(), (200.0,300.0))
         self.assert_tuple(component.position, (50.0,60.0))
         self.assert_tuple(component.bounds, (100.0,110.0))
-        return
 
     def test_resizable_component(self):
         container = OverlayPlotContainer(resizable='', bounds=[200.0,300.0])
@@ -93,7 +90,6 @@ class OverlayPlotContainerTestCase(ContainerTestCase):
         container.do_layout()
         self.assert_tuple(comp3.position, (30.0, 0.0))
         self.assert_tuple(comp3.bounds, (100,300))
-        return
 
     def test_min_size(self):
         container = OverlayPlotContainer(resizable='', bounds=[50.0,50.0])
@@ -103,7 +99,6 @@ class OverlayPlotContainerTestCase(ContainerTestCase):
         container.do_layout()
         self.assert_tuple(component.position, (50.0,60.0))
         self.assert_tuple(component.bounds, (100.0,110.0))
-        return
 
     def test_multiple_min_size(self):
         comp1 = StaticPlotComponent([200, 50])
@@ -115,7 +110,7 @@ class OverlayPlotContainerTestCase(ContainerTestCase):
         self.assert_tuple(container.get_preferred_size(), (200,300))
         self.assert_tuple(comp1.bounds, (200,50))
         self.assert_tuple(comp2.bounds, (60,300))
-        return
+
 
 class HPlotContainerTestCase(ContainerTestCase):
 
@@ -132,7 +127,6 @@ class HPlotContainerTestCase(ContainerTestCase):
         self.assert_tuple(comp1.position, (0,0))
         self.assert_tuple(comp2.position, (100,0))
         self.assert_tuple(comp3.position, (190,0))
-        return
 
     def test_stack_one_resize(self):
         "Checks stacking with 1 resizable component thrown in"
@@ -149,7 +143,6 @@ class HPlotContainerTestCase(ContainerTestCase):
         self.assert_tuple(comp2.position, (100,0))
         self.assert_tuple(comp3.position, (190,0))
         self.assert_tuple(comp4.position, (260,0))
-        return
 
     def test_valign(self):
         container = HPlotContainer(bounds=[300,200], valign="center")
@@ -160,7 +153,6 @@ class HPlotContainerTestCase(ContainerTestCase):
         container.valign="top"
         container.do_layout(force=True)
         self.assertEqual(comp1.position, [0,100])
-        return
 
 
 class VPlotContainerTestCase(ContainerTestCase):
@@ -178,7 +170,6 @@ class VPlotContainerTestCase(ContainerTestCase):
         self.assert_tuple(comp1.position, (0,0))
         self.assert_tuple(comp2.position, (0,100))
         self.assert_tuple(comp3.position, (0,190))
-        return
 
     def test_stack_one_resize(self):
         "Checks stacking with 1 resizable component thrown in"
@@ -195,7 +186,6 @@ class VPlotContainerTestCase(ContainerTestCase):
         self.assert_tuple(comp2.position, (0,100))
         self.assert_tuple(comp3.position, (0,190))
         self.assert_tuple(comp4.position, (0,260))
-        return
 
     def test_halign(self):
         container = VPlotContainer(bounds=[200,300], halign="center")
@@ -206,7 +196,6 @@ class VPlotContainerTestCase(ContainerTestCase):
         container.halign="right"
         container.do_layout(force=True)
         self.assertEqual(comp1.position, [100,0])
-        return
 
     def test_fit_components(self):
         container = VPlotContainer(bounds=[200,300], resizable="v", fit_components="v")
@@ -400,7 +389,6 @@ class GridContainerTestCase(ContainerTestCase):
         cont = GridContainer(shape=(1,1))
         cont.bounds = [100,100]
         cont.do_layout()
-        return
 
     def test_all_empty_cells(self):
         cont = GridContainer(shape=(2,2), spacing=(0,0))
@@ -409,7 +397,6 @@ class GridContainerTestCase(ContainerTestCase):
         self.assert_tuple(size, (0,0))
         cont.bounds = (100,100)
         cont.do_layout()
-        return
 
     def test_some_empty_cells(self):
         cont = GridContainer(shape=(2,2), spacing=(0,0))
@@ -434,7 +421,6 @@ class GridContainerTestCase(ContainerTestCase):
         # assert failures, maybe using Pypy?
         self.assert_tuple(comp1.position, (0,0))
         self.assert_tuple(comp1.bounds, (200,300))
-        return
 
     def test_nonresizable_container(self):
         cont = GridContainer(shape=(1,1), resizable="")
@@ -443,7 +429,6 @@ class GridContainerTestCase(ContainerTestCase):
         cont.do_layout()
         self.assert_tuple(comp1.position, (0,0))
         self.assert_tuple(comp1.bounds, (200,300))
-        return
 
     def test_row(self):
         cont = GridContainer(shape=(1,3), halign="center", valign="center")
@@ -468,7 +453,6 @@ class GridContainerTestCase(ContainerTestCase):
         self.assert_tuple(c2.bounds, (30,30))
         self.assert_tuple(c3.position, (80,0))
         self.assert_tuple(c3.bounds, (20,50))
-        return
 
     def test_two_by_two(self):
         """ Tests a 2x2 grid of components """
@@ -488,7 +472,6 @@ class GridContainerTestCase(ContainerTestCase):
         self.assert_tuple(left.bounds, (50,100))
         self.assert_tuple(lr.position, (50,0))
         self.assert_tuple(lr.bounds, (100,100))
-        return
 
     def test_spacing(self):
         cont = GridContainer(shape=(2,2), spacing=(10,10),
@@ -508,7 +491,6 @@ class GridContainerTestCase(ContainerTestCase):
         self.assert_tuple(left.bounds, (50,100))
         self.assert_tuple(lr.position, (80,10))
         self.assert_tuple(lr.bounds, (100,100))
-        return
 
     def test_resizable(self):
         cont = GridContainer(shape=(2,2), spacing=(0,0),
@@ -528,7 +510,6 @@ class GridContainerTestCase(ContainerTestCase):
         self.assert_tuple(left.bounds, (100,100))
         self.assert_tuple(lr.position, (100,0))
         self.assert_tuple(lr.bounds, (100,100))
-        return
 
     def test_resizable2(self):
         # Tests a resizable component that also has a preferred size
@@ -569,7 +550,6 @@ class GridContainerTestCase(ContainerTestCase):
         self.assert_tuple(left.bounds, (100,100))
         self.assert_tuple(lr.position, (130,10))
         self.assert_tuple(lr.bounds, (100,100))
-        return
 
     def test_resizable_mixed2(self):
         # Tests laying out resizable components with preferred


### PR DESCRIPTION
This PR removes dummy/unnecessary `return` statements in the testsuite.