### PR TITLE
Remove unnecessary return statements in package

### DIFF
--- a/chaco/abstract_controller.py
+++ b/chaco/abstract_controller.py
@@ -16,7 +16,6 @@ class AbstractController(Interactor):
     def __init__(self, component, *args, **kw):
         self.component = component
         super(AbstractController, self).__init__(*args, **kw)
-        return
 
     def deactivate(self, component):
         """ This method is called by the component when this controller is no

--- a/chaco/abstract_mapper.py
+++ b/chaco/abstract_mapper.py
@@ -29,14 +29,12 @@ class AbstractMapper(HasTraits):
 
         Maps values from data space into screen space.
         """
-        return
 
     def map_data(self, screen_val):
         """ map_data(screen_val) -> data_val
 
         Maps values from screen space into data space.
         """
-        return
 
     def map_data_array(self, screen_vals):
         """ map_data_array(screen_vals) -> data_vals
@@ -63,4 +61,3 @@ class AbstractMapper(HasTraits):
     def _post_load(self):
         self._cache_valid = False
         self._range_changed(None, self.range)
-        return

--- a/chaco/abstract_overlay.py
+++ b/chaco/abstract_overlay.py
@@ -51,7 +51,6 @@ class AbstractOverlay(PlotComponent):
             self.overlay(self.component, gc, view_bounds, mode)
         else:
             super(AbstractOverlay, self)._draw(gc, view_bounds, mode)
-        return
 
     def _request_redraw(self):
         """ Overrides Enable Component.
@@ -59,4 +58,3 @@ class AbstractOverlay(PlotComponent):
         if self.component is not None:
             self.component.request_redraw()
         super(AbstractOverlay, self)._request_redraw()
-        return

--- a/chaco/array_data_source.py
+++ b/chaco/array_data_source.py
@@ -108,7 +108,6 @@ class ArrayDataSource(AbstractDataSource):
     def __init__(self, data=array([]), sort_order="none", **kw):
         AbstractDataSource.__init__(self, **kw)
         self.set_data(data, sort_order)
-        return
 
     def set_data(self, newdata, sort_order=None):
         """ Sets the data, and optionally the sort order, for this data source.
@@ -125,21 +124,18 @@ class ArrayDataSource(AbstractDataSource):
             self.sort_order = sort_order
         self._compute_bounds()
         self.data_changed = True
-        return
 
     def set_mask(self, mask):
         """ Sets the mask for this data source.
         """
         self._cached_mask = mask
         self.data_changed = True
-        return
 
     def remove_mask(self):
         """ Removes the mask on this data source.
         """
         self._cached_mask = None
         self.data_changed = True
-        return
 
     #------------------------------------------------------------------------
     # AbstractDataSource interface
@@ -287,7 +283,6 @@ class ArrayDataSource(AbstractDataSource):
 
             self._cached_bounds = (data[self._min_index],
                                data[self._max_index])
-        return
 
     #------------------------------------------------------------------------
     # Event handlers
@@ -317,4 +312,3 @@ class ArrayDataSource(AbstractDataSource):
         super(ArrayDataSource, self)._post_load()
         self._cached_bounds = ()
         self._cached_mask = None
-        return

--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -186,7 +186,6 @@ class PlotAxis(AbstractOverlay):
         """
         self._reset_cache()
         self.invalidate_draw()
-        return
 
     def traits_view(self):
         """ Returns a View instance for use with Traits UI.  This method is
@@ -210,7 +209,6 @@ class PlotAxis(AbstractOverlay):
             self._layout_as_overlay(*args, **kw)
         else:
             super(PlotAxis, self)._do_layout(*args, **kw)
-        return
 
     def overlay(self, component, gc, view_bounds=None, mode='normal'):
         """ Draws this component overlaid on another component.
@@ -220,7 +218,6 @@ class PlotAxis(AbstractOverlay):
         if not self.visible:
             return
         self._draw_component(gc, view_bounds, mode, component)
-        return
 
     def _draw_overlay(self, gc, view_bounds=None, mode='normal'):
         """ Draws the overlay layer of a component.
@@ -228,7 +225,6 @@ class PlotAxis(AbstractOverlay):
         Overrides PlotComponent.
         """
         self._draw_component(gc, view_bounds, mode)
-        return
 
     def _draw_component(self, gc, view_bounds=None, mode='normal', component=None):
         """ Draws the component.
@@ -262,8 +258,6 @@ class PlotAxis(AbstractOverlay):
             self._draw_labels(gc)
 
         self._cache_valid = True
-        return
-
 
     #------------------------------------------------------------------------
     # Private draw routines
@@ -291,7 +285,6 @@ class PlotAxis(AbstractOverlay):
                 elif self.orientation == "top":
                     self.height = self.component.padding_top
                     self.y = self.component.y2 + 1
-        return
 
     def _draw_axis_line(self, gc, startpoint, endpoint):
         """ Draws the line for the axis.
@@ -304,8 +297,6 @@ class PlotAxis(AbstractOverlay):
             gc.move_to(*around(startpoint))
             gc.line_to(*around(endpoint))
             gc.stroke_path()
-        return
-
 
     def _draw_title(self, gc, label=None, axis_offset=None):
         """ Draws the title for the axis.
@@ -341,8 +332,6 @@ class PlotAxis(AbstractOverlay):
         gc.translate_ctm(*offset)
         title_label.draw(gc)
         gc.translate_ctm(*(-offset))
-        return
-
 
     def _draw_ticks(self, gc):
         """ Draws the tick marks for the axis.
@@ -359,7 +348,6 @@ class PlotAxis(AbstractOverlay):
             gc.move_to(*(tick_pos + tick_in_vector))
             gc.line_to(*(tick_pos - tick_out_vector))
         gc.stroke_path()
-        return
 
     def _draw_labels(self, gc):
         """ Draws the tick labels for the axis.
@@ -409,8 +397,6 @@ class PlotAxis(AbstractOverlay):
             gc.translate_ctm(*tlpos)
             ticklabel.draw(gc)
             gc.translate_ctm(*(-tlpos))
-        return
-
 
     #------------------------------------------------------------------------
     # Private methods for computing positions and layout
@@ -422,7 +408,6 @@ class PlotAxis(AbstractOverlay):
         self._tick_positions = []
         self._tick_label_list = []
         self._tick_label_positions = []
-        return
 
     def _compute_tick_positions(self, gc, overlay_component=None):
         """ Calculates the positions for the tick marks.
@@ -498,8 +483,6 @@ class PlotAxis(AbstractOverlay):
                                 for tickpos in mapped_tick_positions]))
         self._tick_label_list = tick_list
         self._tick_label_positions = self._tick_positions
-        return
-
 
     def _compute_labels(self, gc):
         """Generates the labels for tick marks.
@@ -522,8 +505,6 @@ class PlotAxis(AbstractOverlay):
         self.ticklabel_cache = [build_label(val) for val in self._tick_label_list]
         self._tick_label_bounding_boxes = [array(ticklabel.get_bounding_box(gc), float)
                                                for ticklabel in self.ticklabel_cache]
-        return
-
 
     def _calculate_geometry(self):
         origin = self.origin
@@ -565,8 +546,6 @@ class PlotAxis(AbstractOverlay):
         self._axis_vector = self._end_axis_point - self._origin_point
         # This is the vector that represents one unit of data space in terms of screen space.
         self._axis_pixel_vector = self._axis_vector/sqrt(dot(self._axis_vector,self._axis_vector))
-        return
-
 
     def _calculate_geometry_overlay(self, overlay_component=None):
         if overlay_component is None:
@@ -611,8 +590,6 @@ class PlotAxis(AbstractOverlay):
         self._axis_vector = self._end_axis_point - self._origin_point
         # This is the vector that represents one unit of data space in terms of screen space.
         self._axis_pixel_vector = self._axis_vector/sqrt(dot(self._axis_vector,self._axis_vector))
-        return
-
 
     #------------------------------------------------------------------------
     # Event handlers
@@ -669,14 +646,12 @@ class PlotAxis(AbstractOverlay):
     def _updated_fired(self):
         """If the axis bounds changed, redraw."""
         self._cache_valid = False
-        return
 
     def _invalidate(self):
         self._cache_valid = False
         self.invalidate_draw()
         if self.component:
             self.component.invalidate_draw()
-        return
 
     def _component_changed(self):
         if self.mapper is not None:
@@ -699,8 +674,6 @@ class PlotAxis(AbstractOverlay):
 
         # Keep our origin in sync with the component
         self.origin = getattr(component, 'origin', 'bottom left')
-        return
-
 
     #------------------------------------------------------------------------
     # The following event handlers just invalidate our previously computed
@@ -712,7 +685,6 @@ class PlotAxis(AbstractOverlay):
         self.invalidate_draw()
         if self.component:
             self.component.invalidate_draw()
-        return
 
     def _anytrait_changed(self, name, old, new):
         """ For every trait that defines a visual attribute
@@ -800,7 +772,6 @@ class PlotAxis(AbstractOverlay):
         self._mapper_changed(None, self.mapper)
         self._reset_cache()
         self._cache_valid = False
-        return
 
 
 class MinorPlotAxis(PlotAxis):

--- a/chaco/barplot.py
+++ b/chaco/barplot.py
@@ -260,7 +260,6 @@ class BarPlot(AbstractPlotRenderer):
         self._cached_data_pts = compress(point_mask, points, axis=0)
 
         self._cache_valid = True
-        return
 
     def _draw_plot(self, gc, view_bounds=None, mode="normal"):
         """ Draws the 'plot' layer.
@@ -320,8 +319,6 @@ class BarPlot(AbstractPlotRenderer):
                     gc.line_to(int(end[0])+0.5, int(end[1])+0.5)
                     gc.stroke_path()
 
-        return
-
     def _render_icon(self, gc, x, y, width, height):
         with gc:
             gc.set_fill_color(self.effective_fill_color)
@@ -331,8 +328,6 @@ class BarPlot(AbstractPlotRenderer):
 
     def _post_load(self):
         super(BarPlot, self)._post_load()
-        return
-
 
     #------------------------------------------------------------------------
     # Properties

--- a/chaco/base_1d_mapper.py
+++ b/chaco/base_1d_mapper.py
@@ -71,13 +71,11 @@ class Base1DMapper(AbstractMapper):
 
         self._cache_valid = False
         self.updated = new
-        return
 
     def _range_change_handler(self, obj, name, new):
         "Handles the range changing; dynamically attached to our ranges"
         self._cache_valid = False
         self.updated = obj
-        return
 
     def _get_screen_bounds(self):
         return (self.low_pos, self.high_pos)
@@ -103,7 +101,6 @@ class Base1DMapper(AbstractMapper):
         self._low_bound_initialized = True
         self._high_bound_initialized = True
         self.updated = True
-        return
 
     def _adjust_range(self, old_bounds, new_bounds):
         initialized = self._low_bound_initialized and \

--- a/chaco/base_2d_plot.py
+++ b/chaco/base_2d_plot.py
@@ -101,7 +101,6 @@ class Base2DPlot(AbstractPlotRenderer):
         # so we have to manually update our mappers
         if self.resizable == "":
             self._update_mappers()
-        return
 
     #------------------------------------------------------------------------
     # AbstractPlotRenderer interface
@@ -202,7 +201,6 @@ class Base2DPlot(AbstractPlotRenderer):
         Used by the PlotComponent interface.
         """
         self._render(gc)
-        return
 
     #------------------------------------------------------------------------
     # Abstract methods that subclasses must implement

--- a/chaco/base_contour_plot.py
+++ b/chaco/base_contour_plot.py
@@ -66,7 +66,6 @@ class BaseContourPlot(Base2DPlot):
         super(BaseContourPlot, self).__init__(*args, **kwargs)
         if self.color_mapper:
             self.color_mapper.on_trait_change(self._update_color_mapper, "updated")
-        return
 
     def _update_levels(self):
         """ Updates the levels cache.  """
@@ -129,8 +128,6 @@ class BaseContourPlot(Base2DPlot):
                     self._colors.append(self._color_map_trait_)
 
         self._colors_cache_valid = True
-        return
-
 
     #------------------------------------------------------------------------
     # Event handlers

--- a/chaco/base_plot_frame.py
+++ b/chaco/base_plot_frame.py
@@ -46,7 +46,6 @@ class BasePlotFrame(Container, PlotComponent):
     def __init__(self, **kw):
         self._frame_slots = {}
         super(BasePlotFrame, self).__init__(**kw)
-        return
 
     def add_to_slot(self, slot, component, stack="overlay"):
         """
@@ -54,7 +53,6 @@ class BasePlotFrame(Container, PlotComponent):
         The valid modes are: 'overlay', 'left', 'right', 'top', 'bottom'.
         """
         self.frame_slots[slot].add_plot_component(component, stack)
-        return
 
     def set_slot(self, slotname, container):
         """
@@ -66,7 +64,6 @@ class BasePlotFrame(Container, PlotComponent):
         if container is not None:
             self._frame_slots[slotname] = container
             Container.add(self, container)
-        return
 
     def get_slot(self, slotname):
         """ Returns the container in the named slot. """
@@ -94,7 +91,6 @@ class BasePlotFrame(Container, PlotComponent):
                 PlotComponent.draw(self, gc, view_bounds, "interactive")
         else:
             super(BasePlotFrame, self).draw(gc, view_bounds, mode)
-        return
 
     def do_layout(self, size=None, force=False):
         """ Tells this frame to do layout at a given size.
@@ -117,7 +113,6 @@ class BasePlotFrame(Container, PlotComponent):
         PlotComponent version of _draw().
         """
         PlotComponent._draw(self, *args, **kw)
-        return
 
     def _dispatch_to_enable(self, event, suffix):
         """ Calls Enable-level event handlers.
@@ -125,7 +120,6 @@ class BasePlotFrame(Container, PlotComponent):
         Overrides PlotComponent.
         """
         Container.dispatch(self, event, suffix)
-        return
 
     #------------------------------------------------------------------------
     # Event handlers, properties
@@ -156,7 +150,6 @@ class BasePlotFrame(Container, PlotComponent):
             self.set_slot(name, value)
         else:
             super(BasePlotFrame, self).__setattr__(name, value)
-        return
 
     ### Persistence ###########################################################
 #    _pickles = ("_frame_slots", "_components", "fit_components", "fit_window")
@@ -165,4 +158,3 @@ class BasePlotFrame(Container, PlotComponent):
         super(BasePlotFrame, self).post_load(path)
         for slot in self._frame_slots.values():
             slot.post_load(path)
-        return

--- a/chaco/base_xy_plot.py
+++ b/chaco/base_xy_plot.py
@@ -197,7 +197,6 @@ class BaseXYPlot(AbstractPlotRenderer):
         # so we have to manually update our mappers
         if self.resizable == "":
             self._update_mappers()
-        return
 
     def hittest(self, screen_pt, threshold=7.0, return_distance=False):
         """ Performs proximity testing between a given screen point and the
@@ -461,7 +460,6 @@ class BaseXYPlot(AbstractPlotRenderer):
         """ Draws the 'plot' layer.
         """
         self._draw_component(gc, view_bounds, mode)
-        return
 
     def _draw_component(self, gc, view_bounds=None, mode="normal"):
         # This method should be folded into self._draw_plot(), but is here for
@@ -469,7 +467,6 @@ class BaseXYPlot(AbstractPlotRenderer):
 
         pts = self.get_screen_points()
         self._render(gc, pts)
-        return
 
     def _draw_default_axes(self, gc):
         if not self.origin_axis_visible:
@@ -494,7 +491,6 @@ class BaseXYPlot(AbstractPlotRenderer):
                     gc.move_to(int(start[0]), int(start[1]))
                     gc.line_to(int(end[0]), int(end[1]))
                     gc.stroke_path()
-        return
 
     def _post_load(self):
         super(BaseXYPlot, self)._post_load()
@@ -502,11 +498,9 @@ class BaseXYPlot(AbstractPlotRenderer):
         self.invalidate_draw()
         self._cache_valid = False
         self._screen_cache_valid = False
-        return
 
     def _update_subdivision(self):
-
-        return
+        pass
 
     #------------------------------------------------------------------------
     # Properties
@@ -627,14 +621,12 @@ class BaseXYPlot(AbstractPlotRenderer):
             new.on_trait_change(self._either_data_changed, "data_changed")
             new.on_trait_change(self._either_metadata_changed, "metadata_changed")
         self._either_data_changed()
-        return
 
     def _either_data_changed(self):
         self.invalidate_draw()
         self._cache_valid = False
         self._screen_cache_valid = False
         self.request_redraw()
-        return
 
     def _either_metadata_changed(self):
         # By default, don't respond to metadata change events.
@@ -649,7 +641,6 @@ class BaseXYPlot(AbstractPlotRenderer):
             new.on_trait_change(self._either_data_changed, "data_changed")
             new.on_trait_change(self._either_metadata_changed, "metadata_changed")
         self._either_data_changed()
-        return
 
     def _origin_changed(self, old, new):
         # origin switch from left to right or vice versa?
@@ -663,7 +654,6 @@ class BaseXYPlot(AbstractPlotRenderer):
 
         self.invalidate_draw()
         self._screen_cache_valid = False
-        return
 
     def _index_mapper_changed(self, old, new):
         self._either_mapper_changed(self, "index_mapper", old, new)
@@ -671,7 +661,6 @@ class BaseXYPlot(AbstractPlotRenderer):
             self.trait_property_changed("x_mapper", old, new)
         else:
             self.trait_property_changed("y_mapper", old, new)
-        return
 
     def _value_mapper_changed(self, old, new):
         self._either_mapper_changed(self, "value_mapper", old, new)
@@ -679,7 +668,6 @@ class BaseXYPlot(AbstractPlotRenderer):
             self.trait_property_changed("y_mapper", old, new)
         else:
             self.trait_property_changed("x_mapper", old, new)
-        return
 
     def _either_mapper_changed(self, obj, name, old, new):
         if old is not None:
@@ -688,14 +676,12 @@ class BaseXYPlot(AbstractPlotRenderer):
             new.on_trait_change(self._mapper_updated_handler, "updated")
         self.invalidate_draw()
         self._screen_cache_valid = False
-        return
 
     def _mapper_updated_handler(self):
         self._cache_valid = False
         self._screen_cache_valid = False
         self.invalidate_draw()
         self.request_redraw()
-        return
 
     def _visible_changed(self, old, new):
         if new:
@@ -707,7 +693,6 @@ class BaseXYPlot(AbstractPlotRenderer):
     def _use_subdivision_changed(self, old, new):
         if new:
             self._set_up_subdivision()
-        return
 
     #------------------------------------------------------------------------
     # Persistence
@@ -733,4 +718,3 @@ class BaseXYPlot(AbstractPlotRenderer):
         self._cache_valid = False
         self._screen_cache_valid = False
         self._update_mappers()
-        return

--- a/chaco/chaco_plot_editor.py
+++ b/chaco/chaco_plot_editor.py
@@ -146,8 +146,6 @@ class ChacoPlotItem(Item):
 
         self.editor.plotitem = self
 
-        return
-
     def _set_bg_color(self, val):
         self.bgcolor = val
 
@@ -250,7 +248,6 @@ class ChacoPlotEditor ( Editor ):
             object.on_trait_change(lambda s: self._update_axis_grids(), name)
         if plotitem.type_trait not in ("", None):
             object.on_trait_change(self.update_editor, plotitem.type_trait)
-        return
 
     #---------------------------------------------------------------------------
     #  Disposes of the contents of an editor:
@@ -281,7 +278,6 @@ class ChacoPlotEditor ( Editor ):
             self._plot = None
             plot.index = None
             plot.value = None
-        return
 
     #---------------------------------------------------------------------------
     #  Updates the editor when the object trait changes externally to the editor:
@@ -343,7 +339,6 @@ class ChacoPlotEditor ( Editor ):
         self._plot = plot
         self._container.add(plot)
         self._container.request_redraw()
-        return
 
     def _update_data(self):
         """ Updates the editor when the object trait changes externally to the
@@ -362,7 +357,6 @@ class ChacoPlotEditor ( Editor ):
         for attr in ("color", "bgcolor", "border_visible", "border_width",
                      "border_dash", "border_color"):
             setattr(plot, attr, getattr(plotitem, attr))
-        return
 
     def _create_line_plot(self, plotitem, values, **kwargs):
         plot = create_line_plot(values, **kwargs)
@@ -431,4 +425,3 @@ class ChacoPlotEditor ( Editor ):
                 axis.title_color = plotitem.y_label_color
 
         plot.request_redraw()
-        return

--- a/chaco/cmap_image_plot.py
+++ b/chaco/cmap_image_plot.py
@@ -184,12 +184,10 @@ class CMapImagePlot(ImagePlot):
     def _value_data_changed_fired(self):
         super(CMapImagePlot, self)._value_data_changed_fired()
         self._mapped_image_cache_valid = False
-        return
 
     def _index_data_changed_fired(self):
         super(CMapImagePlot, self)._index_data_changed_fired()
         self._mapped_image_cache_valid = False
-        return
     
     def _cache_full_map_changed(self):
         self._mapped_image_cache_valid = False

--- a/chaco/color_bar.py
+++ b/chaco/color_bar.py
@@ -121,7 +121,6 @@ class ColorBar(AbstractPlotRenderer):
         # Now that we have a grid and an axis, we can safely set the visibility
         self.grid_visible = grid_visible
         self.axis_visible = axis_visible
-        return
 
     def _draw_plot(self, gc, view_bounds=None, mode='normal'):
         """ Draws the 'plot' layer.

--- a/chaco/color_mapper.py
+++ b/chaco/color_mapper.py
@@ -38,7 +38,6 @@ class ColorMapTemplate(HasTraits):
         """
         if colormap:
             self.from_colormap(colormap)
-        return
 
     def from_colormap(self, colormap):
         """ Populates this template from a color map.
@@ -47,7 +46,6 @@ class ColorMapTemplate(HasTraits):
         self.steps = colormap.steps
         self.range_low_setting = colormap.range.low_setting
         self.range_high_setting = colormap.range.high_setting
-        return
 
     def to_colormap(self, range=None):
         """ Returns a ColorMapper instance from this template.
@@ -238,8 +236,6 @@ class ColorMapper(AbstractColormap):
         """
         self._segmentdata = segmentdata
         super(ColorMapper, self).__init__(**kwtraits)
-        return
-
 
     def map_screen(self, data_array):
         """ Maps an array of data values to an array of colors.
@@ -329,8 +325,6 @@ class ColorMapper(AbstractColormap):
         self._alpha_lut_uint8 = (self._alpha_lut * 255.0).astype('uint8')
         self.updated = True
         self._dirty = False
-
-        return
 
     #### matplotlib ####
     def _make_mapping_array(self, n, data):

--- a/chaco/colormapped_scatterplot.py
+++ b/chaco/colormapped_scatterplot.py
@@ -27,7 +27,6 @@ class ColormappedScatterPlotView(ScatterPlotView):
         vgroup = self.content
         vgroup.content[0].content.append(Item("fill_alpha", label="Fill alpha",
                                    editor=RangeEditor(low=0.0, high=1.0)))
-        return
 
 
 class ColormappedScatterPlot(ScatterPlot):
@@ -115,7 +114,6 @@ class ColormappedScatterPlot(ScatterPlot):
             screen_pts = self.map_screen(self._cached_data_pts)
             pts = concatenate((screen_pts, colors[:, newaxis]), axis=1)
             self._render(gc, pts)
-        return
 
     def _gather_points(self):
         """
@@ -162,7 +160,6 @@ class ColormappedScatterPlot(ScatterPlot):
         self._cached_point_mask = point_mask
 
         self._cache_valid = True
-        return
 
     def _render(self, gc, points):
         """ Actually draws the plot.
@@ -189,8 +186,6 @@ class ColormappedScatterPlot(ScatterPlot):
                 self._render_bruteforce(gc, points)
             elif method == 'banded':
                 self._render_banded(gc, points)
-        return
-
 
     #------------------------------------------------------------------------
     # Private methods
@@ -246,7 +241,6 @@ class ColormappedScatterPlot(ScatterPlot):
 
         self._color_indices = color_indices
         self._cache_valid = True
-        return
 
     def _calc_render_method(self, numpoints):
         """ Returns a string indicating the render method.
@@ -270,7 +264,6 @@ class ColormappedScatterPlot(ScatterPlot):
             gc.set_fill_color( color )
         if outline_weight is not None:
             gc.set_line_width(outline_weight)
-        return
 
     def _render_banded(self, gc, points):
         """ Draws the points color-band by color-band.
@@ -329,7 +322,6 @@ class ColormappedScatterPlot(ScatterPlot):
                 gc.draw_path_at_points(xy, path, mode)
         else:
             raise RuntimeError("Batch drawing requested on non-batch-capable GC.")
-        return
 
     def _render_bruteforce(self, gc, points):
         """ Draws the points, setting the stroke color for each one.
@@ -398,7 +390,6 @@ class ColormappedScatterPlot(ScatterPlot):
         if new is not None:
             new.on_trait_change(self._either_data_changed, "data_changed")
         self._either_data_changed()
-        return
 
     def _color_mapper_changed(self, old, new):
         self._cache_valid = False
@@ -411,8 +402,6 @@ class ColormappedScatterPlot(ScatterPlot):
         self.invalidate_draw()
         self.request_redraw()
 
-        return
-
     @on_trait_change('color_mapper:updated')
     def _color_mapper_updated(self):
         self.invalidate_draw()
@@ -421,4 +410,3 @@ class ColormappedScatterPlot(ScatterPlot):
     def _fill_alpha_changed(self):
         self.invalidate_draw()
         self.request_redraw()
-        return

--- a/chaco/colormapped_selection_overlay.py
+++ b/chaco/colormapped_selection_overlay.py
@@ -47,7 +47,6 @@ class ColormappedSelectionOverlay(AbstractOverlay):
     def __init__(self, component=None, **kw):
         super(ColormappedSelectionOverlay, self).__init__(**kw)
         self.component = component
-        return
 
     def overlay(self, component, gc, view_bounds=None, mode="normal"):
         """ Draws this component overlaid on another component.
@@ -98,7 +97,6 @@ class ColormappedSelectionOverlay(AbstractOverlay):
         plot.outline_color = fade_outline_color
         plot.line_width = self.unselected_outline_width
         datasource.remove_mask()
-        return
 
     def _component_changed(self, old, new):
         if old:
@@ -109,7 +107,6 @@ class ColormappedSelectionOverlay(AbstractOverlay):
             self._old_outline_color = new.outline_color
             self._old_line_width = new.line_width
             self.datasource_change_handler(new, "color_data", None, new.color_data)
-        return
 
     def datasource_change_handler(self, obj, name, old, new):
         if old:
@@ -117,7 +114,6 @@ class ColormappedSelectionOverlay(AbstractOverlay):
         if new:
             new.on_trait_change(self.selection_change_handler, "metadata_changed")
             self.selection_change_handler(new, "metadata_changed", None, new.metadata)
-        return
 
     def selection_change_handler(self, obj, name, old, new):
         if self.selection_type == 'range':
@@ -158,7 +154,6 @@ class ColormappedSelectionOverlay(AbstractOverlay):
             self._visible = False
 
         self.plot.request_redraw()
-        return
 
     def _get_plot(self):
         if self._plot is not None:

--- a/chaco/cross_plot_frame.py
+++ b/chaco/cross_plot_frame.py
@@ -64,7 +64,6 @@ class CrossPlotFrame(BasePlotFrame):
         self.set_slot("bottom", VPlotContainer(resizable="h"))
 
         self.bounds = bounds
-        return
 
     def set_visible_slots(self, *names):
         """
@@ -76,8 +75,6 @@ class CrossPlotFrame(BasePlotFrame):
                 self.get_slot(slot).visible = True
             else:
                 self.get_slot(slot).visible = False
-        return
-
 
     #------------------------------------------------------------------------
     # Protected methods
@@ -95,7 +92,6 @@ class CrossPlotFrame(BasePlotFrame):
                 if getattr(self, slotname).visible:
                     with gc:
                         self.get_slot(slotname).draw(gc, view_bounds, mode)
-        return
 
     def _do_layout(self):
         """
@@ -154,9 +150,6 @@ class CrossPlotFrame(BasePlotFrame):
                 if "v" not in slot.resizable:
                     slot.outer_height = preferred_size[1]
                 slot.do_layout()
-
-        return
-
 
     ### Persistence ###########################################################
 

--- a/chaco/data_label.py
+++ b/chaco/data_label.py
@@ -498,7 +498,6 @@ class DataLabel(ToolTip):
             self.y = sy + self.label_position[1]
 
         self._cached_arrow = None
-        return
 
     def _data_point_changed(self, old, new):
         if new is not None:
@@ -531,13 +530,11 @@ class DataLabel(ToolTip):
                 if hasattr(comp, 'value_mapper'):
                     self._modify_mapper_listeners(comp.value_mapper,
                                                   attach=attach)
-        return
 
     def _modify_mapper_listeners(self, mapper, attach=True):
         if mapper is not None:
             mapper.on_trait_change(self._handle_mapper, 'updated',
                                    remove=not attach)
-        return
 
     def _handle_mapper(self):
         # This gets fired whenever a mapper on our plot fires its

--- a/chaco/data_range_1d.py
+++ b/chaco/data_range_1d.py
@@ -349,7 +349,6 @@ class DataRange1D(BaseDataRange):
             self._low_value = low_start
             self._high_value = high_start
             self.updated = (self._low_value, self._high_value)
-        return
 
     def _do_track(self):
         changed = False

--- a/chaco/data_range_2d.py
+++ b/chaco/data_range_2d.py
@@ -197,7 +197,6 @@ class DataRange2D(BaseDataRange):
                     oldrange.remove(source1d)
                 if newrange:
                     newrange.add(source1d)
-        return
 
     #------------------------------------------------------------------------
     # Event handlers

--- a/chaco/data_view.py
+++ b/chaco/data_view.py
@@ -213,7 +213,6 @@ class DataView(OverlayPlotContainer):
         # so we have to manually update our mappers
         if self.resizable == "":
             self._update_mappers()
-        return
 
     def map_screen(self, data_array):
         """ Maps an array of data points to screen space and returns an array
@@ -318,7 +317,6 @@ class DataView(OverlayPlotContainer):
                 self.y_mapper.high_pos = y
 
         self.invalidate_draw()
-        return
 
     def _bounds_changed(self, old, new):
         super(DataView, self)._bounds_changed(old, new)
@@ -356,7 +354,6 @@ class DataView(OverlayPlotContainer):
         for renderer in self.components:
             if hasattr(renderer, "orientation"):
                 renderer.orientation = self.orientation
-        return
 
     def _index_mapper_changed(self, old, new):
         if new is not None:
@@ -433,7 +430,6 @@ class DataView(OverlayPlotContainer):
                     setattr(renderer, 'index_range', self.index_range)
                 if hasattr(renderer, 'value_range'):
                     setattr(renderer, 'value_range', self.value_range)
-        return
 
     def _range2d_default(self):
         """ Default trait initializer for the range2d trait """

--- a/chaco/errorbar_plot.py
+++ b/chaco/errorbar_plot.py
@@ -93,7 +93,6 @@ class ErrorBarPlot(LinePlot):
 
         self._cached_data_pts = compress(point_mask, points, axis=0)
         self._cache_valid = True
-        return
 
     def _render(self, gc, points, icon_mode=False):
         if len(points) == 0:
@@ -131,8 +130,6 @@ class ErrorBarPlot(LinePlot):
 
         if not icon_mode:
             self._draw_default_axes(gc)
-        return
-
 
     def _render_bar_endcap(self, gc, start, end, low, high, axis):
         """ Renders the endcaps for endcap_style == "bar".  start and end are
@@ -154,8 +151,6 @@ class ErrorBarPlot(LinePlot):
         end[:,1-axis] = high
         gc.line_set(start, end)
         gc.stroke_path()
-        return
-
 
     def _render_icon(self, gc, x, y, width, height):
         pass

--- a/chaco/example_support.py
+++ b/chaco/example_support.py
@@ -52,7 +52,6 @@ if ETSConfig.toolkit == 'wx':
             sizer.Add(self.plot_window.control, 1, wx.EXPAND)
             self.SetSizer(sizer)
             self.Show( True )
-            return
 
         def _create_window(self):
             "Subclasses should override this method and return an enable.wx.Window"
@@ -116,7 +115,6 @@ elif ETSConfig.toolkit == 'pyglet':
                 window = self._create_window()
                 self.enable_win = window
                 app.add_window(window.control)
-            return
 
         def _create_window(self):
             raise NotImplementedError

--- a/chaco/grid.py
+++ b/chaco/grid.py
@@ -154,15 +154,12 @@ class PlotGrid(AbstractOverlay):
         self.tick_generator = DefaultTickGenerator()
         super(PlotGrid, self).__init__(**traits)
         self.bgcolor = "none" #make sure we're transparent
-        return
 
     @on_trait_change("bounds,bounds_items,position,position_items")
     def invalidate(self):
         """ Invalidate cached information about the grid.
         """
         self._reset_cache()
-        return
-
 
     #------------------------------------------------------------------------
     # PlotComponent and AbstractOverlay interface
@@ -177,7 +174,6 @@ class PlotGrid(AbstractOverlay):
             self._layout_as_overlay(*args, **kw)
         else:
             super(PlotGrid, self).do_layout(*args, **kw)
-        return
 
     #------------------------------------------------------------------------
     # Private methods
@@ -188,7 +184,6 @@ class PlotGrid(AbstractOverlay):
 
         Overrides PlotComponent.
         """
-        return
 
     def _layout_as_overlay(self, size=None, force=False):
         """ Lays out the axis as an overlay on another component.
@@ -196,7 +191,6 @@ class PlotGrid(AbstractOverlay):
         if self.component is not None:
             self.position = self.component.position
             self.bounds = self.component.bounds
-        return
 
     def _reset_cache(self):
         """ Clears the cached tick positions.
@@ -204,7 +198,6 @@ class PlotGrid(AbstractOverlay):
         self._tick_positions = array([], dtype=float)
         self._tick_extents = array([], dtype=float)
         self._cache_valid = False
-        return
 
     def _compute_ticks(self, component=None):
         """ Calculates the positions for the grid lines.
@@ -293,7 +286,6 @@ class PlotGrid(AbstractOverlay):
         Overrides PlotComponent.
         """
         self._draw_component(gc, view_bounds, mode)
-        return
 
     def overlay(self, other_component, gc, view_bounds=None, mode="normal"):
         """ Draws this component overlaid on another component.
@@ -305,7 +297,6 @@ class PlotGrid(AbstractOverlay):
         self._compute_ticks(other_component)
         self._draw_component(gc, view_bounds, mode)
         self._cache_valid = False
-        return
 
     def _draw_component(self, gc, view_bounds=None, mode="normal"):
         """ Draws the component.
@@ -351,7 +342,6 @@ class PlotGrid(AbstractOverlay):
                 starts, ends = ends, starts
             gc.line_set(starts, ends)
             gc.stroke_path()
-        return
 
     def _mapper_changed(self, old, new):
         if old is not None:
@@ -359,14 +349,12 @@ class PlotGrid(AbstractOverlay):
         if new is not None:
             new.on_trait_change(self.mapper_updated, "updated")
         self.invalidate()
-        return
 
     def mapper_updated(self):
         """
         Event handler that is bound to this mapper's **updated** event.
         """
         self.invalidate()
-        return
 
     def _position_changed_for_component(self):
         self.invalidate()
@@ -403,8 +391,6 @@ class PlotGrid(AbstractOverlay):
     def _orientation_changed(self):
         self.invalidate()
         self.visual_attr_changed()
-        return
-
 
     ### Persistence ###########################################################
 
@@ -421,4 +407,3 @@ class PlotGrid(AbstractOverlay):
         self._mapper_changed(None, self.mapper)
         self._reset_cache()
         self._cache_valid = False
-        return

--- a/chaco/label.py
+++ b/chaco/label.py
@@ -83,7 +83,6 @@ class Label(HasTraits):
     def __init__(self, **traits):
         super(Label, self).__init__(**traits)
         self._bounding_box = [0, 0]
-        return
 
     def get_width_height(self, gc):
         """ Returns the width and height of the label, in the rotated frame of
@@ -279,4 +278,3 @@ class Label(HasTraits):
             self._bounding_box[1] = prev_y_pos + prev_y_height + margin \
                 + 2*border_width
             self._position_cache_valid = True
-        return

--- a/chaco/label_axis.py
+++ b/chaco/label_axis.py
@@ -87,8 +87,6 @@ class LabelAxis(PlotAxis):
         self._tick_positions = [self._axis_vector*tickpos + self._origin_point \
                                  for tickpos in mapped_label_positions]
         self._tick_label_positions = self._tick_positions
-        return
-
 
     def _compute_labels(self, gc):
         """Generates the labels for tick marks.
@@ -106,5 +104,3 @@ class LabelAxis(PlotAxis):
             self._tick_label_bounding_boxes = [array(ticklabel.get_bounding_box(gc), float64) for ticklabel in self.ticklabel_cache]
         except:
             print_exc()
-        return
-

--- a/chaco/lasso_overlay.py
+++ b/chaco/lasso_overlay.py
@@ -49,7 +49,6 @@ class LassoOverlay(AbstractOverlay):
             c = other_component
             gc.clip_to_rect(c.x, c.y, c.width, c.height)
             self._draw_component(gc, view_bounds, mode)
-        return
 
     def _updated_changed_for_lasso_selection(self):
         self.component.invalidate_draw()

--- a/chaco/layers/status_layer.py
+++ b/chaco/layers/status_layer.py
@@ -115,8 +115,6 @@ class StatusLayer(AbstractOverlay):
 
             self._draw_component(gc, view_bounds, mode)
 
-        return
-
     def fade_out(self):
         interval = self.fade_out_time/self.fade_out_steps
         self.timer = Timer(interval, self._fade_out_step)

--- a/chaco/layers/svg_range_selection_overlay.py
+++ b/chaco/layers/svg_range_selection_overlay.py
@@ -85,8 +85,6 @@ class SvgRangeSelectionOverlay(StatusLayer):
 
             self._draw_component(gc, view_bounds, mode)
 
-        return
-
     def _get_selection_screencoords(self):
         """ Returns a tuple of (x1, x2) screen space coordinates of the start
         and end selection points.

--- a/chaco/legend.py
+++ b/chaco/legend.py
@@ -46,7 +46,6 @@ class CompositeIconRenderer(AbstractCompositeIconRenderer):
         else:
             raise ValueError("Don't know how to render combination plot with " +\
                              "renderers " + str(types))
-        return
 
     def _render_scatterplots(self, plots, gc, x, y, width, height):
         # Don't support this for now
@@ -216,9 +215,6 @@ class Legend(AbstractOverlay):
         else:
             PlotComponent._draw(self, gc, view_bounds, mode)
 
-
-        return
-
     # The following two methods implement the functionality of the Legend
     # to act as a first-class component instead of merely as an overlay.
     # The make the Legend use the normal PlotComponent render methods when
@@ -232,14 +228,12 @@ class Legend(AbstractOverlay):
     def _draw_plot(self, gc, view_bounds=None, mode="normal"):
         if self.component is None:
             self._draw_as_overlay(gc, view_bounds, mode)
-        return
 
     def _draw_overlay(self, gc, view_bounds=None, mode="normal"):
         if self.component is not None:
             self._draw_as_overlay(gc, view_bounds, mode)
         else:
             PlotComponent._draw_overlay(self, gc, view_bounds, mode)
-        return
 
     def _draw_as_overlay(self, gc, view_bounds=None, mode="normal"):
         """ Draws the overlay layer of a component.
@@ -324,8 +318,6 @@ class Legend(AbstractOverlay):
                     y -= self.line_spacing
                 if old_alpha is not None:
                     gc.set_alpha(old_alpha)
-
-        return
 
     def _render_error(self, gc, icon_x, icon_y, icon_width, icon_height):
         """ Renders an error icon or performs some other action when a
@@ -446,7 +438,6 @@ class Legend(AbstractOverlay):
                 self._cached_label_sizes is None or len(self._cached_label_names) == 0:
             width, height = self.get_preferred_size()
             self.outer_bounds = [width, height]
-        return
 
     def _create_label(self, text):
         """ Returns a new Label instance for the given text.  Subclasses can
@@ -468,7 +459,6 @@ class Legend(AbstractOverlay):
             self._layout_needed = True
         if name == "color":
             self.get_preferred_size()
-        return
 
     def _plots_changed(self):
         """ Invalidate the caches.

--- a/chaco/linear_mapper.py
+++ b/chaco/linear_mapper.py
@@ -102,4 +102,3 @@ class LinearMapper(Base1DMapper):
             self._null_data_range = bool(self._scale == 0.0)
 
         self._cache_valid = True
-        return

--- a/chaco/lineplot.py
+++ b/chaco/lineplot.py
@@ -334,7 +334,6 @@ class LinePlot(BaseXYPlot):
                 gc.begin_path()
                 gc.lines(ary)
                 gc.stroke_path()
-        return
 
     @classmethod
     def _render_hold(cls, gc, points, orientation):
@@ -347,7 +346,6 @@ class LinePlot(BaseXYPlot):
             gc.begin_path()
             gc.line_set(starts[:-1], ends)
             gc.stroke_path()
-        return
 
     @classmethod
     def _render_connected_hold(cls, gc, points, orientation):
@@ -361,7 +359,6 @@ class LinePlot(BaseXYPlot):
             gc.line_set(starts[:-1], ends)
             gc.line_set(ends, starts[1:])
             gc.stroke_path()
-        return
 
     def _render_icon(self, gc, x, y, width, height):
         with gc:
@@ -372,7 +369,6 @@ class LinePlot(BaseXYPlot):
             gc.move_to(x, y+height/2)
             gc.line_to(x+width, y+height/2)
             gc.stroke_path()
-        return
 
     def _downsample_vectorized(self):
         """
@@ -390,27 +386,22 @@ class LinePlot(BaseXYPlot):
         z = abs(pts - pts2)
         d = z[:,0] + z[:,1]
         #... TODO ...
-        return
 
     def _alpha_changed(self):
         self.invalidate_draw()
         self.request_redraw()
-        return
 
     def _color_changed(self):
         self.invalidate_draw()
         self.request_redraw()
-        return
 
     def _line_style_changed(self):
         self.invalidate_draw()
         self.request_redraw()
-        return
 
     def _line_width_changed(self):
         self.invalidate_draw()
         self.request_redraw()
-        return
 
     def __getstate__(self):
         state = super(LinePlot,self).__getstate__()

--- a/chaco/log_mapper.py
+++ b/chaco/log_mapper.py
@@ -142,4 +142,3 @@ class LogMapper(Base1DMapper):
             self._screen_offset = self.low_pos
 
         self._cache_valid = True
-        return

--- a/chaco/multi_array_data_source.py
+++ b/chaco/multi_array_data_source.py
@@ -67,7 +67,6 @@ class MultiArrayDataSource(AbstractDataSource):
         self._set_data(data)
         self.sort_order = sort_order
         self.data_changed = True
-        return
 
     def get_data(self, axes = None, remove_nans=False):
         """get_data() -> data_array
@@ -203,7 +202,6 @@ class MultiArrayDataSource(AbstractDataSource):
         """
         self._set_data(value)
         self.data_changed = True
-        return
 
     def _set_data(self, value):
         """ Forces 1-D data to 2-D.

--- a/chaco/multi_line_plot.py
+++ b/chaco/multi_line_plot.py
@@ -374,8 +374,6 @@ class MultiLinePlot(BaseXYPlot):
 
         self._cached_data_pts = line_points
         self._cache_valid = True
-        return
-
 
     # See base_xy_plot.py for:
     ## def _downsample(self):
@@ -426,8 +424,6 @@ class MultiLinePlot(BaseXYPlot):
                 gc.begin_path()
                 gc.lines(ary)
                 gc.stroke_path()
-        return
-
 
     def _render_icon(self, gc, x, y, width, height):
         with gc:
@@ -443,28 +439,23 @@ class MultiLinePlot(BaseXYPlot):
     def _alpha_changed(self):
         self.invalidate_draw()
         self.request_redraw()
-        return
 
     def _color_changed(self):
         self.invalidate_draw()
         self.request_redraw()
-        return
 
     def _line_style_changed(self):
         self.invalidate_draw()
         self.request_redraw()
-        return
 
     def _line_width_changed(self):
         self.invalidate_draw()
         self.request_redraw()
-        return
 
     def _amplitude_changed(self):
         self.value.data_changed = True
         self.invalidate_draw()
         self.request_redraw()
-        return
 
     def __getstate__(self):
         state = super(MultiLinePlot,self).__getstate__()

--- a/chaco/overlays/databox.py
+++ b/chaco/overlays/databox.py
@@ -119,8 +119,6 @@ class DataBox(AbstractOverlay):
                 gc.rect(*rect)
                 gc.stroke_path()
 
-        return
-
     #-------------------------------------------------------------------------
     # Property setters/getters, event handlers
     #-------------------------------------------------------------------------

--- a/chaco/pdf_graphics_context.py
+++ b/chaco/pdf_graphics_context.py
@@ -181,7 +181,6 @@ if Canvas is not None:
             component.use_backbuffer = False
             component.draw(self, view_bounds=(0, 0, width, height))
             component.use_backbuffer = old_bb_setting
-            return
 
         def save(self, filename=None):
             self.gc.save()

--- a/chaco/plot.py
+++ b/chaco/plot.py
@@ -195,8 +195,6 @@ class Plot(DataView):
         # ensure that we only get displayed once by new_window()
         self._plot_ui_info = None
 
-        return
-
     def add_xy_plot(self, index_name, value_name, renderer_factory, name=None,
         origin=None, **kwds):
         """ Add a BaseXYPlot renderer subclass to this Plot.
@@ -1152,22 +1150,18 @@ class Plot(DataView):
             else:
                 warnings.warn("Couldn't remove datasource from datarange.")
 
-        return
-
     def hideplot(self, *names):
         """ Convenience function to sets the named plots to be invisible.  Their
         renderers are not removed, and they are still in the list of plots.
         """
         for renderer in itertools.chain(*[self.plots[name] for name in names]):
             renderer.visible = False
-        return
 
     def showplot(self, *names):
         """ Convenience function to sets the named plots to be visible.
         """
         for renderer in itertools.chain(*[self.plots[name] for name in names]):
             renderer.visible = True
-        return
 
     def new_window(self, configure=False):
         """Convenience function that creates a window containing the Plot

--- a/chaco/plot_canvas.py
+++ b/chaco/plot_canvas.py
@@ -78,5 +78,3 @@ class PlotCanvas(Canvas):
 
         for component in self.components + self.underlays + self.overlays:
             component.do_layout()
-        return
-

--- a/chaco/plot_canvas_toolbar.py
+++ b/chaco/plot_canvas_toolbar.py
@@ -65,7 +65,7 @@ class PlotCanvasToolbar(VPlotContainer):
         if self.component is not None:
             self.component.request_redraw()
         super(PlotCanvasToolbar, self)._request_redraw()
-        return
+
 
 class PlotToolbarButton(PlotComponent, ToolbarButton):
 

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -63,7 +63,7 @@ class OverlayPlotContainer(BasePlotContainer):
         """ Actually performs a layout (called by do_layout()).
         """
         simple_container_do_layout(self)
-        return
+
 
 class StackedPlotContainer(BasePlotContainer):
     """
@@ -227,7 +227,6 @@ class StackedPlotContainer(BasePlotContainer):
             component.outer_position = position
             component.outer_bounds = bounds
             component.do_layout()
-        return
 
     ### Persistence ###########################################################
 
@@ -415,7 +414,6 @@ class GridPlotContainer(BasePlotContainer):
                 self.index = 0
             else:
                 self.index = 1
-            return
 
         def update_from_component(self, component, index):
             """ Given a component at a particular index along this SizePref's
@@ -432,7 +430,6 @@ class GridPlotContainer(BasePlotContainer):
             else:
                 if pref_length > self.fixed_lengths[index]:
                     self.fixed_lengths[index] = pref_length
-            return
 
         def get_preferred_size(self):
             return amax((self.fixed_lengths, self.resizable_lengths), axis=0)
@@ -668,9 +665,6 @@ class GridPlotContainer(BasePlotContainer):
                 component.outer_bounds = bounds
                 component.do_layout()
 
-        return
-
-
     def _reflow_layout(self):
         """ Re-computes self._grid based on self.components and self.shape.
         Adjusts self.shape accordingly.
@@ -684,7 +678,6 @@ class GridPlotContainer(BasePlotContainer):
         grid[grid==0] = None
         self._grid = grid
         self._layout_needed = True
-        return
 
     def _shape_changed(self, old, new):
         self._reflow_layout()
@@ -724,4 +717,3 @@ class GridPlotContainer(BasePlotContainer):
             self.compact()
 
         self.invalidate_draw()
-        return

--- a/chaco/plot_graphics_context.py
+++ b/chaco/plot_graphics_context.py
@@ -27,7 +27,6 @@ class PlotGraphicsContextMixin(object):
         super(PlotGraphicsContextMixin, self).__init__(size_or_ary, *args, **kw)
         self.translate_ctm(0.5, 0.5)
         self.scale_ctm(scale, scale)
-        return
 
     def render_component(self, component, container_coords=False):
         """ Renders the given component.
@@ -56,7 +55,6 @@ class PlotGraphicsContextMixin(object):
         with self:
             self.translate_ctm(x, y)
             component.draw(self, view_bounds=(0, 0, self.width(), self.height()))
-        return
 
     def clip_to_rect(self, x, y, width, height):
         """ Offsets the coordinate frame by (0.5, 0.5) and increases the actual

--- a/chaco/plot_label.py
+++ b/chaco/plot_label.py
@@ -79,7 +79,6 @@ class PlotLabel(AbstractOverlay):
     def __init__(self, text="", *args, **kw):
         super(PlotLabel, self).__init__(*args, **kw)
         self.text = text
-        return
 
     def overlay(self, component, gc, view_bounds=None, mode="normal"):
         """ Draws this label overlaid on another component.
@@ -87,7 +86,6 @@ class PlotLabel(AbstractOverlay):
         Overrides AbstractOverlay.
         """
         self._draw_overlay(gc, view_bounds, mode)
-        return
 
     def get_preferred_size(self):
         """ Returns the label's preferred size.
@@ -107,7 +105,6 @@ class PlotLabel(AbstractOverlay):
             self._layout_as_overlay()
         else:
             self._layout_as_component()
-        return
 
     def _draw_overlay(self, gc, view_bounds=None, mode="normal"):
         """ Draws the overlay layer of a component.
@@ -139,8 +136,6 @@ class PlotLabel(AbstractOverlay):
             # tries to draw at (0,0).
             gc.translate_ctm(self.x + x_offset, self.y + y_offset)
             self._label.draw(gc)
-
-        return
 
     def _draw_plot(self, gc, view_bounds=None, mode="normal"):
         if self.component is None:
@@ -206,22 +201,18 @@ class PlotLabel(AbstractOverlay):
             else:
                 # Leave the position alone
                 pass
-        return
 
     def _text_changed(self, old, new):
         self._label.text = new
         self.do_layout()
-        return
 
     def _font_changed(self, old, new):
         self._label.font = new
         self.do_layout()
-        return
 
     def _angle_changed(self, old, new):
         self._label.rotate_angle = new
         self.do_layout()
-        return
 
     def _overlay_position_changed(self):
         self.do_layout()
@@ -231,4 +222,3 @@ class PlotLabel(AbstractOverlay):
             self.draw_layer = "overlay"
         else:
             self.draw_layer = "plot"
-        return

--- a/chaco/plotscrollbar.py
+++ b/chaco/plotscrollbar.py
@@ -105,7 +105,6 @@ class PlotScrollBar(NativeScrollBar):
                         scroll_position = max(min(self.scroll_position, totalmax-view), totalmin))
         self._scroll_updated = True
         self.request_redraw()
-        return
 
     def _scroll_position_changed(self):
         super(PlotScrollBar, self)._scroll_position_changed()
@@ -115,7 +114,6 @@ class PlotScrollBar(NativeScrollBar):
         view_width = range.high - range.low
         new_scroll_pos = self.scroll_position
         range.set_bounds(new_scroll_pos, new_scroll_pos + view_width)
-        return
 
     #----------------------------------------------------------------------
     # Event listeners
@@ -131,7 +129,6 @@ class PlotScrollBar(NativeScrollBar):
         if new is not None:
             self._modify_plot_listeners(new, "attach")
             self._update_mapper_listeners()
-        return
 
     def __plot_changed(self, old, new):
         if old is not None:
@@ -145,7 +142,6 @@ class PlotScrollBar(NativeScrollBar):
         elif self.component is not None:
             self._modify_plot_listeners(self.component, "attach")
             self._update_mapper_listeners()
-        return
 
     def _modify_plot_listeners(self, plot, action="attach"):
         if action == "attach":
@@ -160,7 +156,6 @@ class PlotScrollBar(NativeScrollBar):
                              "position", remove=remove)
         plot.on_trait_change(self._component_pos_handler,
                              "position_items", remove=remove)
-        return
 
     def _component_bounds_handler(self):
         self._handle_dataspace_update()
@@ -189,7 +184,6 @@ class PlotScrollBar(NativeScrollBar):
 
     def _set_plot(self, val):
         self._plot = val
-        return
 
     def _get_mapper(self):
         if self._mapper is not None:
@@ -199,7 +193,6 @@ class PlotScrollBar(NativeScrollBar):
 
     def _set_mapper(self, new_mapper):
         self._mapper = new_mapper
-        return
 
     def _get_axis_index(self):
         if self._axis_index is None:
@@ -209,7 +202,6 @@ class PlotScrollBar(NativeScrollBar):
 
     def _set_axis_index(self, val):
         self._axis_index = val
-        return
 
     #------------------------------------------------------------------------
     # Private methods

--- a/chaco/point_data_source.py
+++ b/chaco/point_data_source.py
@@ -75,7 +75,6 @@ class PointDataSource(ArrayDataSource):
         if (len(shape) != 2) or (shape[1] != 2):
             raise RuntimeError("PointDataSource constructor requires Nx2 array, but got array of shape " + str(shape) + " instead.")
         super(PointDataSource, self).__init__(data, **kw)
-        return
 
     def get_data(self):
         """ Returns the data for this data source, or (0.0, 0.0) if it has no
@@ -157,7 +156,6 @@ class PointDataSource(ArrayDataSource):
             min_y = min(y)
             max_y = max(y)
             self._cached_bounds = ((min_x,min_y), (max_x,max_y))
-        return
 
     def _get__xdata(self):
         return ArrayDataSource(self._data[:,0])

--- a/chaco/polar_line_renderer.py
+++ b/chaco/polar_line_renderer.py
@@ -57,11 +57,9 @@ class PolarLineRenderer(AbstractPlotRenderer):
         points = transpose(array((sx,sy)))
         self._cached_data_pts = points
         self._cache_valid = True
-        return
 
     def _data_changed(self):
         self._cache_valid = False
-        return
 
     def _update_mappers(self):
         #Dunno if there is anything else to do here
@@ -83,8 +81,6 @@ class PolarLineRenderer(AbstractPlotRenderer):
                 gc.begin_path()
                 gc.lines(points)
                 gc.stroke_path()
-
-        return
 
     def map_screen(self, data_array):
         """ Maps an array of data points into screen space and returns it as
@@ -168,7 +164,6 @@ class PolarLineRenderer(AbstractPlotRenderer):
                     gc.move_to(int(start[0]), int(start[1]))
                     gc.line_to(int(end[0]), int(end[1]))
                     gc.stroke_path()
-        return
 
     def _draw_default_grid(self,gc):
         if not self.grid_visible:
@@ -186,5 +181,3 @@ class PolarLineRenderer(AbstractPlotRenderer):
                 r = rad*r_part/4
                 gc.arc(x_center, y_center, r, 0, 2*pi)
                 gc.stroke_path()
-
-        return

--- a/chaco/polar_mapper.py
+++ b/chaco/polar_mapper.py
@@ -87,4 +87,3 @@ class PolarMapper(AbstractMapper):
             self._null_data_range = False
 
         self._cache_valid = True
-        return

--- a/chaco/polygon_plot.py
+++ b/chaco/polygon_plot.py
@@ -118,7 +118,6 @@ class PolygonPlot(BaseXYPlot):
             if hasattr(self, 'line_style_'):
                 gc.set_line_dash(self.line_style_)
             gc.draw_rect((x,y,width,height))
-        return
 
     def hittest(self, screen_pt, threshold=7.0, return_distance=False):
         """ Performs point-in-polygon testing or point/line proximity testing.

--- a/chaco/quiverplot.py
+++ b/chaco/quiverplot.py
@@ -65,8 +65,6 @@ class QuiverPlot(ScatterPlot):
             self._selected_vector_data = compress(indices, vectors, axis=0)
         else:
             self._selected_vector_data = None
-        return
-
 
     def _render(self, gc, points, icon_mode=False):
         if len(points) < 1:

--- a/chaco/scales/formatters.py
+++ b/chaco/scales/formatters.py
@@ -472,7 +472,6 @@ class TimeFormatter(object):
                 size = len(strftimeEx(s, tmptime))
                 sizes.append(size)
             self.formats[fmt_name] = (array(sizes), fmt_strings)
-        return
 
     def _get_resolution(self, resolution, interval):
         r = resolution

--- a/chaco/scales/time_scale.py
+++ b/chaco/scales/time_scale.py
@@ -243,7 +243,6 @@ class TimeScale(AbstractScale):
         else:
             self.val = val
             self.resolution = val * self.SECS_PER_UNIT[unit]
-        return
 
     def num_ticks(self, start, end, desired_ticks=None):
         """ Returns an approximate number of ticks that this scale

--- a/chaco/scatter_inspector_overlay.py
+++ b/chaco/scatter_inspector_overlay.py
@@ -44,7 +44,6 @@ class ScatterInspectorOverlay(AbstractOverlay):
     def metadata_changed(self, object, name, old, new):
         if self.component is not None:
             self.component.request_redraw()
-        return
 
     def overlay(self, component, gc, view_bounds=None, mode="normal"):
         plot = self.component
@@ -83,7 +82,6 @@ class ScatterInspectorOverlay(AbstractOverlay):
                     else:
                         prefix = "hover"
                     self._render_at_indices(gc, screen_pts, prefix)
-        return
 
     def _render_at_indices(self, gc, screen_pts, inspect_type):
         """ screen_pt should always be a list """
@@ -137,13 +135,9 @@ class ScatterInspectorOverlay(AbstractOverlay):
                 new.on_trait_change(self._ds_changed, dsname)
                 if getattr(new, dsname):
                     self._ds_changed(new, dsname, None, getattr(new,dsname))
-        return
 
     def _ds_changed(self, object, name, old, new):
         if old:
             old.on_trait_change(self.metadata_changed, 'metadata_changed', remove=True)
         if new:
             new.on_trait_change(self.metadata_changed, 'metadata_changed')
-        return
-
-

--- a/chaco/scatterplot.py
+++ b/chaco/scatterplot.py
@@ -150,8 +150,6 @@ def render_markers(gc, points, marker, marker_size,
                     gc.add_path(path)
                     gc.draw_path(STROKE)
 
-    return
-
 #------------------------------------------------------------------------------
 # The scatter plot
 #------------------------------------------------------------------------------
@@ -420,8 +418,6 @@ class ScatterPlot(BaseXYPlot):
                 self._cached_selected_pts = None
                 self._selection_cache_valid = True
 
-        return
-
     def _gather_points_fast(self):
         if self._cache_valid and self._selection_cache_valid:
             return
@@ -496,7 +492,6 @@ class ScatterPlot(BaseXYPlot):
     def _render_icon(self, gc, x, y, width, height):
         point = array([x+width/2, y+height/2])
         self._render(gc, [point], icon_mode=True)
-        return
 
     #------------------------------------------------------------------------
     # Event handlers

--- a/chaco/selectable_legend.py
+++ b/chaco/selectable_legend.py
@@ -66,10 +66,8 @@ class SelectableLegend(Legend, SelectTool):
             self.selections.append(index)
         else:
             self.selections = [index]
-        return
 
     def _deselect(self, index=None):
         if index in self.selections:
             self.selections.remove(index)
-        return
 

--- a/chaco/serializable.py
+++ b/chaco/serializable.py
@@ -49,7 +49,6 @@ class Serializable(object):
         Called before __getstate__ to give the object a chance to tidy up
         and get ready to be saved.  This usually also calls the superclass.
         """
-        return
 
     def _post_load(self):
         """
@@ -73,7 +72,6 @@ class Serializable(object):
         """
         # Quietly set all the attributes
         self.trait_setq(**state)
-        return
 
     #------------------------------------------------------------------------
     # Private methods

--- a/chaco/shell/commands.py
+++ b/chaco/shell/commands.py
@@ -176,7 +176,7 @@ def activate(ident=None):
     if win is not None:
         session.active_window = win
         win.raise_window()
-    return
+
 
 def show():
     """ Shows all the figure windows that have been created thus far, and
@@ -194,7 +194,6 @@ def show():
         frame = session.active_window
         frame.raise_window()
         start_event_loop()
-    return
 
 
 def close(ident=None):
@@ -216,7 +215,7 @@ def close(ident=None):
 
     for win in win_list:
         win.close()
-    return
+
 
 def colormap(map):
     """Sets the active colormap.
@@ -246,7 +245,7 @@ def hold(state=None):
         session.hold = not session.hold
     else:
         session.hold = state
-    return
+
 
 def curplot():
     if session.active_window:
@@ -311,7 +310,6 @@ def plot(*data, **kwargs):
                                *data, **kwargs)
 
     cont.request_redraw()
-    return
 
 
 def semilogx(*data, **kwargs):
@@ -403,7 +401,6 @@ def imshow(*data, **kwargs):
     plots = plot_maker.do_imshow(session.data, cont,
                                  *data, **kwargs)
     cont.request_redraw()
-    return
 
 
 def pcolor(*data, **kwargs):
@@ -427,8 +424,6 @@ def pcolor(*data, **kwargs):
     plots = plot_maker.do_pcolor(session.data, session.colormap, cont,
                                  *data, **kwargs)
     cont.request_redraw()
-    return
-
 
 
 def contour(*data, **kwargs):
@@ -452,8 +447,6 @@ def contour(*data, **kwargs):
     plots = plot_maker.do_contour(session.data, session.colormap, cont,
                                   "line", *data, **kwargs)
     cont.request_redraw()
-    return
-
 
 
 def contourf(*data, **kwargs):
@@ -477,8 +470,6 @@ def contourf(*data, **kwargs):
     plots = plot_maker.do_contour(session.data, session.colormap, cont,
                                   "poly", *data, **kwargs)
     cont.request_redraw()
-    return
-
 
 
 def plotv(*args, **kwargs):
@@ -543,7 +534,6 @@ def plotv(*args, **kwargs):
     plots = plot_maker.do_plotv(session, *args, **kwargs)
     cont.add(*plots)
     cont.request_redraw()
-    return
 
 
 #-----------------------------------------------------------------------------
@@ -809,4 +799,3 @@ def save(filename="chacoplot.png", dpi=72, pagesize="letter", dest_box=None, uni
     else:
         print("Format not yet supported:", ext)
         print("Currently supported formats are: bmp, png, jpg.")
-    return

--- a/chaco/shell/plot_window.py
+++ b/chaco/shell/plot_window.py
@@ -56,7 +56,6 @@ if ETSConfig.toolkit == "wx":
             self.SetSizer(sizer)
             self.SetAutoLayout(True)
             self.Show(True)
-            return
 
         def get_container(self):
             return self.plot_window.component

--- a/chaco/simple_plot_frame.py
+++ b/chaco/simple_plot_frame.py
@@ -55,7 +55,6 @@ class SimplePlotFrame(BasePlotFrame):
         BasePlotFrame.__init__(self, **kwtraits)
         self.set_slot("center", OverlayPlotContainer(resizable="hv"))
         self.bounds = bounds
-        return
 
     #------------------------------------------------------------------------
     # Protected methods
@@ -74,7 +73,6 @@ class SimplePlotFrame(BasePlotFrame):
             gc.translate_ctm(*self.position)
             with gc:
                 self.center.draw(gc, view_bounds, mode)
-        return
 
     def get_preferred_size(self):
         """ Returns the size (width,height) that is preferred for this component.
@@ -131,7 +129,6 @@ class SimplePlotFrame(BasePlotFrame):
 
         component.outer_position = [0,0]
         component.do_layout()
-        return
 
     ### Persistence ###########################################################
     #_pickles = ()

--- a/chaco/svg_graphics_context.py
+++ b/chaco/svg_graphics_context.py
@@ -25,7 +25,6 @@ class SVGGraphicsContext(GraphicsContext):
         super(SVGGraphicsContext, self).__init__(size_or_ary, *args, **kw)
         self.translate_ctm(0.5, 0.5)
         self.scale_ctm(scale, scale)
-        return
 
     def render_component(self, component, container_coords=False):
         """ Renders the given component.
@@ -61,7 +60,6 @@ class SVGGraphicsContext(GraphicsContext):
             self.translate_ctm(x, y)
             self.scale_ctm(width_scale, height_scale)
             component.draw(self, view_bounds=(0, 0, width, height))
-        return
 
     def clip_to_rect(self, x, y, width, height):
         """ Offsets the coordinate frame by (0.5, 0.5) and increases the actual

--- a/chaco/tools/better_selecting_zoom.py
+++ b/chaco/tools/better_selecting_zoom.py
@@ -156,8 +156,6 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
             self._start_select(event)
             event.handled = True
 
-        return
-
     def normal_right_down(self, event):
         """ Handles the right mouse button being pressed while the tool is
         in the 'normal' state.
@@ -167,8 +165,6 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
         if self._is_enabling_event(event):
             self._start_select(event)
             event.handled = True
-
-        return
 
     def pre_selecting_left_down(self, event):
         """ The user pressed the key to turn on the zoom mode,
@@ -222,7 +218,6 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
             self._screen_end = (event.x, event.y)
         self.component.request_redraw()
         event.handled = True
-        return
 
     def selecting_left_up(self, event):
         """ Handles the left mouse button being released when the tool is in
@@ -232,7 +227,6 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
         """
         if self.drag_button in ("left", None):
             self._end_select(event)
-        return
 
     def selecting_right_up(self, event):
         """ Handles the right mouse button being released when the tool is in
@@ -242,7 +236,6 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
         """
         if self.drag_button == "right":
             self._end_select(event)
-        return
 
     def selecting_mouse_leave(self, event):
         """ Handles the mouse leaving the plot when the tool is in the
@@ -251,7 +244,6 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
         Ends the selection operation without zooming.
         """
         self._end_selecting(event)
-        return
 
     #--------------------------------------------------------------------------
     #  AbstractOverlay interface
@@ -267,7 +259,6 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
                 self._overlay_range(component, gc)
             else:
                 self._overlay_box(component, gc)
-        return
 
     #--------------------------------------------------------------------------
     #  private interface
@@ -321,7 +312,6 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
         event.window.set_pointer(self.pointer)
         event.window.set_mouse_owner(self, event.net_transform())
         self.selecting_mouse_move(event)
-        return
 
     def _end_select(self, event):
         """ Ends selection of the zoom region, adds the new zoom range to
@@ -362,7 +352,6 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
 
         self._end_selecting(event)
         event.handled = True
-        return
 
     def _end_selecting(self, event=None):
         """ Ends selection of zoom region, without zooming.
@@ -377,7 +366,6 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
         self.component.request_redraw()
         if event and event.window.mouse_owner == self:
             event.window.set_mouse_owner(None)
-        return
 
     def _overlay_box(self, component, gc):
         """ Draws the overlay as a box.
@@ -398,7 +386,6 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
                 else:
                     gc.rect(*rect)
                     gc.stroke_path()
-        return
 
     def _overlay_range(self, component, gc):
         """ Draws the overlay as a range.
@@ -418,8 +405,6 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
             gc.set_stroke_color(self.border_color_)
             gc.clip_to_rect(component.x, component.y, component.width, component.height)
             gc.draw_rect((lower_left[0], lower_left[1], upper_right[0], upper_right[1]))
-
-        return
 
     def _get_fill_color(self):
         """Get the fill color based on the alpha and the color property

--- a/chaco/tools/better_zoom.py
+++ b/chaco/tools/better_zoom.py
@@ -262,8 +262,6 @@ class BetterZoom(BaseTool, ToolHistoryMixin):
 
         ToolHistoryMixin.normal_key_pressed(self, event)
 
-        return
-
     def normal_mouse_wheel(self, event):
         if not self.enable_wheel:
             return

--- a/chaco/tools/cursor_tool.py
+++ b/chaco/tools/cursor_tool.py
@@ -119,7 +119,6 @@ class BaseCursorTool(LineInspector, DragTool):
                         # Kiva GCs have a path-drawing interface
                         marker.add_to_path(gc, marker_size)
                         gc.draw_path(marker.draw_mode)
-        return
 
     def normal_mouse_move(self, event):
         """ Handles the mouse being moved.

--- a/chaco/tools/data_label_tool.py
+++ b/chaco/tools/data_label_tool.py
@@ -54,8 +54,6 @@ class DataLabelTool(DragTool):
             self._original_offset = (label.x - pointx, label.y - pointy)
             event.window.set_mouse_owner(self, event.net_transform())
             event.handled = True
-        return
-
 
     def dragging(self, event):
         """ This method is called for every mouse_move event that the tool
@@ -87,8 +85,6 @@ class DataLabelTool(DragTool):
 
             event.handled = True
             label.request_redraw()
-        return
-
 
     def drag_end(self, event):
         """ Called when a mouse event causes the drag operation to end.
@@ -100,4 +96,3 @@ class DataLabelTool(DragTool):
                 event.window.set_mouse_owner(None)
             event.handled = True
             self.component.request_redraw()
-        return

--- a/chaco/tools/dataprinter.py
+++ b/chaco/tools/dataprinter.py
@@ -38,7 +38,6 @@ class DataPrinter(BaseTool):
             else:
                 msg = "dataprinter: don't know how to handle plots of type {}"
                 print(msg.format(plot.__class__.__name__))
-        return
 
     def _build_text_from_event(self, event):
         """ Build the text to display from the mouse event.

--- a/chaco/tools/drag_zoom.py
+++ b/chaco/tools/drag_zoom.py
@@ -94,8 +94,6 @@ class DragZoom(DragTool, BetterZoom):
         self.zoom_in_x(zoom_x)
         self.zoom_in_y(zoom_y)
 
-        return
-
     def drag_start(self, event, capture_mouse=True):
         self._original_xy = (event.x, event.y)
         c = self.component
@@ -107,14 +105,12 @@ class DragZoom(DragTool, BetterZoom):
             event.window.set_pointer(self.drag_pointer)
             event.window.set_mouse_owner(self, event.net_transform())
         event.handled = True
-        return
 
     def drag_end(self, event):
         event.window.set_pointer("arrow")
         if event.window.mouse_owner == self:
             event.window.set_mouse_owner(None)
         event.handled = True
-        return
 
     def _calc_zoom(self, original, clicked):
         """ Returns the amount to scale the range based on the original

--- a/chaco/tools/draw_points_tool.py
+++ b/chaco/tools/draw_points_tool.py
@@ -28,7 +28,6 @@ class DrawPointsTool(BaseTool):
         BaseTool.__init__(self, **kwtraits)
         self.xdata = self.component.value1
         self.ydata = self.component.value2
-        return
 
     def normal_left_down(self, event):
         """ Handles the left mouse button being clicked when the tool is in the
@@ -42,18 +41,14 @@ class DrawPointsTool(BaseTool):
         self._append_data(self.xdata, data_x)
         self._append_data(self.ydata, data_y)
         self.component.request_redraw()
-        return
 
     def _activate(self):
         self.activated = True
-        return
 
     def _deactivate(self):
         self.activated = False
-        return
 
     def _append_data(self, datasource, data):
         olddata = array(datasource.get_data(), float64)
         newdata = hstack((olddata, data))
         datasource.set_data(newdata)
-        return

--- a/chaco/tools/highlight_tool.py
+++ b/chaco/tools/highlight_tool.py
@@ -42,7 +42,6 @@ class HighlightTool(BaseTool):
         """
         if self.drag_button == "left":
             self._highlight(event)
-        return
 
     def normal_right_down(self, event):
         """ Handles the right mouse button being pressed.
@@ -51,7 +50,6 @@ class HighlightTool(BaseTool):
         """
         if self.drag_button == "right":
             self._highlight(event)
-        return
 
     def _highlight(self, event):
         if isinstance(self.component, BasePlotContainer):
@@ -81,7 +79,6 @@ class HighlightTool(BaseTool):
                 self.component.request_redraw()
 
         event.handled = True
-        return
 
 
     def _find_curve(self, plots, event):

--- a/chaco/tools/image_inspector_tool.py
+++ b/chaco/tools/image_inspector_tool.py
@@ -80,7 +80,6 @@ class ImageInspectorTool(BaseTool):
                          "color_value": image_data.data[y_index, x_index]}
 
                 self.last_mouse_position = (event.x, event.y)
-        return
 
 
 class ImageInspectorOverlay(TextBoxOverlay):

--- a/chaco/tools/lasso_selection.py
+++ b/chaco/tools/lasso_selection.py
@@ -154,7 +154,6 @@ class LassoSelection(AbstractController):
             else:
                 self.selection_mode = "include"
         self.trait_property_changed("disjoint_selections", [], self.disjoint_selections)
-        return
 
     def selecting_left_up(self, event):
         if self.drag_button == "left":
@@ -175,7 +174,6 @@ class LassoSelection(AbstractController):
 
         self._previous_selections.append(self._active_selection)
         self._active_selection = empty((0,2), dtype=numpy.bool)
-        return
 
     def selecting_mouse_move(self, event):
         """ Handles the mouse moving when the tool is in the 'selecting' state.
@@ -192,7 +190,6 @@ class LassoSelection(AbstractController):
             self._update_selection()
         # Report None for the previous selections
         self.trait_property_changed("disjoint_selections", None)
-        return
 
     def selecting_mouse_leave(self, event):
         """ Handles the mouse leaving the plot when the tool is in the
@@ -217,7 +214,6 @@ class LassoSelection(AbstractController):
             self.selecting_mouse_up(None)
             self.selection_mode = 'invert'
             self._select_all()
-        return
 
     #----------------------------------------------------------------------
     # Protected Methods
@@ -325,4 +321,3 @@ class LassoSelection(AbstractController):
 
     def _set_plot(self, val):
         self._plot = val
-        return

--- a/chaco/tools/legend_highlighter.py
+++ b/chaco/tools/legend_highlighter.py
@@ -95,7 +95,6 @@ class LegendHighlighter(LegendTool):
                 plot._orig_line_width = plot.line_width
             plot.alpha = plot._orig_alpha
             plot.line_width = plot._orig_line_width
-        return
 
     def _set_states(self, plots):
         """ Decorates a plot to indicate it is selected """

--- a/chaco/tools/legend_tool.py
+++ b/chaco/tools/legend_tool.py
@@ -44,8 +44,6 @@ class LegendTool(DragTool):
             self.original_padding = self.component.padding
             event.window.set_mouse_owner(self, event.net_transform())
             event.handled = True
-        return
-
 
     def dragging(self, event):
         """ This method is called for every mouse_move event that the tool
@@ -78,8 +76,6 @@ class LegendTool(DragTool):
 
             event.handled = True
             legend.request_redraw()
-        return
-
 
     def drag_end(self, event):
         """ Called when a mouse event causes the drag operation to end.
@@ -117,4 +113,3 @@ class LegendTool(DragTool):
                 event.window.set_mouse_owner(None)
             event.handled = True
             legend.request_redraw()
-        return

--- a/chaco/tools/line_inspector.py
+++ b/chaco/tools/line_inspector.py
@@ -96,7 +96,6 @@ class LineInspector(BaseTool):
                 self._draw_horizontal_line(gc, sy)
             elif sx is not None:
                 self._draw_vertical_line(gc, sx)
-        return
 
     def do_layout(self, *args, **kw):
         pass
@@ -105,7 +104,6 @@ class LineInspector(BaseTool):
         """ Draws this component overlaid on a graphics context.
         """
         self.draw(gc, view_bounds)
-        return
 
     def normal_mouse_move(self, event):
         """ Handles the mouse being moved.
@@ -163,7 +161,6 @@ class LineInspector(BaseTool):
                     plot.index.metadata[self.metadata_name] = metadata
 
             plot.request_redraw()
-        return
 
     def normal_mouse_leave(self, event):
         """ Handles the mouse leaving the plot.
@@ -180,7 +177,6 @@ class LineInspector(BaseTool):
                 elif isinstance(plot, Base2DPlot):
                     plot.index.metadata.pop(self.metadata_name, None)
             plot.request_redraw()
-        return
 
     #------------------------------------------------------------------------
     # Private methods
@@ -263,7 +259,6 @@ class LineInspector(BaseTool):
             gc.move_to(sx, self.component.y)
             gc.line_to(sx, self.component.y2)
             gc.stroke_path()
-        return
 
     def _draw_horizontal_line(self, gc, sy):
         """ Draws a horizontal line through screen point (sx,sy) having the
@@ -279,4 +274,3 @@ class LineInspector(BaseTool):
             gc.move_to(self.component.x, sy)
             gc.line_to(self.component.x2, sy)
             gc.stroke_path()
-        return

--- a/chaco/tools/line_segment_tool.py
+++ b/chaco/tools/line_segment_tool.py
@@ -91,7 +91,6 @@ class LineSegmentTool(AbstractOverlay):
         self.component = component
         self.reset()
         self.line.line_dash = (4.0, 2.0)
-        return
 
     #------------------------------------------------------------------------
     # Drawing tool methods
@@ -105,7 +104,6 @@ class LineSegmentTool(AbstractOverlay):
         self.event_state = "normal"
         self.visible = False
         self.request_redraw()
-        return
 
     def _activate(self):
         """
@@ -118,7 +116,6 @@ class LineSegmentTool(AbstractOverlay):
         Called by a PlotComponent when this is no longer the active tool.
         """
         self.reset()
-        return
 
     #------------------------------------------------------------------------
     # PointLine methods
@@ -129,7 +126,6 @@ class LineSegmentTool(AbstractOverlay):
         space point to the list for this tool.
         """
         self.points.append(self._map_data(point))
-        return
 
     def get_point(self, index):
         """ Retrieves the indexed point and returns its screen space value.
@@ -140,14 +136,12 @@ class LineSegmentTool(AbstractOverlay):
         """ Sets the data-space *index* for a screen-space *point*.
         """
         self.points[index] = self._map_data(point)
-        return
 
     def remove_point(self, index):
         """ Removes the point for a given *index* from this tool's list of
         points.
         """
         del self.points[index]
-        return
 
     #------------------------------------------------------------------------
     # "normal" state
@@ -183,7 +177,6 @@ class LineSegmentTool(AbstractOverlay):
             self.visible = True
             self.event_state = "dragging"
             self.dragging_mouse_move(event)
-        return
 
     def normal_mouse_move(self, event):
         """ Handles the user moving the mouse in the 'normal' state.
@@ -208,14 +201,12 @@ class LineSegmentTool(AbstractOverlay):
             event.handled = False
             event.window.set_pointer(self.normal_cursor)
         self.request_redraw()
-        return
 
     def normal_draw(self, gc):
         """ Draws the line.
         """
         self.line.points = list(self.component.map_screen(array(self.points)))
         self.line._draw(gc)
-        return
 
     def normal_key_pressed(self, event):
         """ Handles the user pressing a key in the 'normal' state.
@@ -225,13 +216,11 @@ class LineSegmentTool(AbstractOverlay):
         if event.character == "Enter":
             self._finalize_selection()
             self.reset()
-        return
 
     def normal_mouse_leave(self, event):
         """ Handles the user moving the cursor away from the tool area.
         """
         event.window.set_pointer("arrow")
-        return
 
     #------------------------------------------------------------------------
     # "dragging" state
@@ -246,13 +235,11 @@ class LineSegmentTool(AbstractOverlay):
         self.points[self._dragged] = mouse_position
         self.line.points = list(self.component.map_screen(array(self.points)))
         self.request_redraw()
-        return
 
     def dragging_draw(self, gc):
         """ Draws the polygon in the 'dragging' state.
         """
         self.line._draw(gc)
-        return
 
     def dragging_left_up(self, event):
         """ Handles the left mouse coming up in the 'dragging' state.
@@ -262,7 +249,6 @@ class LineSegmentTool(AbstractOverlay):
         self.event_state = "normal"
         self._dragged = None
         self.updated = self
-        return
 
     def dragging_key_pressed(self, event):
         """ Handles a key being pressed in the 'dragging' state.
@@ -271,7 +257,6 @@ class LineSegmentTool(AbstractOverlay):
         """
         if event.character == "Esc":
             self._cancel_drag()
-        return
 
     def dragging_mouse_leave(self, event):
         """ Handles the mouse leaving the tool area in the 'dragging' state.
@@ -280,7 +265,6 @@ class LineSegmentTool(AbstractOverlay):
         """
         self._cancel_drag()
         event.window.set_pointer("arrow")
-        return
 
     def _cancel_drag(self):
         """ Cancels a drag operation.
@@ -293,7 +277,6 @@ class LineSegmentTool(AbstractOverlay):
         self.mouse_position = None
         self.event_state = "normal"
         self.request_redraw()
-        return
 
     #------------------------------------------------------------------------
     # override AbstractOverlay methods
@@ -309,7 +292,6 @@ class LineSegmentTool(AbstractOverlay):
             with gc:
                 gc.clip_to_rect(component.x, component.y, component.width-1, component.height-1)
                 draw_func(gc)
-        return
 
     def request_redraw(self):
         """ Requests that the component redraw itself.
@@ -318,7 +300,6 @@ class LineSegmentTool(AbstractOverlay):
         """
         self.component.invalidate_draw()
         self.component.request_redraw()
-        return
 
     #------------------------------------------------------------------------
     # Private methods
@@ -385,4 +366,3 @@ class LineSegmentTool(AbstractOverlay):
     def _component_changed(self, old, new):
         if new:
             self.container = new
-        return

--- a/chaco/tools/pan_tool.py
+++ b/chaco/tools/pan_tool.py
@@ -102,7 +102,6 @@ class PanTool(BaseTool):
             event.x = dest[0]
             event.y = dest[1]
             self.panning_mouse_move(event)
-        return
 
     def normal_left_down(self, event):
         """ Handles the left mouse button being pressed when the tool is in
@@ -112,7 +111,6 @@ class PanTool(BaseTool):
         """
         if self.drag_button == "left":
             self._start_pan(event)
-        return
 
     def normal_right_down(self, event):
         """ Handles the right mouse button being pressed when the tool is in
@@ -122,7 +120,6 @@ class PanTool(BaseTool):
         """
         if self.drag_button == "right":
             self._start_pan(event)
-        return
 
     def normal_middle_down(self, event):
         """ Handles the middle mouse button being pressed when the tool is in
@@ -132,7 +129,6 @@ class PanTool(BaseTool):
         """
         if self.drag_button == "middle":
             self._start_pan(event)
-        return
 
     def panning_left_up(self, event):
         """ Handles the left mouse button coming up when the tool is in the
@@ -142,7 +138,6 @@ class PanTool(BaseTool):
         """
         if self.drag_button == "left":
             self._end_pan(event)
-        return
 
     def panning_right_up(self, event):
         """ Handles the right mouse button coming up when the tool is in the
@@ -152,7 +147,6 @@ class PanTool(BaseTool):
         """
         if self.drag_button == "right":
             self._end_pan(event)
-        return
 
     def panning_middle_up(self, event):
         """ Handles the middle mouse button coming up when the tool is in the
@@ -162,7 +156,6 @@ class PanTool(BaseTool):
         """
         if self.drag_button == "middle":
             self._end_pan(event)
-        return
 
     def panning_mouse_move(self, event):
         """ Handles the mouse being moved when the tool is in the 'panning'
@@ -236,7 +229,6 @@ class PanTool(BaseTool):
 
         self._original_xy = (event.x, event.y)
         plot.request_redraw()
-        return
 
     def panning_mouse_leave(self, event):
         """ Handles the mouse leaving the plot when the tool is in the 'panning'
@@ -258,7 +250,6 @@ class PanTool(BaseTool):
             event.window.set_pointer(self.drag_pointer)
             event.window.set_mouse_owner(self, event.net_transform())
         event.handled = True
-        return
 
     def _end_pan(self, event):
         if self._auto_constrain:
@@ -269,4 +260,3 @@ class PanTool(BaseTool):
         if event.window.mouse_owner == self:
             event.window.set_mouse_owner(None)
         event.handled = True
-        return

--- a/chaco/tools/pan_tool2.py
+++ b/chaco/tools/pan_tool2.py
@@ -130,7 +130,6 @@ class PanTool(DragTool):
 
         self._original_xy = (event.x, event.y)
         plot.request_redraw()
-        return
 
     def drag_cancel(self, event):
         # We don't do anything for "cancelling" of the drag event because its
@@ -153,7 +152,6 @@ class PanTool(DragTool):
             event.window.set_pointer(self.drag_pointer)
             event.window.set_mouse_owner(self, event.net_transform())
         event.handled = True
-        return
 
     def _end_pan(self, event):
         if self._auto_constrain:
@@ -164,6 +162,3 @@ class PanTool(DragTool):
         if event.window.mouse_owner == self:
             event.window.set_mouse_owner(None)
         event.handled = True
-        return
-
-

--- a/chaco/tools/point_marker.py
+++ b/chaco/tools/point_marker.py
@@ -59,7 +59,6 @@ class PointMarker(BaseTool):
                     self._draw_horizontal_lines(gc, screen_pts)
                 else:
                     self._draw_vertical_lines(gc, screen_pts)
-        return
 
     #------------------------------------------------------------------------
     # Private methods
@@ -72,7 +71,6 @@ class PointMarker(BaseTool):
                 gc.move_to(int(pt[0])+0.5, self.component.y)
                 gc.line_to(int(pt[0])+0.5, self.component.y2)
             gc.stroke_path()
-        return
 
     def _draw_horizontal_lines(self, gc, points):
         with gc:
@@ -81,4 +79,3 @@ class PointMarker(BaseTool):
                 gc.move_to(self.component.x, int(pt[1])+0.5)
                 gc.line_to(self.component.x2, int(pt[1])+0.5)
             gc.stroke_path()
-        return

--- a/chaco/tools/range_selection.py
+++ b/chaco/tools/range_selection.py
@@ -172,7 +172,6 @@ class RangeSelection(AbstractController):
         if event:
             event.window.set_pointer("arrow")
             event.handled = True
-        return
 
     #------------------------------------------------------------------------
     # Event handlers for the "selected" event state
@@ -222,7 +221,6 @@ class RangeSelection(AbstractController):
             self.deselect(event)
             self.normal_left_down(event)
         event.handled = True
-        return
 
     def selected_right_down(self, event):
         """ Handles the right mouse button being pressed when the tool is in
@@ -265,7 +263,6 @@ class RangeSelection(AbstractController):
             self.deselect(event)
             self.normal_right_down(event)
         event.handled = True
-        return
 
     def selected_mouse_move(self, event):
         """ Handles the mouse moving when the tool is in the 'selected' srate.
@@ -291,7 +288,6 @@ class RangeSelection(AbstractController):
                     return
         event.window.set_pointer("arrow")
         event.handled = True
-        return
 
     def selected_mouse_leave(self, event):
         """ Handles the mouse leaving the plot when the tool is in the
@@ -300,7 +296,6 @@ class RangeSelection(AbstractController):
         Sets the cursor to an arrow.
         """
         event.window.set_pointer("arrow")
-        return
 
     #------------------------------------------------------------------------
     # Event handlers for the "moving" event state
@@ -319,7 +314,6 @@ class RangeSelection(AbstractController):
         self.selection_completed = self.selection
         self._down_point = []
         event.handled = True
-        return
 
     def moving_mouse_move(self, event):
         """ Handles the mouse moving when the tool is in the 'moving' state.
@@ -346,7 +340,6 @@ class RangeSelection(AbstractController):
         self.selection_completed = new_selection
         self.component.request_redraw()
         event.handled = True
-        return
 
     def moving_mouse_leave(self, event):
         """ Handles the mouse leaving the plot while the tool is in the
@@ -371,12 +364,10 @@ class RangeSelection(AbstractController):
             # the mouse left and exceeds the mapping range, so we need to slam
             # the selection all the way to the minimum or the maximum
             self.moving_mouse_move(event)
-        return
 
     def moving_mouse_enter(self, event):
         if not event.left_down:
             return self.moving_left_up(event)
-        return
 
     #------------------------------------------------------------------------
     # Event handlers for the "normal" event state
@@ -411,7 +402,6 @@ class RangeSelection(AbstractController):
         else:
             self.selection_mode = "set"
         self.selecting_mouse_move(event)
-        return
 
     #------------------------------------------------------------------------
     # Event handlers for the "selecting" event state
@@ -448,7 +438,6 @@ class RangeSelection(AbstractController):
 
                 self.component.request_redraw()
             event.handled = True
-        return
 
     def selecting_button_up(self, event):
         # Check to see if the selection region is bigger than the minimum
@@ -472,7 +461,6 @@ class RangeSelection(AbstractController):
             # Fire the "completed" event
             self.selection_completed = self.selection
             event.handled = True
-        return
 
     def selecting_right_up(self, event):
         """ Handles the right mouse button coming up when the tool is in the
@@ -523,7 +511,6 @@ class RangeSelection(AbstractController):
         self.selection = (selection_low, selection_high)
         event.window.set_pointer("arrow")
         self.component.request_redraw()
-        return
 
     def selecting_mouse_enter(self, event):
         """ Handles the mouse entering the plot when the tool is in the
@@ -540,7 +527,6 @@ class RangeSelection(AbstractController):
             return self.selecting_button_up(event)
         else:
             self._set_sizing_cursor(event)
-        return
 
     #------------------------------------------------------------------------
     # Property getter/setters
@@ -554,7 +540,6 @@ class RangeSelection(AbstractController):
 
     def _set_plot(self, val):
         self._plot = val
-        return
 
     def _get_mapper(self):
         if self._mapper is not None:
@@ -564,7 +549,6 @@ class RangeSelection(AbstractController):
 
     def _set_mapper(self, new_mapper):
         self._mapper = new_mapper
-        return
 
     def _get_axis_index(self):
         if self._axis_index is None:
@@ -574,7 +558,6 @@ class RangeSelection(AbstractController):
 
     def _set_axis_index(self, val):
         self._axis_index = val
-        return
 
     def _get_selection(self):
         selection = getattr(self.plot, self.axis).metadata[self.metadata_name]
@@ -620,7 +603,6 @@ class RangeSelection(AbstractController):
             if hasattr(l, "set_value_selection"):
                 l.set_value_selection(val)
 
-        return
 
     #------------------------------------------------------------------------
     # Private methods
@@ -648,7 +630,6 @@ class RangeSelection(AbstractController):
         else:
             # vertical range selection, so use up/down arrow
             event.window.set_pointer("size top")
-        return
 
     def _get_axis_coord(self, event, axis="index"):
         """ Returns the coordinate of the event along the axis of interest
@@ -681,7 +662,6 @@ class RangeSelection(AbstractController):
 
     def __mapper_changed(self):
         self.deselect()
-        return
 
     def _axis_changed(self, old, new):
         if old is not None:
@@ -690,4 +670,3 @@ class RangeSelection(AbstractController):
         if new is not None:
             self.plot.on_trait_change(self.__mapper_changed,
                                       old + "_mapper", remove=True)
-        return

--- a/chaco/tools/range_selection_2d.py
+++ b/chaco/tools/range_selection_2d.py
@@ -61,7 +61,6 @@ class RangeSelection2D(RangeSelection):
             self.deselect(event)
             self.normal_left_down(event)
         event.handled = True
-        return
 
     def selected_right_down(self, event):
         """ Handles the right mouse button being pressed when the tool is in
@@ -104,7 +103,6 @@ class RangeSelection2D(RangeSelection):
             self.deselect(event)
             self.normal_right_down(event)
         event.handled = True
-        return
 
     def selected_mouse_move(self, event):
         """ Handles the mouse moving when the tool is in the 'selected' state.
@@ -129,7 +127,6 @@ class RangeSelection2D(RangeSelection):
                     return
         event.window.set_pointer("arrow")
         event.handled = True
-        return
 
     #------------------------------------------------------------------------
     # Event handlers for the "moving" event state
@@ -162,7 +159,6 @@ class RangeSelection2D(RangeSelection):
         self.selection_completed = new_selection
         self.component.request_redraw()
         event.handled = True
-        return
 
     #------------------------------------------------------------------------
     # Event handlers for the "normal" event state
@@ -186,7 +182,6 @@ class RangeSelection2D(RangeSelection):
         self._set_sizing_cursor(event)
         self.event_state = "selecting"
         self.selecting_mouse_move(event)
-        return
 
     #------------------------------------------------------------------------
     # Event handlers for the "selecting" event state
@@ -240,7 +235,6 @@ class RangeSelection2D(RangeSelection):
 
                 self.component.request_redraw()
             event.handled = True
-        return
 
     def selecting_mouse_leave(self, event):
         """ Handles the mouse leaving the plot when the tool is in the
@@ -272,7 +266,6 @@ class RangeSelection2D(RangeSelection):
         self.selection = (selection_low, selection_high)
         event.window.set_pointer("arrow")
         self.component.request_redraw()
-        return
 
     #------------------------------------------------------------------------
     # Private methods

--- a/chaco/tools/range_selection_overlay.py
+++ b/chaco/tools/range_selection_overlay.py
@@ -147,11 +147,9 @@ class RangeSelectionOverlay(AbstractOverlay):
 
     def _component_changed(self, old, new):
         self._attach_metadata_handler(old, new)
-        return
 
     def _axis_changed(self, old, new):
         self._attach_metadata_handler(old, new)
-        return
 
     def _attach_metadata_handler(self, old, new):
         # This is used to attach a listener to the datasource so that when
@@ -165,11 +163,9 @@ class RangeSelectionOverlay(AbstractOverlay):
                                         remove=True)
         if new:
             datasource.on_trait_change(self._metadata_change_handler, "metadata_changed")
-        return
 
     def _metadata_change_handler(self, event):
         self.component.request_redraw()
-        return
 
     #------------------------------------------------------------------------
     # Default initializers

--- a/chaco/tools/regression_lasso.py
+++ b/chaco/tools/regression_lasso.py
@@ -42,7 +42,6 @@ class RegressionLasso(LassoSelection):
         else:
             self.fit_params = None
             self.centroid = None
-        return
 
 
 class RegressionOverlay(LassoOverlay):
@@ -97,5 +96,3 @@ class RegressionOverlay(LassoOverlay):
                 gc.move_to(*left_pt)
                 gc.line_to(*right_pt)
                 gc.stroke_path()
-
-        return

--- a/chaco/tools/save_tool.py
+++ b/chaco/tools/save_tool.py
@@ -51,7 +51,6 @@ class SaveTool(BaseTool):
             else:
                 self._save_raster()
             event.handled = True
-        return
 
     def _save_raster(self):
         """ Saves an image of the component.
@@ -60,7 +59,6 @@ class SaveTool(BaseTool):
         gc = PlotGraphicsContext((int(self.component.outer_width), int(self.component.outer_height)))
         self.component.draw(gc, mode="normal")
         gc.save(self.filename)
-        return
 
     def _save_pdf(self):
         from chaco.pdf_graphics_context import PdfPlotGraphicsContext

--- a/chaco/tools/scatter_inspector.py
+++ b/chaco/tools/scatter_inspector.py
@@ -82,8 +82,6 @@ class ScatterInspector(SelectTool):
             if hasattr(plot, "value"):
                 plot.value.metadata.pop(self.hover_metadata_name, None)
 
-        return
-
     def _get_selection_state(self, event):
         plot = self.component
         index = plot.map_index((event.x, event.y), threshold=self.threshold)
@@ -130,7 +128,6 @@ class ScatterInspector(SelectTool):
                 # Only issue 1 event:
                 if name == 'index':
                     self.inspector_event = insp_event
-        return
 
     def _select(self, index, append=True):
         plot = self.component
@@ -164,5 +161,3 @@ class ScatterInspector(SelectTool):
             # Test to only issue 1 event per selection, not 1 per axis:
             if name == 'index':
                 self.inspector_event = insp_event
-
-        return

--- a/chaco/tools/simple_zoom.py
+++ b/chaco/tools/simple_zoom.py
@@ -151,7 +151,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
                 (x_range.high_setting, y_range.high_setting)
         component.on_trait_change(self._reset_state_to_current,
                                   "index_data_changed")
-        return
 
     def enable(self, event=None):
         """ Provides a programmatic way to enable this tool, if
@@ -165,7 +164,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
         self._enabled = True
         if event and event.window:
             event.window.set_pointer(self.pointer)
-        return
 
     def disable(self, event=None):
         """ Provides a programmatic way to enable this tool, if **always_on**
@@ -180,7 +178,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
             self.component.active_tool = None
         if event and event.window:
             event.window.set_pointer("arrow")
-        return
 
     def reset(self, event=None):
         """ Resets the tool to normal state, with no start or end position.
@@ -205,7 +202,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
                 self.overlay_range(component, gc)
             else:
                 self.overlay_box(component, gc)
-        return
 
     def overlay_box(self, component, gc):
         """ Draws the overlay as a box.
@@ -234,7 +230,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
                 else:
                     gc.rect(*rect)
                     gc.stroke_path()
-        return
 
     def overlay_range(self, component, gc):
         """ Draws the overlay as a range.
@@ -256,8 +251,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
             gc.rect(lower_left[0], lower_left[1], upper_right[0], upper_right[1])
             gc.draw_path()
 
-        return
-
     def normal_left_down(self, event):
         """ Handles the left mouse button being pressed while the tool is
         in the 'normal' state.
@@ -267,8 +260,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
         if self._is_enabling_event(event):
             self._start_select(event)
             event.handled = True
-
-        return
 
     def normal_right_down(self, event):
         """ Handles the right mouse button being pressed while the tool is
@@ -280,8 +271,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
             self._start_select(event)
             event.handled = True
 
-        return
-
     def selecting_mouse_move(self, event):
         """ Handles the mouse moving when the tool is in the 'selecting' state.
 
@@ -290,7 +279,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
         self._screen_end = (event.x, event.y)
         self.component.request_redraw()
         event.handled = True
-        return
 
     def selecting_left_up(self, event):
         """ Handles the left mouse button being released when the tool is in
@@ -300,7 +288,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
         """
         if self.drag_button == "left":
             self._end_select(event)
-        return
 
     def selecting_right_up(self, event):
         """ Handles the right mouse button being released when the tool is in
@@ -310,7 +297,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
         """
         if self.drag_button == "right":
             self._end_select(event)
-        return
 
     def selecting_mouse_leave(self, event):
         """ Handles the mouse leaving the plot when the tool is in the
@@ -319,7 +305,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
         Ends the selection operation without zooming.
         """
         self._end_selecting(event)
-        return
 
     def selecting_key_pressed(self, event):
         """ Handles a key being pressed when the tool is in the 'selecting'
@@ -331,7 +316,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
         if self.cancel_zoom_key.match(event):
             self._end_selecting(event)
             event.handled = True
-        return
 
     def _start_select(self, event):
         """ Starts selecting the zoom region
@@ -346,7 +330,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
         event.window.set_pointer(self.pointer)
         event.window.set_mouse_owner(self, event.net_transform())
         self.selecting_mouse_move(event)
-        return
 
     def _end_select(self, event):
         """ Ends selection of the zoom region, adds the new zoom range to
@@ -378,7 +361,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
         self._do_zoom()
         self._end_selecting(event)
         event.handled = True
-        return
 
     def _end_selecting(self, event=None):
         """ Ends selection of zoom region, without zooming.
@@ -390,7 +372,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
         self.component.request_redraw()
         if event and event.window.mouse_owner == self:
             event.window.set_mouse_owner(None)
-        return
 
     def _do_zoom(self):
         """ Does the zoom operation.
@@ -448,7 +429,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
                 x_range.high, y_range.high = high
 
         self.component.request_redraw()
-        return
 
     def normal_key_pressed(self, event):
         """ Handles a key being pressed when the tool is in 'normal' state.
@@ -475,7 +455,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
 
         if event.handled:
             self.component.request_redraw()
-        return
 
     def normal_mouse_wheel(self, event):
         """ Handles the mouse wheel being used when the tool is in the 'normal'
@@ -549,7 +528,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
 
             event.handled = True
             c.request_redraw()
-        return
 
     def _is_enabling_event(self, event):
         always_on = self.always_on
@@ -571,7 +549,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
     def _component_changed(self):
         if self.traits_inited() and self._get_mapper() is not None:
             self._reset_state_to_current()
-        return
 
     def _tool_mode_changed(self, old, new):
         if not self.traits_inited():
@@ -634,7 +611,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
 
         # Now reset the state to the current bounds settings.
         self._reset_state_to_current()
-        return
 
     def _prev_state_pressed(self):
         """ Called when the tool needs to advance to the previous state in the
@@ -644,7 +620,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
         to the prev state. Implements ToolHistoryMixin.
         """
         self._do_zoom()
-        return
 
     def _next_state_pressed(self):
         """ Called when the tool needs to advance to the next state in the stack.
@@ -653,7 +628,6 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
         to the next state. Implements ToolHistoryMixin.
         """
         self._do_zoom()
-        return
 
     ### Persistence ###########################################################
 

--- a/chaco/tools/tool_history_mixin.py
+++ b/chaco/tools/tool_history_mixin.py
@@ -73,7 +73,6 @@ class ToolHistoryMixin(HasTraits):
         """
         self._history = [state]
         self._history_index = 0
-        return
 
     def _append_state(self, state, set_index=True):
         """ Clears the history after the current **_history_index**, and
@@ -87,7 +86,6 @@ class ToolHistoryMixin(HasTraits):
         self._history = new_history
         if set_index:
             self._history_index = len(self._history) - 1
-        return
 
     def _pop_state(self):
         """ Pops the most last state off the history stack.
@@ -115,7 +113,6 @@ class ToolHistoryMixin(HasTraits):
         one of the history keys defined for this class.
         """
         self._history_handle_key(event)
-        return
 
     def _history_handle_key(self, event):
         if self.reset_state_key is not None and self.reset_state_key.match(event):

--- a/chaco/tools/toolbars/plot_toolbar.py
+++ b/chaco/tools/toolbars/plot_toolbar.py
@@ -102,7 +102,6 @@ class PlotToolbar(Container, AbstractOverlay):
         self.add(button)
         button.toolbar_overlay = self
         self._layout_needed = True
-        return
 
     def normal_mouse_move(self, event):
         """ handler for normal mouse move
@@ -253,8 +252,6 @@ class PlotToolbar(Container, AbstractOverlay):
         else:
             if self.auto_hide:
                 self.hiding = True
-
-        return
 
     ############################################################
     # Trait handlers

--- a/chaco/tools/toolbars/toolbar_buttons.py
+++ b/chaco/tools/toolbars/toolbar_buttons.py
@@ -77,7 +77,6 @@ class IndexAxisLogButton(ToolbarButton):
         else:
             self.container.component.index_scale = 'linear'
         self.container.request_redraw()
-        return
 
 
 class ValueAxisLogButton(ToolbarButton):
@@ -91,7 +90,6 @@ class ValueAxisLogButton(ToolbarButton):
         else:
             self.container.component.value_scale = 'linear'
         self.container.request_redraw()
-        return
 
 
 class ZoomResetButton(ToolbarButton):

--- a/chaco/tools/tracking_pan_tool.py
+++ b/chaco/tools/tracking_pan_tool.py
@@ -49,4 +49,3 @@ class TrackingPanTool(PanTool):
 
 
         event.handled = True
-        return

--- a/chaco/tools/tracking_zoom.py
+++ b/chaco/tools/tracking_zoom.py
@@ -75,4 +75,3 @@ class TrackingZoom(ZoomTool):
                 datarange.set_bounds(newlow, newhigh)
             event.handled = True
             self.component.request_redraw()
-        return

--- a/chaco/tools/traits_tool.py
+++ b/chaco/tools/traits_tool.py
@@ -118,5 +118,3 @@ class TraitsTool(BaseTool):
             event.handled = True
             self.component.active_tool = None
             item.request_redraw()
-
-        return

--- a/chaco/tooltip.py
+++ b/chaco/tooltip.py
@@ -72,7 +72,6 @@ class ToolTip(AbstractOverlay):
         Overrides PlotComponent.
         """
         self.overlay(self, gc, view_bounds=view_bounds, mode='normal')
-        return
 
     def overlay(self, component, gc, view_bounds=None, mode='normal'):
         """ Draws the tooltip overlaid on another component.
@@ -81,7 +80,6 @@ class ToolTip(AbstractOverlay):
         """
         self.do_layout()
         PlotComponent._draw(self, gc, view_bounds, mode)
-        return
 
     def _draw_overlay(self, gc, view_bounds=None, mode='normal'):
         """ Draws the overlay layer of a component.
@@ -99,8 +97,6 @@ class ToolTip(AbstractOverlay):
                 label.draw(gc)
                 gc.translate_ctm(0,-y)
                 y -= self.line_spacing
-        return
-
 
     def _do_layout(self):
         """Computes the size of the tooltip, and creates the label objects
@@ -154,7 +150,6 @@ class ToolTip(AbstractOverlay):
         self._total_line_height = sum(line_sizes[:,1]) + \
                                   len(line_sizes-1)*self.line_spacing
         self._layout_needed = True
-        return
 
     def __font_metrics_provider_default(self):
         return font_metrics_provider()

--- a/chaco/ui/popupable_plot.py
+++ b/chaco/ui/popupable_plot.py
@@ -31,6 +31,3 @@ class PopupablePlot(Plot):
         """Queue up the plot commands"""
         self.command_queue.append((data, kw))
         super(PopupablePlot, self).plot(data, **kw)
-        return
-
-


### PR DESCRIPTION
This PR removes unnecessary `return` statements from the `chaco` package.