### PR TITLE
Remove dummy return statements in docs and examples

### DIFF
--- a/docs/source/user_manual/tutorial_van_der_waal.rst
+++ b/docs/source/user_manual/tutorial_van_der_waal.rst
@@ -152,7 +152,6 @@ The following is the code for these two needs::
         self.pressure = ((self.r_constant*self.temperature)
 		         /(self.volume - self.totVolume)
                         -(self.attraction/(self.volume*self.volume)))
-        return
 
 The :func:`calc` function computes the :attr:`pressure` array using the current
 values of the independent variables.  Meanwhile, the

--- a/examples/demo/advanced/data_cube.py
+++ b/examples/demo/advanced/data_cube.py
@@ -200,7 +200,6 @@ class PlotFrame(DemoFrame):
         self.center.invalidate_and_redraw()
         self.right.invalidate_and_redraw()
         self.bottom.invalidate_and_redraw()
-        return
 
     def _wheel_callback(self, tool, wheelamt):
         plane_slice_dict = {"xy": ("slice_z", 2),
@@ -220,7 +219,6 @@ class PlotFrame(DemoFrame):
         self.center.invalidate_and_redraw()
         self.right.invalidate_and_redraw()
         self.bottom.invalidate_and_redraw()
-        return
 
     def _create_window(self):
         # Create the model

--- a/examples/demo/advanced/data_stream.py
+++ b/examples/demo/advanced/data_stream.py
@@ -104,7 +104,6 @@ class Controller(HasTraits):
 
         self.viewer.index = new_index
         self.viewer.data = new_data
-        return
 
     def _distribution_type_changed(self):
         # This listens for a change in the type of distribution to use.
@@ -122,7 +121,6 @@ class DemoHandler(Handler):
         """
 
         info.object.timer.Stop()
-        return
 
 
 class Demo(HasTraits):

--- a/examples/demo/advanced/javascript_hover_tools.py
+++ b/examples/demo/advanced/javascript_hover_tools.py
@@ -583,7 +583,7 @@ def main(embedded=False):
         print('Browser did not open properly.  Exception %s.  The results' \
               'can be viewed with the file plot_hover_coords.html.' % str(e))
         raise
-    return
+
 
 #===============================================================================
 # # Demo class that is used by the demo.py application.

--- a/examples/demo/advanced/spec_waterfall.py
+++ b/examples/demo/advanced/spec_waterfall.py
@@ -48,7 +48,6 @@ class WaterfallRenderer(LinePlot):
 
             self._cached_data_pts = [transpose(array((index, v))) for v in values]
             self._cache_value = True
-        return
 
     def get_screen_points(self):
         self._gather_points()
@@ -160,7 +159,7 @@ class TimerController(HasTraits):
         spec_data = self.spectrogram_plot.values[1:] + [spectrum]
         self.spectrogram_plot.values = spec_data
         self.spectrum_plot.request_redraw()
-        return
+
 
 #============================================================================
 # Attributes to use for the plot view.
@@ -179,7 +178,7 @@ class DemoHandler(Handler):
         """
 
         info.object.timer.Stop()
-        return
+
 
 class Demo(HasTraits):
 

--- a/examples/demo/advanced/spectrum.py
+++ b/examples/demo/advanced/spectrum.py
@@ -128,7 +128,6 @@ class TimerController(HasTraits):
 
         self.spectrogram_plotdata.set_data('imagedata', spectrogram_data)
         self.spectrum_plot.request_redraw()
-        return
 
 #============================================================================
 # Attributes to use for the plot view.
@@ -147,7 +146,7 @@ class DemoHandler(Handler):
         """
 
         info.object.timer.Stop()
-        return
+
 
 class Demo(HasTraits):
 

--- a/examples/demo/basic/image_lasso.py
+++ b/examples/demo/basic/image_lasso.py
@@ -36,7 +36,7 @@ def lasso_updated(lasso_tool, name, old, new_selections):
         # Now map each point into the grid index
         for x, y in screen_pts:
             print("\t", lasso_tool.plot.map_index((x, y)))
-    return
+
 
 def _create_plot_component():# Create a scalar field to colormap
     xbounds = (-2*pi, 2*pi, 600)

--- a/examples/demo/canvas/axis_tool.py
+++ b/examples/demo/canvas/axis_tool.py
@@ -96,7 +96,6 @@ class AxisTool(BaseTool):
         axis.request_redraw()
         plot._debug = True
         event.handled = True
-        return
 
     def normal_left_up(self, event):
         if self.component is None:
@@ -122,7 +121,6 @@ class AxisTool(BaseTool):
 
         axis.request_redraw()
         event.handled = True
-        return
 
 
 class MPAxisTool(AxisTool):

--- a/examples/demo/canvas/canvas.py
+++ b/examples/demo/canvas/canvas.py
@@ -213,7 +213,6 @@ def clone_plot(clonetool, drop_position):
     newplot.invalidate_draw()
     newplot.request_redraw()
     canvas.request_redraw()
-    return
 
 
 def make_toolbar(canvas):

--- a/examples/demo/canvas/cliptest.py
+++ b/examples/demo/canvas/cliptest.py
@@ -44,8 +44,6 @@ class Box(Component):
             #gc.rect(self.outer_x, self.outer_y, self.outer_width, self.outer_height)
             #gc.stroke_path()
 
-        return
-
     def normal_left_down(self, event):
         self.event_state = "moving"
         event.window.set_pointer(self.moving_pointer)
@@ -53,13 +51,11 @@ class Box(Component):
         self.offset_x = event.x - self.x
         self.offset_y = event.y - self.y
         event.handled = True
-        return
 
     def moving_mouse_move(self, event):
         self.position = [event.x-self.offset_x, event.y-self.offset_y]
         event.handled = True
         self.request_redraw()
-        return
 
     def moving_left_up(self, event):
         self.event_state = "normal"
@@ -67,12 +63,11 @@ class Box(Component):
         event.window.set_mouse_owner(None)
         event.handled = True
         self.request_redraw()
-        return
 
     def moving_mouse_leave(self, event):
         self.moving_left_up(event)
         event.handled = True
-        return
+
 
 class MainFrame(DemoFrame):
     def _create_window(self):

--- a/examples/demo/canvas/data_source_button.py
+++ b/examples/demo/canvas/data_source_button.py
@@ -51,7 +51,6 @@ class ButtonController(HasTraits):
             #if not control_down:
             if 1:
                 self.button_deselected(button)
-        return
 
     def button_selected(self, button):
         if DEBUG:
@@ -76,7 +75,6 @@ class ButtonController(HasTraits):
         else:
             return
         button.button_state = "down"
-        return
 
     def button_deselected(self, button):
         if DEBUG:
@@ -99,7 +97,6 @@ class ButtonController(HasTraits):
         else:
             return
         button.button_state = "up"
-        return
 
     def show_scatterplot(self, b1, b2):
         if len(self.plot.plots) > 0:
@@ -191,13 +188,11 @@ class DataSourceButton(PlotToolbarButton):
             self._do_layout()
             self.plot_overlay.visible = True
         self.request_redraw()
-        return
 
     def hide_overlay(self):
         if self.plot_overlay is not None:
             self.plot_overlay.visible = False
         self.request_redraw()
-        return
 
     def _do_layout(self):
         if self.canvas is not None:

--- a/examples/demo/canvas/mp_viewport_pan_tool.py
+++ b/examples/demo/canvas/mp_viewport_pan_tool.py
@@ -36,7 +36,6 @@ class MPViewportPanTool(ViewportPanTool):
             self.event_state = "dragging"
             event.handled = True
             ViewportPanTool.drag_start(self, event)
-        return
 
     def drag_end(self, event):
         event.x, event.y = self._last_blob_pos

--- a/examples/demo/canvas/mptools.py
+++ b/examples/demo/canvas/mptools.py
@@ -255,7 +255,6 @@ class MPLegendTool(LegendTool):
             self.mouse_down_position = (event.x,event.y)
             self.event_state = "dragging"
             event.handled = True
-        return
 
     def drag_end(self, event):
         if hasattr(event, "bid"):

--- a/examples/demo/canvas/plot_clone_tool.py
+++ b/examples/demo/canvas/plot_clone_tool.py
@@ -122,7 +122,6 @@ class MPPlotCloneTool(PlotCloneTool):
             self.event_state = "dragging"
             event.handled = True
         PlotCloneTool.drag_start(self, event)
-        return
 
     def drag_end(self, event):
         if hasattr(event, "bid"):

--- a/examples/demo/financial/correlations.py
+++ b/examples/demo/financial/correlations.py
@@ -72,8 +72,6 @@ class PlotApp(HasTraits):
         if len(self.symbols) > 1:
             self.sym2 = self.symbols[1]
 
-        return
-
     def _create_returns_plot(self):
         plot = Plot(self.plotdata)
         plot.legend.visible = True

--- a/examples/demo/noninteractive.py
+++ b/examples/demo/noninteractive.py
@@ -53,7 +53,6 @@ def draw_plot(filename, size=(800, 600)):
     gc = PlotGraphicsContext(size, dpi=DPI)
     gc.render_component(container)
     gc.save(filename)
-    return
 
 
 def draw_svg(filename, size=(800, 600)):

--- a/examples/demo/updating_plot/updating_plot1.py
+++ b/examples/demo/updating_plot/updating_plot1.py
@@ -42,7 +42,6 @@ class PlotFrame(DemoFrame):
         self.y_values = y
         self.current_index = numpoints/2
         self.increment = 2
-        return
 
     def _create_window(self):
         self._create_data()
@@ -81,7 +80,6 @@ class PlotFrame(DemoFrame):
         self.plot.index.set_data(self.x_values[:self.current_index])
         self.plot.value.set_data(self.y_values[:self.current_index])
         self.plot.request_redraw()
-        return
 
 
 if __name__ == "__main__":

--- a/examples/demo/updating_plot/updating_plot2.py
+++ b/examples/demo/updating_plot/updating_plot2.py
@@ -90,7 +90,6 @@ class PlotFrame(DemoFrame):
     def onTimer(self, *args):
         for plot in self.animated_plots:
             plot.timer_tick()
-        return
 
 
 if __name__ == "__main__":

--- a/examples/demo/updating_plot/updating_plot3.py
+++ b/examples/demo/updating_plot/updating_plot3.py
@@ -103,7 +103,6 @@ class PlotFrame(DemoFrame):
     def onTimer(self, *args):
         for plot in self.animated_plots:
             plot.timer_tick()
-        return
 
 
 if __name__ == "__main__":

--- a/examples/demo/updating_plot/updating_plot4.py
+++ b/examples/demo/updating_plot/updating_plot4.py
@@ -114,7 +114,6 @@ class PlotFrame(DemoFrame):
     def onTimer(self, *args):
         for plot in self.animated_plots:
             plot.timer_tick()
-        return
 
 
 if __name__ == "__main__":

--- a/examples/demo/updating_plot/updating_plot5.py
+++ b/examples/demo/updating_plot/updating_plot5.py
@@ -109,7 +109,6 @@ class PlotFrame(DemoFrame):
     def onTimer(self, *args):
         for plot in self.animated_plots:
             plot.timer_tick()
-        return
 
 
 if __name__ == "__main__":

--- a/examples/demo/vtk/spectrum.py
+++ b/examples/demo/vtk/spectrum.py
@@ -115,7 +115,7 @@ class TimerController(HasTraits):
 
         self.spectrogram_plotdata.set_data('imagedata', spectrogram_data)
         self.spectrum_plot.request_redraw()
-        return
+
 
 def main():
     from tvtk.api import tvtk

--- a/examples/demo/zoomed_plot/zoom_overlay.py
+++ b/examples/demo/zoomed_plot/zoom_overlay.py
@@ -78,8 +78,6 @@ class ZoomOverlay(AbstractOverlay):
             gc.lines(right_line)
             gc.stroke_path()
 
-        return
-
     def _get_selection_screencoords(self):
         """
         Returns a tuple of (x1, x2) screen space coordinates of the start
@@ -103,7 +101,6 @@ class ZoomOverlay(AbstractOverlay):
                                            remove=True)
         if new is not None and new.controller is not None:
             new.controller.on_trait_change(self._selection_update_handler, "selection")
-        return
 
     def _selection_update_handler(self, value):
         if value is not None and self.destination is not None:
@@ -114,4 +111,3 @@ class ZoomOverlay(AbstractOverlay):
 
         self.source.request_redraw()
         self.destination.request_redraw()
-        return

--- a/examples/tutorials/scipy2008/custom_overlay.py
+++ b/examples/tutorials/scipy2008/custom_overlay.py
@@ -35,7 +35,7 @@ class ScatterPlotHandler(Handler):
 
     def object_edit_overlay_changed(self, info):
         info.object.plot.overlays[-1].edit_traits(parent=info.ui.control)
-        return
+
 
 class ScatterPlot(HasTraits):
 

--- a/examples/tutorials/scipy2008/custom_overlay_dataspace.py
+++ b/examples/tutorials/scipy2008/custom_overlay_dataspace.py
@@ -48,7 +48,7 @@ class ScatterPlotHandler(Handler):
 
     def object_edit_overlay_changed(self, info):
         info.object.plot.overlays[-1].edit_traits(parent=info.ui.control)
-        return
+
 
 class ScatterPlot(HasTraits):
 

--- a/examples/tutorials/scipy2008/custom_overlay_movetool.py
+++ b/examples/tutorials/scipy2008/custom_overlay_movetool.py
@@ -55,7 +55,7 @@ class ScatterPlotHandler(Handler):
 
     def object_edit_overlay_changed(self, info):
         info.object.plot.overlays[-1].edit_traits(parent=info.ui.control)
-        return
+
 
 class ScatterPlot(HasTraits):
 


### PR DESCRIPTION
This PR removes dummy/unnecessary `return` statements from the documentation and examples.