### PR TITLE
Import version from installed package if the file doesnt exist

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,10 +58,10 @@ if os.path.isfile(version_file):
     version = release = runpy.run_path(version_file)['full_version']
 else:
     try:
-        from enable._version import full_version as version
+        from chaco._version import full_version as version
         release = version
     except ImportError:
-        raise RuntimeError("Enable must be installed before building docs!")
+        raise RuntimeError("Chaco must be installed before building docs!")
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,8 +13,8 @@
 # All configuration values have a default value; values that are commented out
 # serve to show the default value.
 
-import sys
 import os
+import runpy
 
 # The docset build will use slightly different formatting rules
 
@@ -52,11 +52,16 @@ copyright = '2008-2019, Enthought, Inc.'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
-d = {}
-chaco_version_file = os.path.join('..', '..', 'chaco', '_version.py')
-exec(compile(open(chaco_version_file).read(), chaco_version_file, 'exec'), d)
-release = d['version']
-version = '.'.join(release.split('.',2)[:2])
+base_path = os.path.abspath(os.path.dirname(__file__))
+version_file = os.path.join(base_path, '..', '..', 'chaco', '_version.py')
+if os.path.isfile(version_file):
+    version = release = runpy.run_path(version_file)['full_version']
+else:
+    try:
+        from enable._version import full_version as version
+        release = version
+    except ImportError:
+        raise RuntimeError("Enable must be installed before building docs!")
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
If the package is installed in a non-editable way, the `_version` file won't exist where we expect it to. This PR updates the sphinx configuration to get the version information from the package directly if the file doesn't exist.