### PR TITLE
Replace use of depends_on in Traits Properties with observe

### DIFF
--- a/chaco/barplot.py
+++ b/chaco/barplot.py
@@ -97,12 +97,12 @@ class BarPlot(AbstractPlotRenderer):
     #: The RGBA tuple for rendering lines. It is always a tuple of length 4.
     #: It has the same RGB values as :attr:`line_color`, and its alpha value
     #: is the alpha value of self.line_color multiplied by self.alpha.
-    effective_line_color = Property(Tuple, depends_on=["line_color", "alpha"])
+    effective_line_color = Property(Tuple, observe=["line_color", "alpha"])
 
     #: The RGBA tuple for rendering the fill. It is always a tuple of length
     #: 4. It has the same RGB values as :attr:`fill_color`, and its alpha
     #: value is the alpha value of self.fill_color multiplied by self.alpha.
-    effective_fill_color = Property(Tuple, depends_on=["fill_color", "alpha"])
+    effective_fill_color = Property(Tuple, observe=["fill_color", "alpha"])
 
     #: Overall alpha value of the image. Ranges from 0.0 for transparent to 1.0
     alpha = Range(0.0, 1.0, 1.0, requires_redraw=True)

--- a/chaco/base_1d_plot.py
+++ b/chaco/base_1d_plot.py
@@ -37,7 +37,7 @@ class Base1DPlot(AbstractPlotRenderer):
     index_mapper = Instance(AbstractMapper)
 
     #: Convenience property for accessing the data range of the mapper.
-    index_range = Property(observe="index_mapper.range")
+    index_range = Property(depends_on="index_mapper.range")
 
     #: Corresponds to either **index_mapper** or None, depending on
     #: the orientation of the plot.

--- a/chaco/base_1d_plot.py
+++ b/chaco/base_1d_plot.py
@@ -37,15 +37,15 @@ class Base1DPlot(AbstractPlotRenderer):
     index_mapper = Instance(AbstractMapper)
 
     #: Convenience property for accessing the data range of the mapper.
-    index_range = Property(depends_on="index_mapper.range")
+    index_range = Property(observe="index_mapper.range")
 
     #: Corresponds to either **index_mapper** or None, depending on
     #: the orientation of the plot.
-    x_mapper = Property(depends_on=["orientation", "index_mapper"])
+    x_mapper = Property(observe=["orientation", "index_mapper"])
 
     #: Corresponds to either **index_mapper** or None, depending on
     #: the orientation of the plot.
-    y_mapper = Property(depends_on=["orientation", "index_mapper"])
+    y_mapper = Property(observe=["orientation", "index_mapper"])
 
     #: The orientation of the index axis.
     orientation = Enum("v", "h")
@@ -56,7 +56,7 @@ class Base1DPlot(AbstractPlotRenderer):
     #: Faux origin for the axes and other objects to look at
     origin = Property(
         Enum("bottom left", "top left", "bottom right", "top right"),
-        depends_on=["orientation", "direction"],
+        observe=["orientation", "direction"],
     )
 
     # ------------------------------------------------------------------------

--- a/chaco/color_bar.py
+++ b/chaco/color_bar.py
@@ -35,7 +35,7 @@ class ColorBar(AbstractPlotRenderer):
     color_mapper = Property  # Instance(ColorMapper)
 
     #: Screen mapper for value data (synonym for color_mapper)
-    value_mapper = Property(depends_on="color_mapper")
+    value_mapper = Property(observe="color_mapper")
 
     #: Optional index data source for generic tools to attach metadata to.
     index = Property

--- a/chaco/data_label.py
+++ b/chaco/data_label.py
@@ -185,10 +185,10 @@ class DataLabel(ToolTip):
     clip_to_plot = Bool(True)
 
     #: The center x position (average of x and x2)
-    xmid = Property(Float, depends_on=['x', 'x2'])
+    xmid = Property(Float, observe=['x', 'x2'])
 
     #: The center y position (average of y and y2)
-    ymid = Property(Float, depends_on=['y', 'y2'])
+    ymid = Property(Float, observe=['y', 'y2'])
 
     #: 'box' is a simple rectangular box, with an arrow that is a single line
     #: with an arrowhead at the data point.

--- a/chaco/data_view.py
+++ b/chaco/data_view.py
@@ -111,7 +111,7 @@ class DataView(OverlayPlotContainer):
     )
 
     #: The origin reported to axes, etc
-    origin = Property(depends_on="default_origin")
+    origin = Property(observe="default_origin")
 
     # Whether our map_screen and map_data should treat screen-space
     # coords as being in our coordinate space or in our contained

--- a/chaco/image_plot.py
+++ b/chaco/image_plot.py
@@ -66,10 +66,10 @@ class ImagePlot(Base2DPlot):
     interpolation = Enum("nearest", "bilinear", "bicubic")
 
     #: Bool indicating whether x-axis is flipped.
-    x_axis_is_flipped = Property(depends_on=["orientation", "origin"])
+    x_axis_is_flipped = Property(observe=["orientation", "origin"])
 
     #: Bool indicating whether y-axis is flipped.
-    y_axis_is_flipped = Property(depends_on=["orientation", "origin"])
+    y_axis_is_flipped = Property(observe=["orientation", "origin"])
 
     # ------------------------------------------------------------------------
     # Private traits
@@ -87,7 +87,7 @@ class ImagePlot(Base2DPlot):
 
     # Bool indicating whether the origin is top-left or bottom-right.
     # The name "principal diagonal" is borrowed from linear algebra.
-    _origin_on_principal_diagonal = Property(depends_on="origin")
+    _origin_on_principal_diagonal = Property(observe="origin")
 
     # ------------------------------------------------------------------------
     # Properties

--- a/chaco/layers/svg_range_selection_overlay.py
+++ b/chaco/layers/svg_range_selection_overlay.py
@@ -27,15 +27,15 @@ class SvgRangeSelectionOverlay(StatusLayer):
     # The axis to which this tool is perpendicular.
     axis = Enum("index", "value")
 
-    axis_index = Property(depends_on="axis")
+    axis_index = Property(observe="axis")
 
     # Mapping from screen space to data space. By default, it is just
     # self.component.
-    plot = Property(depends_on="component")
+    plot = Property(observe="component")
 
     # The mapper (and associated range) that drive this RangeSelectionOverlay.
     # By default, this is the mapper on self.plot that corresponds to self.axis.
-    mapper = Property(depends_on="plot")
+    mapper = Property(observe="plot")
 
     # The name of the metadata to look at for dataspace bounds. The metadata
     # can be either a tuple (dataspace_start, dataspace_end) in "selections" or

--- a/chaco/lineplot.py
+++ b/chaco/lineplot.py
@@ -47,7 +47,7 @@ class LinePlot(BaseXYPlot):
     #: The RGBA tuple for rendering lines. It is always a tuple of length 4.
     #: It has the same RGB values as :attr:`color`, and its alpha value is the
     #: alpha value of self.color multiplied by self.alpha.
-    effective_color = Property(Tuple, depends_on=["color", "alpha"])
+    effective_color = Property(Tuple, observe=["color", "alpha"])
 
     #: The color to use to highlight the line when selected.
     selected_color = ColorTrait("lightyellow")

--- a/chaco/multi_line_plot.py
+++ b/chaco/multi_line_plot.py
@@ -140,7 +140,7 @@ class MultiLinePlot(BaseXYPlot):
 
     amplitude_scale = Property(
         Float,
-        depends_on=[
+        observe=[
             "global_min",
             "global_max",
             "data",
@@ -150,7 +150,7 @@ class MultiLinePlot(BaseXYPlot):
     )
 
     amplitude = Property(
-        Float, depends_on=["normalized_amplitude", "amplitude_scale"]
+        Float, observe=["normalized_amplitude", "amplitude_scale"]
     )
 
     # ------------------------------------------------------------------------
@@ -160,7 +160,7 @@ class MultiLinePlot(BaseXYPlot):
     # The projected 2D numpy array.
     _trace_data = Property(
         Array,
-        depends_on=[
+        observe=[
             "index",
             "index.data_changed",
             "value",

--- a/chaco/polygon_plot.py
+++ b/chaco/polygon_plot.py
@@ -53,12 +53,12 @@ class PolygonPlot(BaseXYPlot):
     #: The RGBA tuple for rendering edges. It is always a tuple of length 4.
     #: It has the same RGB values as :attr:`edge_color`, and its alpha value
     #: is the alpha value of self.edge_color multiplied by self.alpha.
-    effective_edge_color = Property(Tuple, depends_on=["edge_color", "alpha"])
+    effective_edge_color = Property(Tuple, observe=["edge_color", "alpha"])
 
     #: The RGBA tuple for rendering the face. It is always a tuple of length
     #: 4. It has the same RGB values as :attr:`face_color`, and its alpha
     #: value is the alpha value of self.face_color multiplied by self.alpha.
-    effective_face_color = Property(Tuple, depends_on=["face_color", "alpha"])
+    effective_face_color = Property(Tuple, observe=["face_color", "alpha"])
 
     # ----------------------------------------------------------------------
     # Private 'BaseXYPlot' interface

--- a/chaco/scatterplot.py
+++ b/chaco/scatterplot.py
@@ -235,13 +235,13 @@ class ScatterPlot(BaseXYPlot):
     # The RGBA tuple for rendering lines.  It is always a tuple of length 4.
     # It has the same RGB values as color_, and its alpha value is the alpha
     # value of self.color multiplied by self.alpha.
-    effective_color = Property(Tuple, depends_on=["color", "alpha"])
+    effective_color = Property(Tuple, observe=["color", "alpha"])
 
     # The RGBA tuple for rendering the fill.  It is always a tuple of length 4.
     # It has the same RGB values as outline_color_, and its alpha value is the
     # alpha value of self.outline_color multiplied by self.alpha.
     effective_outline_color = Property(
-        Tuple, depends_on=["outline_color", "alpha"]
+        Tuple, observe=["outline_color", "alpha"]
     )
 
     # Traits UI View for customizing the plot.

--- a/chaco/segment_plot.py
+++ b/chaco/segment_plot.py
@@ -101,7 +101,7 @@ class SegmentPlot(BaseXYPlot):
             "color_mapper.updated",
             "color_data.data_changed",
             "alpha",
-            "selection_mask",
+            "selected_mask",
             "selection_color",
             "selection_alpha",
         ],

--- a/chaco/segment_plot.py
+++ b/chaco/segment_plot.py
@@ -95,7 +95,7 @@ class SegmentPlot(BaseXYPlot):
     #: with the global 'alpha' mixed in.
     effective_colors = Property(
         Array,
-        depends_on=[
+        observe=[
             "color_by_data",
             "alpha",
             "color_mapper.updated",
@@ -110,11 +110,11 @@ class SegmentPlot(BaseXYPlot):
     #: The widths of the individual lines in screen units, if mapped to data.
     #: The values are computed with the width mapper.
     screen_widths = Property(
-        Array, depends_on=["width_mapper.updated", "width_data.data_changed"]
+        Array, observe=["width_mapper.updated", "width_data.data_changed"]
     )
 
     selected_mask = Property(
-        depends_on=["selection_metadata_name", "index.metadata_changed"]
+        observe=["selection_metadata_name", "index.metadata_changed"]
     )
 
     # These BaseXYPlot methods either don't make sense or aren't currently

--- a/chaco/tools/better_selecting_zoom.py
+++ b/chaco/tools/better_selecting_zoom.py
@@ -44,7 +44,7 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
     # -------------------------------------------------------------------------
 
     #: Conversion ratio from wheel steps to zoom factors.
-    wheel_zoom_step = Property(Float, depends_on="zoom_factor")
+    wheel_zoom_step = Property(Float, observe="zoom_factor")
 
     #: The key press to enter zoom mode, if **always_on** is False.  Has no effect
     #: if **always_on** is True.

--- a/chaco/tools/cursor_tool.py
+++ b/chaco/tools/cursor_tool.py
@@ -74,7 +74,7 @@ class BaseCursorTool(LineInspector, DragTool):
     current_index = Disallow
 
     # The current position of the cursor in data units
-    current_position = Property(depends_on=["current_index"])
+    current_position = Property(observe=["current_index"])
 
     # Stuff from line_inspector which is not required
     axis = Disallow

--- a/chaco/tools/range_selection_overlay.py
+++ b/chaco/tools/range_selection_overlay.py
@@ -26,7 +26,7 @@ class RangeSelectionOverlay(AbstractOverlay):
 
     #: Mapping from screen space to data space. By default, it is just
     #: self.component.
-    plot = Property(depends_on="component")
+    plot = Property(observe="component")
 
     #: The mapper (and associated range) that drive this RangeSelectionOverlay.
     #: By default, this is the mapper on self.plot that corresponds to self.axis.

--- a/chaco/tools/toolbars/toolbar_buttons.py
+++ b/chaco/tools/toolbars/toolbar_buttons.py
@@ -24,11 +24,11 @@ class ToolbarButton(Button):
 
     color = "black"
 
-    width = Property(Int, depends_on="label, image")
-    height = Property(Int, depends_on="label, image")
+    width = Property(Int, observe="label, image")
+    height = Property(Int, observe="label, image")
 
     # bounds are used for hit testing
-    bounds = Property(List, depends_on="label, image")
+    bounds = Property(List, observe="label, image")
 
     def __init__(self, *args, **kw):
         super(ToolbarButton, self).__init__(*args, **kw)

--- a/examples/demo/nonlinear_color_mapping.py
+++ b/examples/demo/nonlinear_color_mapping.py
@@ -59,16 +59,16 @@ class DataGrid(HasTraits):
     # ------------------------------------------------------
 
     # 1D array of x coordinates.
-    x_array = Property(Array, depends_on=["domain_bounds, grid_size"])
+    x_array = Property(Array, observe=["domain_bounds, grid_size"])
 
     # 1D array of y coordinates.
-    y_array = Property(Array, depends_on=["domain_bounds, grid_size"])
+    y_array = Property(Array, observe=["domain_bounds, grid_size"])
 
     # 2D array of function values, z = f(x,y)
-    data = Property(Array, depends_on=["func, x_array, y_array"])
+    data = Property(Array, observe=["func, x_array, y_array"])
 
-    data_min = Property(Float, depends_on=["data"])
-    data_max = Property(Float, depends_on=["data"])
+    data_min = Property(Float, observe=["data"])
+    data_max = Property(Float, observe=["data"])
 
     # ------------------------------------------------------
     # Trait handlers
@@ -186,9 +186,9 @@ class DataGridView(HasTraits):
 
     plot = Instance(Component)
 
-    img_renderer = Property(Instance(CMapImagePlot), depends_on=["plot"])
+    img_renderer = Property(Instance(CMapImagePlot), observe=["plot"])
 
-    colorbar = Property(Instance(ColorBar), depends_on=["plot"])
+    colorbar = Property(Instance(ColorBar), observe=["plot"])
 
     traits_view = View(
         HGroup(


### PR DESCRIPTION
This PR replaces _almost_ all uses of `depends_on` with observe, aside from this:
https://github.com/enthought/chaco/blob/99109d95850864b74ab636f385741b595b671c7c/chaco/base_1d_plot.py#L40

changing this line resulted in he following errors:
<details>

```
======================================================================
FAIL: test_linescatter_1d_set_index_mapper_notifies_index_range (chaco.tests.test_line_scatterplot.LineScatterPlot1DTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/aayres/Desktop/chaco/chaco/tests/test_line_scatterplot.py", line 185, in test_linescatter_1d_set_index_mapper_notifies_index_range
    self.linescatterplot.index_mapper = LinearMapper(range=new_range)
  File "/Users/aayres/Desktop/traits/traits/testing/unittest_tools.py", line 118, in __exit__
    raise self.failureException(msg.format(*items))
AssertionError: Change event for index_range was fired 2 times instead of 1

======================================================================
FAIL: test_scatter_1d_set_index_mapper_notifies_index_range (chaco.tests.test_scatterplot_1d.Scatterplot1DTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/aayres/Desktop/chaco/chaco/tests/test_scatterplot_1d.py", line 181, in test_scatter_1d_set_index_mapper_notifies_index_range
    self.scatterplot.index_mapper = LinearMapper(range=new_range)
  File "/Users/aayres/Desktop/traits/traits/testing/unittest_tools.py", line 118, in __exit__
    raise self.failureException(msg.format(*items))
AssertionError: Change event for index_range was fired 2 times instead of 1

======================================================================
FAIL: test_text_1d_set_index_mapper_notifies_index_range (chaco.tests.test_text_plot_1d.TextPlot1DTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/aayres/Desktop/chaco/chaco/tests/test_text_plot_1d.py", line 133, in test_text_1d_set_index_mapper_notifies_index_range
    self.textplot.index_mapper = LinearMapper(range=new_range)
  File "/Users/aayres/Desktop/traits/traits/testing/unittest_tools.py", line 118, in __exit__
    raise self.failureException(msg.format(*items))
AssertionError: Change event for index_range was fired 2 times instead of 1

----------------------------------------------------------------------
```

</details>

Note that the trait is changed twice with observe.  `assertTraitChanges` conveniently provides the events that were triggered.  Printing these for one of the tests, we see:
```
[
(<chaco.line_scatterplot_1d.LineScatterPlot1D object at 0x7fcfc7e7c258>, 'index_range', <undefined>, <chaco.data_range_1d.DataRange1D object at 0x7fcfc7e7c308>),
(<chaco.line_scatterplot_1d.LineScatterPlot1D object at 0x7fcfc7e7c258>, 'index_range', <undefined>, <chaco.data_range_1d.DataRange1D object at 0x7fcfc7e7c308>)
]
```
ie the exact same event is occurring twice.

I spent a bit of time trying to understand this, but still am not sure where the problem is coming from.
For now, I figure we can go ahead with the rest of the changes and save this for another day.


Additionally, this PR also changes a property to observe `selected_mask` not `selection_mask` as no `selection_mask` is defined on the class but `selected_mask` is (I assume this was the original intention, +1 for observe catching a potential silent bug).
