### PR TITLE
Remove all uses/definitions of use_draw_order

### DIFF
--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -232,7 +232,7 @@ class PlotAxis(AbstractOverlay):
 
         Overrides Component.
         """
-        if self.use_draw_order and self.component is not None:
+        if self.component is not None:
             self._layout_as_overlay(*args, **kw)
         else:
             super(PlotAxis, self)._do_layout(*args, **kw)

--- a/chaco/base_plot_container.py
+++ b/chaco/base_plot_container.py
@@ -42,10 +42,6 @@ class BasePlotContainer(Container):
     # Deprecated traits
     # ------------------------------------------------------------------------
 
-    #: Deprecated flag to indicate that a component needed to do old-style
-    #: drawing.  Unused by any recent Chaco component.
-    use_draw_order = Bool(True)
-
     #: Deprecated property for accessing the components in the container.
     plot_components = Property
 
@@ -64,13 +60,3 @@ class BasePlotContainer(Container):
             DeprecationWarning,
         )
         self._components = new
-
-    def _use_draw_order_changed(self, old, new):
-        """Handler to catch the case when someone is trying to use the
-        old-style drawing mechanism, which is now unsupported.
-        """
-        if new == False:
-            raise RuntimeError(
-                "The old-style drawing mechanism is no longer "
-                "supported in Chaco."
-            )

--- a/chaco/grid.py
+++ b/chaco/grid.py
@@ -198,7 +198,7 @@ class PlotGrid(AbstractOverlay):
 
         Overrides PlotComponent.
         """
-        if self.use_draw_order and self.component is not None:
+        if self.component is not None:
             self._layout_as_overlay(*args, **kw)
         else:
             super(PlotGrid, self).do_layout(*args, **kw)

--- a/chaco/plot_component.py
+++ b/chaco/plot_component.py
@@ -62,20 +62,6 @@ class PlotComponent(Component):
     #: The default draw layer for Chaco plot components is the "plot" layer
     draw_layer = Str("plot")
 
-    #: Draw layers in **draw_order**? If False, use _do_draw() (for backwards
-    #: compatibility).
-    use_draw_order = Bool(True)
-
-    def _use_draw_order_changed(self, old, new):
-        """Handler to catch the case when someone is trying to use the
-        old-style drawing mechanism, which is now unsupported.
-        """
-        if new == False:
-            raise RuntimeError(
-                "The old-style drawing mechanism is no longer "
-                "supported in Chaco."
-            )
-
     @observe("+requires_redraw")
     def _plot_component_invalidated(self, event):
         self.invalidate_and_redraw()


### PR DESCRIPTION
fixes #659 

This PR simply removes all the uses / definitions of the `use_draw_order` trait. A similar PR is coming shortly in enable.