### PR TITLE
Dont use traitsui.api as tui

### DIFF
--- a/chaco/plugin/plot_editor.py
+++ b/chaco/plugin/plot_editor.py
@@ -2,7 +2,7 @@ from chaco.shell.scaly_plot import ScalyPlot
 from enable.component_editor import ComponentEditor
 from pyface.workbench.api import TraitsUIEditor
 from traits.api import Any, Enum, HasTraits, Property, Str
-from traitsui import api as tui
+from traitsui.api import Item, View
 
 
 class PlotUI(HasTraits):
@@ -11,8 +11,8 @@ class PlotUI(HasTraits):
     # The plot.
     component = Any()
 
-    traits_view = tui.View(
-        tui.Item("component", editor=ComponentEditor(), show_label=False),
+    traits_view = View(
+        Item("component", editor=ComponentEditor(), show_label=False),
         resizable=True,
     )
 


### PR DESCRIPTION
fixes #611 

This PR simply imports the needed objects from `traitsui.api` rather than importing the whole thing as tui.

As a side note, this module is based around Workbench which has been deprecated in favor of tasks.  Perhaps we want to rewrite this module? Or deprecate, or remove it... 🤔 