### PR TITLE
Dont hook up listeners in ChacoPlotEditor if the trait is None

### DIFF
--- a/chaco/chaco_plot_editor.py
+++ b/chaco/chaco_plot_editor.py
@@ -14,7 +14,7 @@ from enable.api import (
 )
 from enable.trait_defs.ui.api import RGBAColorEditor
 from kiva.trait_defs.kiva_font_trait import KivaFont
-from traits.api import Enum, Str, Range, Tuple, Bool, Trait, Int, Any, Property
+from traits.api import Enum, Str, Range, Trait, Tuple, Bool, Int, Any, Property
 from traitsui.api import Item
 from traitsui.editor_factory import EditorFactory
 
@@ -261,7 +261,8 @@ class ChacoPlotEditor(Editor):
             for name in (plotitem.index, plotitem.value):
                 object.observe(self._update_data, name)
         for name in (plotitem.x_label_trait, plotitem.y_label_trait):
-            object.observe(lambda s: self._update_axis_grids(), name)
+            if name and getattr(object, name, None):
+                object.observe(lambda s: self._update_axis_grids(), name)
         if plotitem.type_trait not in ("", None):
             object.observe(self.update_editor, plotitem.type_trait)
 


### PR DESCRIPTION
This PR updates the `ChacoPlotEditor` to not hook up the listeners if the trait is `None` or if the trait doesnt exist on the plot object. This was discovered when running the examples https://github.com/enthought/chaco/blob/fdd858aa6dbc76addb50d011fb81e879ce8e0355/examples/demo/basic/traits_editor.py and https://github.com/enthought/chaco/blob/fdd858aa6dbc76addb50d011fb81e879ce8e0355/examples/demo/advanced/data_stream.py