### PR TITLE
fix windows/pyqt test_dont_crash_on_click failure

### DIFF
--- a/chaco/tests/test_plot.py
+++ b/chaco/tests/test_plot.py
@@ -131,5 +131,5 @@ class TestEmptyPlot(unittest.TestCase, EnableTestAssistant):
         with tester.create_ui(empty_plot):
             self.press_move_release(
                 empty_plot.plot,
-                [(1, 1), (25, 25), (50, 50), (100, 100)],
+                [(1, 1), (2, 2), (3, 3), (4, 4)],
             )


### PR DESCRIPTION
This PR attempts to fix the CI failure observed here: https://github.com/enthought/chaco/pull/633#issuecomment-818831955 and https://github.com/enthought/chaco/pull/649#issuecomment-818799658

TBH I do not understand the error entirely yet. It doesn't make sense to me that '_QtWindow' object has no attribute 'handler' as it is explicitly defined in the `__init__` method of '_QtWindow' .  Further I don't get how that would be a windows specific problem....
_Nonetheless_, the error is occurring in a `leaveEvent` method.  This PR is really a hunch (I don't have a windows machine so I am opening the PR to see if it actually fixes the problem).  I changed the coordinates of the drag in the test to hopefully avoid any sort of `leaveEvent` occurring. Leaving the window is actually not the intended behavior of the test anyway.
I am not sure why a leaveEvent was ever getting triggered in the first place as the view being tested explicitly sets `height = 500`, `width = 500`.