### PR TITLE
Use #: instead of # when needed

### DIFF
--- a/chaco/abstract_colormap.py
+++ b/chaco/abstract_colormap.py
@@ -10,14 +10,14 @@ class AbstractColormap(HasTraits):
     Abstract class for color maps, which map from scalar values to color values.
     """
 
-    # The data-space bounds of the mapper.
+    #: The data-space bounds of the mapper.
     range = Instance(DataRange1D)
 
-    # The color depth of the colors to use.
+    #: The color depth of the colors to use.
     color_depth = Enum("rgba", "rgb")
 
-    # A generic "update" event that generally means that anything that relies
-    # on this mapper for visual output should do a redraw or repaint.
+    #: A generic "update" event that generally means that anything that relies
+    #: on this mapper for visual output should do a redraw or repaint.
     updated = Event
 
     def map_screen(self, val):

--- a/chaco/base.py
+++ b/chaco/base.py
@@ -37,24 +37,24 @@ point_dtype = dtype([("x", float), ("y", float)])
 
 # Dimensions
 
-# A single array of numbers.
+#: A single array of numbers.
 NumericalSequenceTrait = ArrayOrNone()
 
-# A sequence of pairs of numbers, i.e., an Nx2 array.
+#: A sequence of pairs of numbers, i.e., an Nx2 array.
 PointTrait = ArrayOrNone(shape=(None, 2))
 
-# An NxM array of numbers or NxMxRGB(A) array of colors.
+#: An NxM array of numbers or NxMxRGB(A) array of colors.
 ImageTrait = ArrayOrNone()
 
-# An 3D array of numbers of shape (Nx, Ny, Nz)
+#: An 3D array of numbers of shape (Nx, Ny, Nz)
 CubeTrait = ArrayOrNone(shape=(None, None, None))
 
 
-# This enumeration lists the fundamental mathematical coordinate types that
-# Chaco supports.
+#: This enumeration lists the fundamental mathematical coordinate types that
+#: Chaco supports.
 DimensionTrait = Enum("scalar", "point", "image", "cube")
 
-# Linear sort order.
+#: Linear sort order.
 SortOrderTrait = Enum("ascending", "descending", "none")
 
 

--- a/chaco/base_candle_plot.py
+++ b/chaco/base_candle_plot.py
@@ -32,40 +32,40 @@ class BaseCandlePlot(BaseXYPlot):
     # Appearance traits
     # ------------------------------------------------------------------------
 
-    # The fill color of the marker.
+    #: The fill color of the marker.
     color = ColorTrait("black")
 
-    # The fill color of the bar
+    #: The fill color of the bar
     bar_color = Alias("color")
 
-    # The color of the rectangular box forming the bar.
+    #: The color of the rectangular box forming the bar.
     bar_line_color = Alias("outline_color")
 
-    # The color of the stems reaching from the bar ends to the min and max
-    # values.  Also the color of the endcap line segments at min and max.  If
-    # None, this defaults to **bar_line_color**.
+    #: The color of the stems reaching from the bar ends to the min and max
+    #: values.  Also the color of the endcap line segments at min and max.  If
+    #: None, this defaults to **bar_line_color**.
     stem_color = Trait(None, None, ColorTrait("black"))
 
-    # The color of the line drawn across the bar at the center values.
-    # If None, this defaults to **bar_line_color**.
+    #: The color of the line drawn across the bar at the center values.
+    #: If None, this defaults to **bar_line_color**.
     center_color = Trait(None, None, ColorTrait("black"))
 
-    # The color of the outline to draw around the bar.
+    #: The color of the outline to draw around the bar.
     outline_color = ColorTrait("black")
 
-    # The thickness, in pixels, of the outline to draw around the bar.  If
-    # this is 0, no outline is drawn.
+    #: The thickness, in pixels, of the outline to draw around the bar.  If
+    #: this is 0, no outline is drawn.
     line_width = Float(1.0)
 
-    # The thickness, in pixels, of the stem lines.  If None, this defaults
-    # to **line_width**.
+    #: The thickness, in pixels, of the stem lines.  If None, this defaults
+    #: to **line_width**.
     stem_width = Trait(None, None, Int(1))
 
-    # The thickeness, in pixels, of the line drawn across the bar at the
-    # center values.  If None, this defaults to **line_width**.
+    #: The thickeness, in pixels, of the line drawn across the bar at the
+    #: center values.  If None, this defaults to **line_width**.
     center_width = Trait(None, None, Int(1))
 
-    # Whether or not to draw bars at the min and max extents of the error bar
+    #: Whether or not to draw bars at the min and max extents of the error bar
     end_cap = Bool(True)
 
     # ------------------------------------------------------------------------

--- a/chaco/base_contour_plot.py
+++ b/chaco/base_contour_plot.py
@@ -28,25 +28,25 @@ class BaseContourPlot(Base2DPlot):
     # Data-related traits
     # ------------------------------------------------------------------------
 
-    # Defines the levels to contour.
-    # ``levels`` can be either: a list of floating point numbers that define
-    # the value of the function at the contours; a positive integer, in which
-    # case the range of the value is divided in the given number of equally
-    # spaced levels; or "auto" (default), which divides the range in 10 levels
+    #: Defines the levels to contour.
+    #: ``levels`` can be either: a list of floating point numbers that define
+    #: the value of the function at the contours; a positive integer, in which
+    #: case the range of the value is divided in the given number of equally
+    #: spaced levels; or "auto" (default), which divides the range in 10 levels
     levels = Trait("auto", Int, List)
 
-    # The color(s) of the lines.
-    # ``colors`` can be given as a color name, in which case all contours have
-    # the same color, as a list of colors, or as a colormap. If the list of
-    # colors is shorter than the number of levels, the values are repeated
-    # from the beginning of the list. Default is black.
-    # Colors are associated with levels of increasing value.
+    #: The color(s) of the lines.
+    #: ``colors`` can be given as a color name, in which case all contours have
+    #: the same color, as a list of colors, or as a colormap. If the list of
+    #: colors is shorter than the number of levels, the values are repeated
+    #: from the beginning of the list. Default is black.
+    #: Colors are associated with levels of increasing value.
     colors = Trait(None, Str, Instance(ColorMapper), List, Tuple)
 
-    # If present, the color mapper for the colorbar to look at.
+    #: If present, the color mapper for the colorbar to look at.
     color_mapper = Property(Instance(ColorMapper))
 
-    # A global alpha value to apply to all the contours
+    #: A global alpha value to apply to all the contours
     alpha = Trait(1.0, Range(0.0, 1.0))
 
     # ------------------------------------------------------------------------

--- a/chaco/chaco_plot_editor.py
+++ b/chaco/chaco_plot_editor.py
@@ -40,19 +40,19 @@ from .tools.api import PanTool, ZoomTool
 #  Trait definitions:
 # -------------------------------------------------------------------------------
 
-# Range of values for an axis.
+#: Range of values for an axis.
 AxisRange = Tuple((0.0, 1.0, 0.01), labels=["Low", "High", "Step"], cols=3)
 
-# Range of axis bounds.
+#: Range of axis bounds.
 AxisBounds = Tuple((0.0, 1.0), labels=["Min", "Max"], cols=2)
 
-# Range for the height and width for the plot widget.
+#: Range for the height and width for the plot widget.
 PlotSize = Range(50, 1000, 180)
 
-# Range of plot line weights.
+#: Range of plot line weights.
 LineWeight = Range(1, 9, 3)
 
-# The color editor to use for various color traits.
+#: The color editor to use for various color traits.
 color_editor = RGBAColorEditor()
 
 
@@ -65,80 +65,80 @@ class ChacoPlotItem(Item):
     NOTE: ComponentEditor is preferred over this class, as it is more flexible.
     """
 
-    # Name of the trait that references the index data source.
+    #: Name of the trait that references the index data source.
     index = Str
-    # Name of the trait that references the value data source.
+    #: Name of the trait that references the value data source.
     value = Str
-    # Title of the plot (overlaid on the plot container).
+    #: Title of the plot (overlaid on the plot container).
     title = Str("Plot Editor")
 
-    # Bounds of the x-axis, used if **x_auto** is False.
+    #: Bounds of the x-axis, used if **x_auto** is False.
     x_bounds = AxisBounds
-    # Set the x-axis bounds automatically?
+    #: Set the x-axis bounds automatically?
     x_auto = Bool(True)
-    # Bounds of the y-axis, used if **y_auto** is False.
+    #: Bounds of the y-axis, used if **y_auto** is False.
     y_bounds = AxisBounds
-    # Set the y-axis bounds automatically?
+    #: Set the y-axis bounds automatically?
     y_auto = Bool(True)
 
-    # The orientation of the index axis.
+    #: The orientation of the index axis.
     orientation = Enum("h", "v")
 
     # If these are None, then the index/value trait names are used
 
-    # Label of the x-axis; if None, the **index** name is used.
+    #: Label of the x-axis; if None, the **index** name is used.
     x_label = Trait(None, None, Str)
-    # Name of the trait on the object containing the label of the x-axis.
-    # This takes precedence over **x_label**.
+    #: Name of the trait on the object containing the label of the x-axis.
+    #: This takes precedence over **x_label**.
     x_label_trait = Trait(None, None, Str)
-    # Font for the label of the x-axis.
+    #: Font for the label of the x-axis.
     x_label_font = KivaFont("modern 10")
-    # Color of the label of the x-axis.
+    #: Color of the label of the x-axis.
     x_label_color = black_color_trait
-    # Label of the y-axis; if None, the **value** name is used.
+    #: Label of the y-axis; if None, the **value** name is used.
     y_label = Trait(None, None, Str)
-    # Name of the trait on the object containing the label of the y-axis.
-    # This takes precedence over **y_label**.
+    #: Name of the trait on the object containing the label of the y-axis.
+    #: This takes precedence over **y_label**.
     y_label_trait = Trait(None, None, Str)
-    # Font for the label of the y-axis.
+    #: Font for the label of the y-axis.
     y_label_font = KivaFont("modern 10")
-    # Color of the label of the y-axis.
+    #: Color of the label of the y-axis.
     y_label_color = black_color_trait
 
     # General plot properties
 
-    # Foreground olor of the plot.
+    #: Foreground olor of the plot.
     color = ColorTrait("blue")
-    # Background color of the plot.
+    #: Background color of the plot.
     bgcolor = white_color_trait
-    # Background color of the plot (deprecated).
+    #: Background color of the plot (deprecated).
     bg_color = Property  # backwards compatibility; deprecated
-    # Color of the background padding.
+    #: Color of the background padding.
     padding_bg_color = ColorTrait("sys_window")
 
     # Border properties
 
-    # Width of the plot border
+    #: Width of the plot border
     border_width = Int(1)
-    # Is the border visible?
+    #: Is the border visible?
     border_visible = Bool(False)
-    # Line style of the border.
+    #: Line style of the border.
     border_dash = LineStyle
-    # Color of the border.
+    #: Color of the border.
     border_color = black_color_trait
 
-    # The type of the plot.
+    #: The type of the plot.
     type = Enum("line", "scatter")
-    # The type of the plot as a string.
+    #: The type of the plot as a string.
     type_trait = Str
 
     # plot-specific properties.  These might not apply to all plot types.
 
-    # Type of marker (for plots that use markers).
+    #: Type of marker (for plots that use markers).
     marker = MarkerTrait
-    # Size of marker (for plots that use markers).
+    #: Size of marker (for plots that use markers).
     marker_size = Int(4)
-    # Marker outline color (for plots that user markers).
+    #: Marker outline color (for plots that user markers).
     outline_color = black_color_trait
 
     def __init__(self, index, value, type="line", **traits):

--- a/chaco/chaco_traits.py
+++ b/chaco/chaco_traits.py
@@ -11,8 +11,8 @@ from traits.api import Enum
 
 box_edge_enum = Enum("left", "right", "top", "bottom")
 
-# Values correspond to: top, bottom, left, right, top left, top right, bottom
-# left, bottom right
+#: Values correspond to: top, bottom, left, right, top left, top right, bottom
+#: left, bottom right
 box_position_enum = Enum("T", "B", "L", "R", "TL", "TR", "BL", "BR")
 
 # For backwards compatibility, import LineStyle & LineStyleEditor from enable.

--- a/chaco/data_frame_plot_data.py
+++ b/chaco/data_frame_plot_data.py
@@ -23,10 +23,10 @@ class DataFramePlotData(AbstractPlotData):
     # Public traits
     # -------------------------------------------------------------------------
 
-    # The DataFrame backing this object.
+    #: The DataFrame backing this object.
     data_frame = Instance("pandas.core.frame.DataFrame")
 
-    # Consumers can write data to this object (overrides AbstractPlotData).
+    #: Consumers can write data to this object (overrides AbstractPlotData).
     writable = True
 
     # -------------------------------------------------------------------------

--- a/chaco/function_data_source.py
+++ b/chaco/function_data_source.py
@@ -24,11 +24,11 @@ class FunctionDataSource(ArrayDataSource):
     behavior, create a subclass that hooks up the appropriate listeners.
     """
 
-    # The function to call with the low and high values of the range.
-    # It should return an array of values.
+    #: The function to call with the low and high values of the range.
+    #: It should return an array of values.
     func = Callable
 
-    # A reference to a datarange
+    #: A reference to a datarange
     data_range = Instance(DataRange1D)
 
     def __init__(self, **kw):

--- a/chaco/function_image_data.py
+++ b/chaco/function_image_data.py
@@ -18,13 +18,13 @@ class FunctionImageData(ImageData):
     Computation should be fairly swift for acceptable interactive performance.
     """
 
-    # The function to call with the low and high values of the range
-    # in the x and y dimensions.  It should return either a 2-D array
-    # of numerical values, or an array of RGB or RGBA values (shape should
-    # be (n, m), (n, m, 3) or (n, m, 4)).
+    #: The function to call with the low and high values of the range
+    #: in the x and y dimensions.  It should return either a 2-D array
+    #: of numerical values, or an array of RGB or RGBA values (shape should
+    #: be (n, m), (n, m, 3) or (n, m, 4)).
     func = Callable
 
-    # the 2D data_range required for the data shown
+    #: the 2D data_range required for the data shown
     data_range = Instance(DataRange2D)
 
     def __init__(self, **kw):

--- a/chaco/jitterplot.py
+++ b/chaco/jitterplot.py
@@ -14,8 +14,8 @@ class JitterPlot(ScatterPlot1D):
     dense collections of points.
     """
 
-    # The size, in pixels, of the area over which to spread the data points
-    # along the dimension orthogonal to the index direction.
+    #: The size, in pixels, of the area over which to spread the data points
+    #: along the dimension orthogonal to the index direction.
     jitter_width = Int(50)
 
     # ------------------------------------------------------------------------

--- a/chaco/shell/preferences.py
+++ b/chaco/shell/preferences.py
@@ -8,22 +8,22 @@ from traits.api import Enum, HasTraits, Int, Str
 class Preferences(HasTraits):
     """Contains all the preferences that configure the Chaco shell session."""
 
-    # Width of the plot window, in pixels.
+    #: Width of the plot window, in pixels.
     window_width = Int(600)
 
-    # Height of the plot window, in pixels.
+    #: Height of the plot window, in pixels.
     window_height = Int(600)
 
-    # The type of plot to display.
+    #: The type of plot to display.
     plot_type = Enum("line", "scatter")
 
-    # Default name to use for the plot window.
+    #: Default name to use for the plot window.
     default_window_name = Str("Chaco Plot")
 
-    # The default background color.
+    #: The default background color.
     bgcolor = white_color_trait
 
-    # The default location of the origin for new image plots
+    #: The default location of the origin for new image plots
     image_default_origin = Enum(
         "top left", "bottom left", "bottom right", "top right"
     )

--- a/chaco/shell/session.py
+++ b/chaco/shell/session.py
@@ -30,33 +30,33 @@ class PlotSession(HasTraits):
     windows, etc.
     """
 
-    # The preferences object in effect for this session.
+    #: The preferences object in effect for this session.
     prefs = Instance(Preferences, args=())
 
-    # The list of currently active windows.
+    #: The list of currently active windows.
     windows = List(PlotWindow)
 
-    # A dict mapping names to windows.
+    #: A dict mapping names to windows.
     window_map = Dict(Str, PlotWindow)
 
-    # The current hold state.
+    #: The current hold state.
     hold = Bool(False)
 
-    # The session holds a single ArrayPlotData instance to which it adds unnamed
-    # arrays that are provided to various plotting commands.
+    #: The session holds a single ArrayPlotData instance to which it adds unnamed
+    #: arrays that are provided to various plotting commands.
     data = Instance(ArrayPlotData, args=())
 
     # ------------------------------------------------------------------------
     # "active" pointers
     # ------------------------------------------------------------------------
 
-    # The index of the active window.
+    #: The index of the active window.
     active_window_index = Trait(None, None, Int)
 
-    # The active window.
+    #: The active window.
     active_window = Property
 
-    # The active colormap.
+    #: The active colormap.
     colormap = Trait(jet, Any)
 
     def new_window(self, name=None, title=None, is_image=False):

--- a/chaco/tools/base_zoom_tool.py
+++ b/chaco/tools/base_zoom_tool.py
@@ -18,16 +18,16 @@ class BaseZoomTool(HasTraits):
     onto a plot.
     """
 
-    # If the tool only applies to a particular axis, this attribute is used to
-    # determine which mapper and range to use.
+    #: If the tool only applies to a particular axis, this attribute is used to
+    #: determine which mapper and range to use.
     axis = Enum("index", "value")
 
-    # The maximum ratio between the original data space bounds and the zoomed-in
-    # data space bounds.  If None, then there is no limit (not advisable!).
+    #: The maximum ratio between the original data space bounds and the zoomed-in
+    #: data space bounds.  If None, then there is no limit (not advisable!).
     max_zoom_in_factor = Float(1e5, allow_none=True)
 
-    # The maximum ratio between the zoomed-out data space bounds and the original
-    # bounds.  If None, then there is no limit.
+    #: The maximum ratio between the zoomed-out data space bounds and the original
+    #: bounds.  If None, then there is no limit.
     max_zoom_out_factor = Float(1e5, allow_none=True)
 
     def _zoom_limit_reached(

--- a/chaco/tools/cursor_tool.py
+++ b/chaco/tools/cursor_tool.py
@@ -58,22 +58,22 @@ class BaseCursorTool(LineInspector, DragTool):
     Abstract base class for CursorTool objects
     """
 
-    # if true, draw a small circle at the cursor/line intersection
+    #: if true, draw a small circle at the cursor/line intersection
     show_marker = Bool(True)
 
-    # the radius of the marker in pixels
+    #: the radius of the marker in pixels
     marker_size = Float(3.0)
 
-    # the marker object. this should probably be private
+    #: the marker object. this should probably be private
     marker = Instance(CircleMarker, ())
 
-    # pick threshold, in screen units (pixels)
+    #: pick threshold, in screen units (pixels)
     threshold = Float(5.0)
 
-    # The current index-value of the cursor. Over-ridden in subclasses
+    #: The current index-value of the cursor. Over-ridden in subclasses
     current_index = Disallow
 
-    # The current position of the cursor in data units
+    #: The current position of the cursor in data units
     current_position = Property(observe=["current_index"])
 
     # Stuff from line_inspector which is not required

--- a/chaco/tools/pan_tool2.py
+++ b/chaco/tools/pan_tool2.py
@@ -10,29 +10,29 @@ class PanTool(DragTool):
     a bare BaseTool
     """
 
-    # The cursor to use when panning.
+    #: The cursor to use when panning.
     drag_pointer = Pointer("hand")
 
-    # Scaling factor on the panning "speed".
+    #: Scaling factor on the panning "speed".
     speed = Float(1.0)
 
-    # The modifier key that, if depressed when the drag is initiated, constrains
-    # the panning to happen in the only direction of largest initial motion.
-    # It is possible to permanently restrict this tool to always drag along one
-    # direction.  To do so, set constrain=True, constrain_key=None, and
-    # constrain_direction to the desired direction.
+    #: The modifier key that, if depressed when the drag is initiated, constrains
+    #: the panning to happen in the only direction of largest initial motion.
+    #: It is possible to permanently restrict this tool to always drag along one
+    #: direction.  To do so, set constrain=True, constrain_key=None, and
+    #: constrain_direction to the desired direction.
     constrain_key = Enum(None, "shift", "control", "alt")
 
-    # Constrain the panning to one direction?
+    #: Constrain the panning to one direction?
     constrain = Bool(False)
 
-    # The direction of constrained draw. A value of None means that the user
-    # has initiated the drag and pressed the constrain_key, but hasn't moved
-    # the mouse yet; the magnitude of the components of the next mouse_move
-    # event will determine the constrain_direction.
+    #: The direction of constrained draw. A value of None means that the user
+    #: has initiated the drag and pressed the constrain_key, but hasn't moved
+    #: the mouse yet; the magnitude of the components of the next mouse_move
+    #: event will determine the constrain_direction.
     constrain_direction = Enum(None, "x", "y")
 
-    # Restrict to the bounds of the plot data
+    #: Restrict to the bounds of the plot data
     restrict_to_data = Bool(False)
 
     # (x,y) of the point where the mouse button was pressed.
@@ -50,11 +50,11 @@ class PanTool(DragTool):
     # Inherited BaseTool traits
     # ------------------------------------------------------------------------
 
-    # The tool does not have a visual representation (overrides
-    # BaseTool).
+    #: The tool does not have a visual representation (overrides
+    #: BaseTool).
     draw_mode = "none"
 
-    # The tool is not visible (overrides BaseTool).
+    #: The tool is not visible (overrides BaseTool).
     visible = False
 
     def drag_start(self, event):

--- a/chaco/tools/rect_zoom.py
+++ b/chaco/tools/rect_zoom.py
@@ -11,9 +11,9 @@ class RectZoomTool(ZoomTool):
     traits.
     """
 
-    # Selects a box in two dimensions (overrides SimpleZoom).
+    #: Selects a box in two dimensions (overrides SimpleZoom).
     tool_mode = "box"
 
-    # The tool is always on; left-clicking initiates a zoom (overrides
-    # SimpleZoom).
+    #: The tool is always on; left-clicking initiates a zoom (overrides
+    #: SimpleZoom).
     always_on = True

--- a/chaco/tools/scatter_inspector.py
+++ b/chaco/tools/scatter_inspector.py
@@ -38,8 +38,10 @@ class ScatterInspector(SelectTool):
     #: a point does no de-hover until another point get hover focus.
     persistent_hover = Bool(False)
 
-    #: The names of the data source metadata for hover and selection events.
+    #: The names of the data source metadata for hover events.
     hover_metadata_name = Str("hover")
+
+    #: The names of the data source metadata for selection events.
     selection_metadata_name = Str("selections")
 
     #: This tool emits events when hover or selection changes

--- a/chaco/tools/simple_zoom.py
+++ b/chaco/tools/simple_zoom.py
@@ -30,91 +30,91 @@ class SimpleZoom(AbstractOverlay, ToolHistoryMixin, BaseZoomTool):
     through previous zoom regions.
     """
 
-    # The selection mode:
-    #
-    # range:
-    #   Select a range across a single index or value axis.
-    # box:
-    #   Perform a "box" selection on two axes.
+    #: The selection mode:
+    #:
+    #: range:
+    #:   Select a range across a single index or value axis.
+    #: box:
+    #:   Perform a "box" selection on two axes.
     tool_mode = Enum("box", "range")
 
-    # Is the tool always "on"? If True, left-clicking always initiates
-    # a zoom operation; if False, the user must press a key to enter zoom mode.
+    #: Is the tool always "on"? If True, left-clicking always initiates
+    #: a zoom operation; if False, the user must press a key to enter zoom mode.
     always_on = Bool(False)
 
-    # Defines a meta-key, that works with always_on to set the zoom mode. This
-    # is useful when the zoom tool is used in conjunction with the pan tool.
+    #: Defines a meta-key, that works with always_on to set the zoom mode. This
+    #: is useful when the zoom tool is used in conjunction with the pan tool.
     always_on_modifier = Enum(None, "shift", "control", "alt")
 
     # -------------------------------------------------------------------------
     # Zoom control
     # -------------------------------------------------------------------------
 
-    # The axis to which the selection made by this tool is perpendicular. This
-    # only applies in 'range' mode.
+    #: The axis to which the selection made by this tool is perpendicular. This
+    #: only applies in 'range' mode.
     axis = Enum("index", "value")
 
     # -------------------------------------------------------------------------
     # Interaction control
     # -------------------------------------------------------------------------
 
-    # Enable the mousewheel for zooming?
+    #: Enable the mousewheel for zooming?
     enable_wheel = Bool(True)
 
-    # The mouse button that initiates the drag.  If "None", then the tool
-    # will not respond to drag.  (It can still respond to mousewheel events.)
+    #: The mouse button that initiates the drag.  If "None", then the tool
+    #: will not respond to drag.  (It can still respond to mousewheel events.)
     drag_button = Enum("left", "right", None)
 
-    # Conversion ratio from wheel steps to zoom factors.
+    #: Conversion ratio from wheel steps to zoom factors.
     wheel_zoom_step = Float(1.0)
 
-    # The key press to enter zoom mode, if **always_on** is False.  Has no effect
-    # if **always_on** is True.
+    #: The key press to enter zoom mode, if **always_on** is False.  Has no effect
+    #: if **always_on** is True.
     enter_zoom_key = Instance(KeySpec, args=("z",))
 
-    # The key press to leave zoom mode, if **always_on** is False.  Has no effect
-    # if **always_on** is True.
+    #: The key press to leave zoom mode, if **always_on** is False.  Has no effect
+    #: if **always_on** is True.
     exit_zoom_key = Instance(KeySpec, args=("z",))
 
-    # Disable the tool after the zoom is completed?
+    #: Disable the tool after the zoom is completed?
     disable_on_complete = Bool(True)
 
-    # The minimum amount of screen space the user must select in order for
-    # the tool to actually take effect.
+    #: The minimum amount of screen space the user must select in order for
+    #: the tool to actually take effect.
     minimum_screen_delta = Int(10)
 
     # -------------------------------------------------------------------------
     # Appearance properties (for Box mode)
     # -------------------------------------------------------------------------
 
-    # The pointer to use when drawing a zoom box.
+    #: The pointer to use when drawing a zoom box.
     pointer = "magnifier"
 
-    # The color of the selection box.
+    #: The color of the selection box.
     color = ColorTrait("lightskyblue")
 
-    # The alpha value to apply to **color** when filling in the selection
-    # region.  Because it is almost certainly useless to have an opaque zoom
-    # rectangle, but it's also extremely useful to be able to use the normal
-    # named colors from Enable, this attribute allows the specification of a
-    # separate alpha value that replaces the alpha value of **color** at draw
-    # time.
+    #: The alpha value to apply to **color** when filling in the selection
+    #: region.  Because it is almost certainly useless to have an opaque zoom
+    #: rectangle, but it's also extremely useful to be able to use the normal
+    #: named colors from Enable, this attribute allows the specification of a
+    #: separate alpha value that replaces the alpha value of **color** at draw
+    #: time.
     alpha = Trait(0.4, None, Float)
 
-    # The color of the outside selection rectangle.
+    #: The color of the outside selection rectangle.
     border_color = ColorTrait("dodgerblue")
 
-    # The thickness of selection rectangle border.
+    #: The thickness of selection rectangle border.
     border_size = Int(1)
 
-    # The possible event states of this zoom tool.
+    #: The possible event states of this zoom tool.
     event_state = Enum("normal", "selecting")
 
     # ------------------------------------------------------------------------
     # Key mappings
     # ------------------------------------------------------------------------
 
-    # The key that cancels the zoom and resets the view to the original defaults.
+    #: The key that cancels the zoom and resets the view to the original defaults.
     cancel_zoom_key = Instance(KeySpec, args=("Esc",))
 
     # ------------------------------------------------------------------------

--- a/chaco/tools/tool_history_mixin.py
+++ b/chaco/tools/tool_history_mixin.py
@@ -13,13 +13,13 @@ class ToolHistoryMixin(HasTraits):
     process the event.
     """
 
-    # Key to go to the original or start state in the history.
+    #: Key to go to the original or start state in the history.
     reset_state_key = Instance(KeySpec, args=("Esc",))
 
-    # Key to go to the previous state in the history.
+    #: Key to go to the previous state in the history.
     prev_state_key = Instance(KeySpec, args=("Left", "control"))
 
-    # Key to go to the next state in the history.
+    #: Key to go to the next state in the history.
     next_state_key = Instance(KeySpec, args=("Right", "control"))
 
     # The state stack.

--- a/chaco/tools/toolbars/plot_toolbar.py
+++ b/chaco/tools/toolbars/plot_toolbar.py
@@ -45,30 +45,30 @@ class PlotToolbar(Container, AbstractOverlay):
 
     buttons = List(Type(ToolbarButton))
 
-    # Should the toolbar be hidden
+    #: Should the toolbar be hidden
     hiding = Bool(True)
 
-    # should the toolbar go automatically go back into hiding when the mouse
-    # is not hovering over it
+    #: should the toolbar go automatically go back into hiding when the mouse
+    #: is not hovering over it
     auto_hide = Bool(True)
 
-    # the radius used to determine how round to make the toolbar's edges
+    #: the radius used to determine how round to make the toolbar's edges
     end_radius = Float(4.0)
 
-    # button spacing is defined as the number of pixels on either side of
-    # a button. The gap between 2 buttons will be 2 x the button spacing
+    #: button spacing is defined as the number of pixels on either side of
+    #: a button. The gap between 2 buttons will be 2 x the button spacing
     button_spacing = Float(5.0)
 
-    # how many pixels to put before and after the set of buttons
+    #: how many pixels to put before and after the set of buttons
     horizontal_padding = Float(5.0)
 
-    # how many pixels to put on top and bottom the set of buttons
+    #: how many pixels to put on top and bottom the set of buttons
     vertical_padding = Float(5.0)
 
-    # The edge against which the toolbar is placed.
+    #: The edge against which the toolbar is placed.
     location = Enum("top", "right", "bottom", "left")
 
-    # Should tooltips be shown?
+    #: Should tooltips be shown?
     show_tooltips = Bool(False)
 
     ############################################################


### PR DESCRIPTION
closes #615 

This PR simply audits the code base for public trait definitions that use # instead of #: and replaces them as needed.  Note some of the modules changed here may soon be deprecated. 
