### PR TITLE
Remove annotated examples from the usermanual

### DIFF
--- a/docs/source/user_manual/index.rst
+++ b/docs/source/user_manual/index.rst
@@ -27,5 +27,3 @@ User Guide
     common_patterns.rst
     how_do_i.rst
     faq.rst
-    annotated_examples.rst
-


### PR DESCRIPTION
This PR simply removes the annotated examples links from the user guide.  They are already linked from the home page of the documentation, and they simply cloud the user manual TOC.