### PR TITLE
Use draw_marker_at_points if possible otherwise use draw_path_at_points in ColormappedScatterPlot

### DIFF
--- a/chaco/colormapped_scatterplot.py
+++ b/chaco/colormapped_scatterplot.py
@@ -398,8 +398,13 @@ class ColormappedScatterPlot(ScatterPlot):
                     gc, "draw_marker_at_points"
                 ) and self.marker not in (
                     "custom",
-                    "circle",
-                    "diamond",
+                    "left_triangle",
+                    "right_triangle",
+                    "pentagon",
+                    "hexagon",
+                    "hexagon2",
+                    "star",
+                    "cross_plus"
                 ):
                     draw_func = lambda x, y, size: gc.draw_marker_at_points(
                         [[x, y]], size, marker_cls.kiva_marker

--- a/chaco/colormapped_scatterplot.py
+++ b/chaco/colormapped_scatterplot.py
@@ -17,7 +17,7 @@ from numpy import (
 )
 
 # Enthought library imports
-from kiva.constants import STROKE
+from kiva.api import NO_MARKER, STROKE
 from traits.api import Dict, Enum, Float, Instance, observe
 from traitsui.api import Item, RangeEditor
 
@@ -315,16 +315,8 @@ class ColormappedScatterPlot(ScatterPlot):
 
         cmap = self.color_mapper
 
-        if hasattr(gc, "draw_marker_at_points") and self.marker not in (
-            "custom",
-            "left_triangle",
-            "right_triangle",
-            "pentagon",
-            "hexagon",
-            "hexagon2",
-            "star",
-            "cross_plus"
-        ):
+        if hasattr(gc, "draw_marker_at_points") and \
+                (marker.kiva_marker != NO_MARKER):
             # This is the fastest method: we use one of the built-in markers.
             color_bands = cmap.color_bands
             # Initial setup of drawing parameters
@@ -401,16 +393,7 @@ class ColormappedScatterPlot(ScatterPlot):
             if marker_cls != "custom":
                 if hasattr(
                     gc, "draw_marker_at_points"
-                ) and self.marker not in (
-                    "custom",
-                    "left_triangle",
-                    "right_triangle",
-                    "pentagon",
-                    "hexagon",
-                    "hexagon2",
-                    "star",
-                    "cross_plus"
-                ):
+                ) and marker_cls.kiva_marker != NO_MARKER:
                     draw_func = lambda x, y, size: gc.draw_marker_at_points(
                         [[x, y]], size, marker_cls.kiva_marker
                     )

--- a/chaco/colormapped_scatterplot.py
+++ b/chaco/colormapped_scatterplot.py
@@ -317,8 +317,13 @@ class ColormappedScatterPlot(ScatterPlot):
 
         if hasattr(gc, "draw_marker_at_points") and self.marker not in (
             "custom",
-            "circle",
-            "diamond",
+            "left_triangle",
+            "right_triangle",
+            "pentagon",
+            "hexagon",
+            "hexagon2",
+            "star",
+            "cross_plus"
         ):
             # This is the fastest method: we use one of the built-in markers.
             color_bands = cmap.color_bands

--- a/chaco/colormapped_scatterplot.py
+++ b/chaco/colormapped_scatterplot.py
@@ -390,7 +390,7 @@ class ColormappedScatterPlot(ScatterPlot):
                 marker_size = marker_size[self._cached_point_mask]
             mode = marker_cls.draw_mode
 
-            if marker_cls != "custom":
+            if self.marker != "custom":
                 if hasattr(
                     gc, "draw_marker_at_points"
                 ) and marker_cls.kiva_marker != NO_MARKER:
@@ -427,7 +427,7 @@ class ColormappedScatterPlot(ScatterPlot):
                     draw_func(x[i], y[i], size)
 
             else:
-                path = marker_cls.custom_symbol
+                path = self.custom_symbol
                 for i in range(len(x)):
                     gc.set_fill_color(colors[i])
                     gc.draw_path_at_points([[x[i], y[i]]], path, STROKE)

--- a/chaco/tests/test_colormapped_scatterplot.py
+++ b/chaco/tests/test_colormapped_scatterplot.py
@@ -86,3 +86,11 @@ class TestColormappedScatterplot(unittest.TestCase):
         """ If colormapper updated then we need to redraw """
         self.color_mapper.updated = True
         self.assertFalse(self.scatterplot.draw_valid)
+
+    # regression test for enthought/chaco#425
+    def test_non_kiva_marker(self):
+        self.scatterplot.marker = "star"
+
+        self.gc.render_component(self.scatterplot)
+        actual = self.gc.bmp_array[:, :, :]
+        self.assertFalse(alltrue(actual == 255))


### PR DESCRIPTION
fixes #425 
This can close issue #232 as well after https://github.com/enthought/enable/pull/782 is merged

 In enable:
https://github.com/enthought/enable/blob/master/enable/markers.py
some markers have a defined `kiva_marker` while others simply define an `_add_to_path` method detailing how to draw the marker manually. If the marker has `kiva_marker` we can use `draw_marker_at_points`, but if it doesn't we need to fall back to manually drawing the path via the `_add_to_path` method and calling `draw_path_at_points`.