### PR TITLE
Its TraitsUI, not Traits UI

### DIFF
--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -215,7 +215,7 @@ class PlotAxis(AbstractOverlay):
         self.invalidate_draw()
 
     def traits_view(self):
-        """Returns a View instance for use with Traits UI.  This method is
+        """Returns a View instance for use with TraitsUI.  This method is
         called automatically be the Traits framework when .edit_traits() is
         invoked.
         """

--- a/chaco/axis_view.py
+++ b/chaco/axis_view.py
@@ -1,4 +1,4 @@
-""" Defines the Traits UI view for a PlotAxis """
+""" Defines the TraitsUI view for a PlotAxis """
 from traits.api import TraitError
 from traitsui.api import View, HGroup, Group, VGroup, Item, TextEditor
 
@@ -7,7 +7,7 @@ def float_or_auto(val):
     """
     Validator function that returns *val* if *val* is either a number or
     the word 'auto'.  This is used as a validator for the text editor
-    in the Traits UI for the **tick_interval** trait.
+    in the TraitsUI for the **tick_interval** trait.
     """
     try:
         return float(val)
@@ -17,7 +17,7 @@ def float_or_auto(val):
     raise TraitError("Tick interval must be a number or 'auto'.")
 
 
-# Traits UI for a PlotAxis.
+# TraitsUI for a PlotAxis.
 AxisView = View(
     VGroup(
         Group(

--- a/chaco/chaco_plot_editor.py
+++ b/chaco/chaco_plot_editor.py
@@ -1,7 +1,3 @@
-"""
-Traits UI editor for WX, based on the Chaco1 PlotEditor in
-traits.ui.wx.plot_editor.
-"""
 # Enthought library imports
 from traits.etsconfig.api import ETSConfig
 from enable.api import (
@@ -60,7 +56,7 @@ USE_DATA_UPDATE = 1
 
 
 class ChacoPlotItem(Item):
-    """A Traits UI Item for a Chaco plot, for use in Traits UI Views.
+    """A TraitsUI Item for a Chaco plot, for use in TraitsUI Views.
 
     NOTE: ComponentEditor is preferred over this class, as it is more flexible.
     """
@@ -209,7 +205,7 @@ class ChacoEditorFactory(EditorFactory):
 
 
 class ChacoPlotEditor(Editor):
-    """Traits UI editor for displaying trait values in a Chaco plot."""
+    """TraitsUI editor for displaying trait values in a Chaco plot."""
 
     # ---------------------------------------------------------------------------
     #  Finishes initializing the editor by creating the underlying toolkit

--- a/chaco/colormapped_scatterplot.py
+++ b/chaco/colormapped_scatterplot.py
@@ -29,7 +29,7 @@ from .scatterplot import ScatterPlot, ScatterPlotView
 
 
 class ColormappedScatterPlotView(ScatterPlotView):
-    """Traits UI View for customizing a color-mapped scatter plot."""
+    """TraitsUI View for customizing a color-mapped scatter plot."""
 
     def __init__(self):
         super(ColormappedScatterPlotView, self).__init__()
@@ -87,7 +87,7 @@ class ColormappedScatterPlot(ScatterPlot):
     # This mapping is only valid if **_cache_valid** is True.
     _index_bands = Dict()
 
-    #: Traits UI View for customizing the plot. Overrides the ScatterPlot value.
+    #: TraitsUI View for customizing the plot. Overrides the ScatterPlot value.
     traits_view = ColormappedScatterPlotView()
 
     # ------------------------------------------------------------------------

--- a/chaco/grid.py
+++ b/chaco/grid.py
@@ -1,4 +1,4 @@
-""" Defines the PlotGrid class, and associated Traits UI View and validator
+""" Defines the PlotGrid class, and associated TraitsUI View and validator
 function.
 """
 
@@ -157,7 +157,7 @@ class PlotGrid(AbstractOverlay):
     line_width = CInt(1)
     line_weight = Alias("line_width")
 
-    #: Default Traits UI View for modifying grid attributes.
+    #: Default TraitsUI View for modifying grid attributes.
     traits_view = GridView
 
     # ------------------------------------------------------------------------

--- a/chaco/lineplot.py
+++ b/chaco/lineplot.py
@@ -79,7 +79,7 @@ class LinePlot(BaseXYPlot):
     #:     point.  Also called a "right angle plot".
     render_style = Enum("connectedpoints", "hold", "connectedhold")
 
-    #: Traits UI View for customizing the plot.
+    #: TraitsUI View for customizing the plot.
     traits_view = View(
         Item("color", style="custom"),
         "line_width",

--- a/chaco/multi_line_plot.py
+++ b/chaco/multi_line_plot.py
@@ -187,7 +187,7 @@ class MultiLinePlot(BaseXYPlot):
 
     def trait_view(self, obj):
         """Create a minimalist View, with just the amplitude and color attributes."""
-        # Minimalist Traits UI View for customizing the plot: only the trace amplitude
+        # Minimalist TraitsUI View for customizing the plot: only the trace amplitude
         # and line color are exposed.
         view = View(
             HGroup(

--- a/chaco/plugin/plot_editor.py
+++ b/chaco/plugin/plot_editor.py
@@ -6,7 +6,7 @@ from traitsui.api import Item, View
 
 
 class PlotUI(HasTraits):
-    """Simple Traits UI proxy for a Chaco plot."""
+    """Simple TraitsUI proxy for a Chaco plot."""
 
     # The plot.
     component = Any()

--- a/chaco/scatterplot.py
+++ b/chaco/scatterplot.py
@@ -1,4 +1,4 @@
-""" Defines the ScatterPlot class, and associated Traits UI view and helper
+""" Defines the ScatterPlot class, and associated TraitsUI view and helper
 function.
 """
 
@@ -51,12 +51,12 @@ from .speedups import scatterplot_gather_points
 from .base import reverse_map_1d
 
 # ------------------------------------------------------------------------------
-# Traits UI View for customizing a scatter plot.
+# TraitsUI View for customizing a scatter plot.
 # ------------------------------------------------------------------------------
 
 
 class ScatterPlotView(View):
-    """Traits UI View for customizing a scatter plot."""
+    """TraitsUI View for customizing a scatter plot."""
 
     def __init__(self):
         vgroup = VGroup(
@@ -244,7 +244,7 @@ class ScatterPlot(BaseXYPlot):
         Tuple, observe=["outline_color", "alpha"]
     )
 
-    # Traits UI View for customizing the plot.
+    # TraitsUI View for customizing the plot.
     traits_view = ScatterPlotView()
 
     # ------------------------------------------------------------------------

--- a/docs/source/user_manual/annotated_examples.rst
+++ b/docs/source/user_manual/annotated_examples.rst
@@ -453,7 +453,7 @@ source: `tabbed_plots.py <https://github.com/enthought/chaco/tree/master/example
 ``traits_editor.py``
 --------------------
 This example creates a simple 1-D function examiner, illustrating the use of
-ChacoPlotEditors for displaying simple plot relations, as well as Traits UI
+ChacoPlotEditors for displaying simple plot relations, as well as TraitsUI
 integration. Any 1-D numpy/scipy.special function works in the function
 text box.
 

--- a/docs/source/user_manual/chaco_tutorial.rst
+++ b/docs/source/user_manual/chaco_tutorial.rst
@@ -24,12 +24,12 @@ for the last portion of the tutorial, but it is not required.
 This tutorial demonstrates using Chaco with Traits(UI), so knowledge of the
 `Traits User Manual <http://docs.enthought.com/traits/>`_ framework is also
 helpful. We don't use very many sophisticated aspects
-of Traits or Traits UI, and it is entirely possible to pick it up as you go
+of Traits or TraitsUI, and it is entirely possible to pick it up as you go
 through the tutorial.
 
-It's also worth pointing out that you don't *have* to use Traits UI in order to
+It's also worth pointing out that you don't *have* to use TraitsUI in order to
 use Chaco -- you can integrate Chaco components directly with Qt or wxPython -- but for
-this tutorial, we use Traits UI to make things easier.
+this tutorial, we use TraitsUI to make things easier.
 
 
 Goals
@@ -41,7 +41,7 @@ By the end of this tutorial, you will have learned how to:
 
 - arrange plots in various layouts
 
-- configure and dynamically modify your plots using Traits UI
+- configure and dynamically modify your plots using TraitsUI
 
 - interact with plots using tools
 
@@ -205,7 +205,7 @@ plot, called :class:`LinePlot`::
 This class uses the Enthought Traits package, and all of our objects subclass
 from :class:`HasTraits`.
 
-Next, we declare a Traits UI View for this class::
+Next, we declare a TraitsUI View for this class::
 
     traits_view = View(
         Item('plot',editor=ComponentEditor(), show_label=False),
@@ -216,15 +216,15 @@ Next, we declare a Traits UI View for this class::
     )
 
 Inside this view, we are placing a reference to the ``plot`` trait and
-telling Traits UI to use the :class:`ComponentEditor` (imported from
+telling TraitsUI to use the :class:`ComponentEditor` (imported from
 :mod:`enable.api`) to display it. If the
 trait were an Int or Str or Float, Traits could automatically pick an
-appropriate GUI element to display it. Since Traits UI doesn't natively know
+appropriate GUI element to display it. Since TraitsUI doesn't natively know
 how to display Chaco components, we explicitly tell it what kind of editor to
 use.
 
 The other parameters in the :class:`View` constructor are pretty
-self-explanatory, and the `Traits UI User Manual <http://docs.enthought.com/traitsui/>`_
+self-explanatory, and the `TraitsUI User Manual <http://docs.enthought.com/traitsui/>`_
 documents all the various properties
 you can set here. For our purposes, this Traits :class:`View` is sort of boilerplate. It
 gets us a nice little window that we can resize. We'll be using something like
@@ -620,8 +620,8 @@ First, we add traits for color, marker type, and marker size::
         marker = marker_trait
         marker_size = Int(4)
 
-We also change our Traits UI View to include references to these
-new traits.  We put them in a Traits UI :class:`Group` so that we can control
+We also change our TraitsUI View to include references to these
+new traits.  We put them in a TraitsUI :class:`Group` so that we can control
 the layout in the dialog a little better --- here, we're setting the layout
 orientation of the elements in the dialog to "vertical". ::
 
@@ -747,7 +747,7 @@ First, we add an Enumeration trait to select a particular data name ::
 
     data_name = Enum("jn0", "jn1", "jn2")
 
-and a corresponding ``Item`` in the Traits UI View ::
+and a corresponding ``Item`` in the TraitsUI View ::
 
     Item('data_name', label="Y data")
 
@@ -933,7 +933,7 @@ We will again modify the :ref:`LinePlot example <line_plot_example>`. This
 time, we will create a scatter plot and a line plot with connected ranges
 in different windows.
 
-First of all, we define a Traits UI view of a customizable plot.
+First of all, we define a TraitsUI view of a customizable plot.
 This is the full code that we will analyze step by step below ::
 
     from numpy import linspace, sin
@@ -988,7 +988,7 @@ and one for the orientation of the plot ::
         orientation = Enum("horizontal", "vertical")
 
 The ``plot_type`` trait will not be exposed in the UI, but we add a
-Traits UI item for the orientation: ::
+TraitsUI item for the orientation: ::
 
         traits_view = View(Item('orientation', label="Orientation"), ...)
 
@@ -1028,7 +1028,7 @@ this way: ::
         line.edit_traits()
         scatter.configure_traits()
 
-In the last two lines, we open Traits UI editors on both objects.
+In the last two lines, we open TraitsUI editors on both objects.
 Note that we call :meth:`edit_traits()` on the first object,
 and :meth:`configure_traits()` on the second object.
 The technical reason for this is that :meth:`configure_traits()`

--- a/docs/source/user_manual/common_patterns.rst
+++ b/docs/source/user_manual/common_patterns.rst
@@ -20,7 +20,7 @@ Non-interactive/Offscreen Rendering
 ===================================
 
 
-Integrating with Traits UI Controls
+Integrating with TraitsUI Controls
 ===================================
 
 

--- a/docs/source/user_manual/faq.rst
+++ b/docs/source/user_manual/faq.rst
@@ -74,7 +74,7 @@ Peter Wang's response (excerpt)::
     Chaco is a plotting toolkit targeted towards developers for building
     interactive visualizations.  You hook up pieces to build a plot that
     is then easy to inspect, interact with, add configuration UIs for
-    (using Traits UI), etc.  The layout of plot areas, the multiplicity
+    (using TraitsUI), etc.  The layout of plot areas, the multiplicity
     and types of renderers within those windows, the appearance and
     locations of axes, etc. are all completely configurable since these
     are all first-class objects participating in a visual canvas.  They

--- a/docs/source/user_manual/how_do_i.rst
+++ b/docs/source/user_manual/how_do_i.rst
@@ -75,7 +75,7 @@ be set to 'wx'.
 
 * integrate a Chaco plot into my QT app?
 
-Integrate a Chaco plot into my Traits UI?
+Integrate a Chaco plot into my TraitsUI?
 -----------------------------------------
 
 ::

--- a/docs/source/user_manual/modules_and_classes.rst
+++ b/docs/source/user_manual/modules_and_classes.rst
@@ -243,7 +243,8 @@ first in Chaco, and then moved into Enable.
 
 DragTool is a base class for tools that do dragging.
 
-Other tools do things like panning, moving, highlighting, line segments, range selection, drag zoom, move data labels, scatter inspection, Traits UI.
+Other tools do things like panning, moving, highlighting, line segments, range
+selection, drag zoom, move data labels, scatter inspection, TraitsUI.
 
 Overlays
 -----------------------------------------------------------------------------

--- a/docs/source/user_manual/tutorial_van_der_waal.rst
+++ b/docs/source/user_manual/tutorial_van_der_waal.rst
@@ -22,7 +22,7 @@ Development Setup
 In review, Traits is a manifest typing and reactive programming package
 for Python. It also provides UI features that will be used to create a
 simple GUI. The `Traits <http://docs.enthought.com/traits/>`_ and
-`Traits UI <http://docs.enthought.com/traitsui/>`_ user manuals are good
+`TraitsUI <http://docs.enthought.com/traitsui/>`_ user manuals are good
 resources for learning about the packages.
 
 You must have Chaco and its dependencies installed:
@@ -92,7 +92,7 @@ This View contains all of the GUI elements, including the plot.  To
 link a variable with a widget element on the GUI, we create a Traits
 :class:`Item` instance with the same name as the variable and pass it as an
 argument of the Traits View instance declaration.  The
-`Traits UI User Guide <https://svn.enthought.com/svn/enthought/Traits/tags/traits_2.0.1b1/docs/Traits%20UI%20User%20Guide.pdf>`_
+`TraitsUI User Guide <https://docs.enthought.com/traitsui>`_
 discusses the View and Item objects in depth. In order to
 embed a Chaco plot into a Traits View, you need to import the
 :class:`ChacoPlotItem` class, which can be passed as a parameter to View just

--- a/examples/demo/chaco_trait_editor.py
+++ b/examples/demo/chaco_trait_editor.py
@@ -1,4 +1,4 @@
-""" An example of how to use Chaco to render a visual Traits UI editor.
+""" An example of how to use Chaco to render a visual TraitsUI editor.
 This particular editor allows the user to set two endpoints of an
 interval.
 """


### PR DESCRIPTION
This PR does a repo-wide search and replace for `"Traits UI"` with `"TraitsUI"`. After the automated search and replace, the changes were checked and modified.