### PR TITLE
Use @property decorator instead of property function

### DIFF
--- a/chaco/plugin/workbench_session.py
+++ b/chaco/plugin/workbench_session.py
@@ -37,7 +37,7 @@ class WorkbenchSession(PlotSession):
             window=workbench.active_window,
         )
         new_win.data = self.data
-        new_win.get_container().data = self.data
+        new_win.container.data = self.data
         new_win.session = self
 
         if title is not None:

--- a/chaco/shell/commands.py
+++ b/chaco/shell/commands.py
@@ -256,7 +256,7 @@ def hold(state=None):
 
 def curplot():
     if session.active_window:
-        return session.active_window.get_container()
+        return session.active_window.container
     else:
         return None
 
@@ -283,11 +283,11 @@ def _do_plot_boilerplate(kwargs, image=False):
         else:
             figure()
 
-    cont = session.active_window.get_container()
+    cont = session.active_window.container
 
     if not cont:
         cont = Plot(session.data)
-        session.active_window.set_container(cont)
+        session.active_window.container = cont
 
     existing_tools = [type(t) for t in (cont.tools + cont.overlays)]
     if not PanTool in existing_tools:

--- a/chaco/shell/plot_window.py
+++ b/chaco/shell/plot_window.py
@@ -63,10 +63,13 @@ if ETSConfig.toolkit == "wx":
             self.SetAutoLayout(True)
             self.Show(True)
 
-        def get_container(self):
+        # This is a Python property because this is not a HasTraits subclass.
+        @property
+        def container(self):
             return self.plot_window.component
 
-        def set_container(self, container):
+        @container.setter
+        def container(self, container):
             self.plot_window.component = container
 
         def iconize(self, iconize):
@@ -89,9 +92,6 @@ if ETSConfig.toolkit == "wx":
 
         def close(self):
             self.Close()
-
-        # This is a Python property because this is not a HasTraits subclass.
-        container = property(get_container, set_container)
 
         # ------------------------------------------------------------------------
         # Private methods
@@ -183,10 +183,13 @@ elif ETSConfig.toolkit == "qt4":
 
             self.show()
 
-        def get_container(self):
+        # This is a Python property because this is not a HasTraits subclass.
+        @property
+        def container(self):
             return self.plot_window.component
 
-        def set_container(self, container):
+        @container.setter
+        def container(self, container):
             self.plot_window.component = container
 
         def iconize(self, iconize):
@@ -212,9 +215,6 @@ elif ETSConfig.toolkit == "qt4":
         def raise_window(self):
             """Raises this window to the top of the window hierarchy."""
             self.raise_()
-
-        # This is a Python property because this is not a HasTraits subclass.
-        container = property(get_container, set_container)
 
         # ------------------------------------------------------------------------
         # Private methods

--- a/chaco/shell/session.py
+++ b/chaco/shell/session.py
@@ -70,7 +70,7 @@ class PlotSession(HasTraits):
             image_default_origin=self.prefs.image_default_origin,
         )
         new_win.data = self.data
-        new_win.get_container().data = self.data
+        new_win.container.data = self.data
         new_win.session = self
 
         if title is not None:
@@ -145,7 +145,7 @@ class PlotSession(HasTraits):
     def _colormap_changed(self):
         plots = []
         for w in self.windows:
-            container = w.get_container()
+            container = w.container
             for vals in container.plots.values():
                 plots.extend(vals)
         for p in plots:

--- a/chaco/tests/test_speedups.py
+++ b/chaco/tests/test_speedups.py
@@ -64,7 +64,6 @@ class GatherPointsBase(object):
     def test_selection_range(self):
         pass
 
-    def _get_func(self):
+    @property
+    def func(self):
         return self.module.scatterplot_gather_points
-
-    func = property(_get_func)


### PR DESCRIPTION
closes #609 

This PR simply updates the uses of the `property` function to use the `@property` decorator.  Also, users of the property now access the property without calling the `get____` or `set___` methods.