### PR TITLE
Remove unnecessary uses of "use_draw_order"

### DIFF
--- a/chaco/barplot.py
+++ b/chaco/barplot.py
@@ -107,8 +107,6 @@ class BarPlot(AbstractPlotRenderer):
     #: Overall alpha value of the image. Ranges from 0.0 for transparent to 1.0
     alpha = Range(0.0, 1.0, 1.0, requires_redraw=True)
 
-    # use_draw_order = False
-
     # Convenience properties that correspond to either index_mapper or
     # value_mapper, depending on the orientation of the plot.
 

--- a/chaco/color_bar.py
+++ b/chaco/color_bar.py
@@ -69,8 +69,6 @@ class ColorBar(AbstractPlotRenderer):
     direction = Enum("normal", "flipped")
     #: Overrides the default background color trait in PlotComponent.
     bgcolor = "transparent"
-    #: Draw layers in "draw order"
-    use_draw_order = True
     #: Default width is 40 pixels (overrides enable.CoordinateBox)
     width = 40
 

--- a/examples/demo/zoomed_plot/grid_plot_factory.py
+++ b/examples/demo/zoomed_plot/grid_plot_factory.py
@@ -62,7 +62,6 @@ def create_gridded_line_plot(
         orientation="vertical",
         line_color="gray",
         line_style="dot",
-        use_draw_order=True,
     )
 
     horizontal_grid = PlotGrid(
@@ -71,18 +70,14 @@ def create_gridded_line_plot(
         orientation="horizontal",
         line_color="gray",
         line_style="dot",
-        use_draw_order=True,
     )
 
-    vertical_axis = PlotAxis(
-        orientation="left", mapper=plot.value_mapper, use_draw_order=True
-    )
+    vertical_axis = PlotAxis(orientation="left", mapper=plot.value_mapper)
 
     horizontal_axis = PlotAxis(
         orientation="bottom",
         title="Time (s)",
         mapper=plot.index_mapper,
-        use_draw_order=True,
     )
 
     plot.underlays.append(vertical_grid)
@@ -150,7 +145,6 @@ def create_gridded_scatter_plot(
         orientation="vertical",
         line_color="gray",
         line_style="dot",
-        use_draw_order=True,
     )
 
     horizontal_grid = PlotGrid(
@@ -159,18 +153,14 @@ def create_gridded_scatter_plot(
         orientation="horizontal",
         line_color="gray",
         line_style="dot",
-        use_draw_order=True,
     )
 
-    vertical_axis = PlotAxis(
-        orientation="left", mapper=plot.value_mapper, use_draw_order=True
-    )
+    vertical_axis = PlotAxis(orientation="left", mapper=plot.value_mapper)
 
     horizontal_axis = PlotAxis(
         orientation="bottom",
         title="Time (s)",
         mapper=plot.index_mapper,
-        use_draw_order=True,
     )
 
     plot.underlays.append(vertical_grid)

--- a/examples/demo/zoomed_plot/zoom_plot.py
+++ b/examples/demo/zoomed_plot/zoom_plot.py
@@ -117,7 +117,6 @@ class ZoomPlot(HasTraits):
             orientation="vertical",
             line_color="gray",
             line_style="dot",
-            use_draw_order=True,
         )
 
         horizontal_grid = PlotGrid(
@@ -126,18 +125,14 @@ class ZoomPlot(HasTraits):
             orientation="horizontal",
             line_color="gray",
             line_style="dot",
-            use_draw_order=True,
         )
 
-        vertical_axis = PlotAxis(
-            orientation="left", mapper=plot.value_mapper, use_draw_order=True
-        )
+        vertical_axis = PlotAxis(orientation="left", mapper=plot.value_mapper)
 
         horizontal_axis = PlotAxis(
             orientation="bottom",
             title=xlabel,
             mapper=plot.index_mapper,
-            use_draw_order=True,
         )
 
         plot.underlays.append(vertical_grid)


### PR DESCRIPTION
This PR removes unnecessary uses of `use_draw_order` in the code - which is by default `True` - and redefinition of the `use_draw_order` trait on a `PlotComponent` subclass and a commented out piece of code.

Note that I tested the `zoomed_plot` and it still works as expected. You need to do `python -m zoomed_plot.zoom_plot` if you want to run the example (which I think needs to be documented somewhere).

Related to #659 