### PR TITLE
Import color palette from chaco.api directly

### DIFF
--- a/examples/demo/advanced/javascript_hover_tools.py
+++ b/examples/demo/advanced/javascript_hover_tools.py
@@ -35,7 +35,7 @@ from scipy.special import jn
 
 # Chaco imports
 from chaco.api import ArrayPlotData, Plot, PlotGraphicsContext, LinePlot
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 
 
 # -- Constants -----------------------------------------------------------------

--- a/examples/demo/advanced/javascript_hover_tools.py
+++ b/examples/demo/advanced/javascript_hover_tools.py
@@ -34,8 +34,13 @@ from numpy import arange, searchsorted, where, array, vstack, linspace
 from scipy.special import jn
 
 # Chaco imports
-from chaco.api import ArrayPlotData, Plot, PlotGraphicsContext, LinePlot
-from chaco.api import cbrewer as COLOR_PALETTE
+from chaco.api import (
+    ArrayPlotData,
+    Plot,
+    PlotGraphicsContext,
+    LinePlot,
+    cbrewer as COLOR_PALETTE,
+)
 
 
 # -- Constants -----------------------------------------------------------------

--- a/examples/demo/basic/grid_container.py
+++ b/examples/demo/basic/grid_container.py
@@ -20,7 +20,7 @@ predictable.
 from numpy import linspace
 from scipy.special import jn
 
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 
 # Enthought library imports
 from enable.api import Component, ComponentEditor

--- a/examples/demo/basic/grid_container.py
+++ b/examples/demo/basic/grid_container.py
@@ -20,15 +20,15 @@ predictable.
 from numpy import linspace
 from scipy.special import jn
 
-from chaco.api import cbrewer as COLOR_PALETTE
-
 # Enthought library imports
 from enable.api import Component, ComponentEditor
 from traits.api import HasTraits, Instance
 from traitsui.api import Item, Group, View
 
 # Chaco imports
-from chaco.api import ArrayPlotData, GridContainer, Plot, PlotLabel
+from chaco.api import (
+    ArrayPlotData, GridContainer, Plot, PlotLabel, cbrewer as COLOR_PALETTE,
+)
 from chaco.tools.api import PanTool, ZoomTool
 
 

--- a/examples/demo/basic/grid_container_aspect_ratio.py
+++ b/examples/demo/basic/grid_container_aspect_ratio.py
@@ -9,7 +9,7 @@ change no matter how the window is resized.
 from numpy import linspace
 from scipy.special import jn
 
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 
 # Enthought library imports
 from enable.api import Component, ComponentEditor

--- a/examples/demo/basic/grid_container_aspect_ratio.py
+++ b/examples/demo/basic/grid_container_aspect_ratio.py
@@ -9,15 +9,15 @@ change no matter how the window is resized.
 from numpy import linspace
 from scipy.special import jn
 
-from chaco.api import cbrewer as COLOR_PALETTE
-
 # Enthought library imports
 from enable.api import Component, ComponentEditor
 from traits.api import HasTraits, Instance
 from traitsui.api import Item, Group, View
 
 # Chaco imports
-from chaco.api import ArrayPlotData, GridContainer, Plot
+from chaco.api import (
+    ArrayPlotData, GridContainer, Plot, cbrewer as COLOR_PALETTE,
+)
 from chaco.tools.api import PanTool, ZoomTool
 
 

--- a/examples/demo/bigdata.py
+++ b/examples/demo/bigdata.py
@@ -14,8 +14,6 @@ is also available, but panning is not.
 from scipy.special import jn
 from numpy import arange
 
-from chaco.api import cbrewer as COLOR_PALETTE
-
 # Enthought library imports
 from enable.api import Component, ComponentEditor
 from traits.api import Bool, HasTraits, Instance
@@ -24,6 +22,7 @@ from traitsui.api import Group, Item, UItem, View
 # Chaco imports
 from chaco.api import (
     OverlayPlotContainer,
+    cbrewer as COLOR_PALETTE,
     create_line_plot,
     add_default_axes,
     add_default_grids,

--- a/examples/demo/bigdata.py
+++ b/examples/demo/bigdata.py
@@ -14,7 +14,7 @@ is also available, but panning is not.
 from scipy.special import jn
 from numpy import arange
 
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 
 # Enthought library imports
 from enable.api import Component, ComponentEditor

--- a/examples/demo/canvas/data_source_button.py
+++ b/examples/demo/canvas/data_source_button.py
@@ -1,7 +1,6 @@
 from random import choice
 from traits.api import Any, Enum, HasTraits, Instance, Int, List, Str
-from chaco.api import cbrewer as COLOR_PALETTE
-from chaco.api import Plot
+from chaco.api import Plot, cbrewer as COLOR_PALETTE
 from chaco.plot_canvas_toolbar import PlotToolbarButton
 
 DEBUG = False

--- a/examples/demo/canvas/data_source_button.py
+++ b/examples/demo/canvas/data_source_button.py
@@ -1,6 +1,6 @@
 from random import choice
 from traits.api import Any, Enum, HasTraits, Instance, Int, List, Str
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 from chaco.api import Plot
 from chaco.plot_canvas_toolbar import PlotToolbarButton
 

--- a/examples/demo/data_labels.py
+++ b/examples/demo/data_labels.py
@@ -32,7 +32,7 @@ from chaco.api import (
     OverlayPlotContainer,
     DataLabel,
 )
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 from chaco.tools.api import PanTool, ZoomTool, DataLabelTool
 
 

--- a/examples/demo/data_labels.py
+++ b/examples/demo/data_labels.py
@@ -26,13 +26,13 @@ from traitsui.api import Item, View
 
 # Chaco imports
 from chaco.api import (
+    cbrewer as COLOR_PALETTE,
     create_line_plot,
     add_default_axes,
     add_default_grids,
     OverlayPlotContainer,
     DataLabel,
 )
-from chaco.api import cbrewer as COLOR_PALETTE
 from chaco.tools.api import PanTool, ZoomTool, DataLabelTool
 
 

--- a/examples/demo/edit_line.py
+++ b/examples/demo/edit_line.py
@@ -18,7 +18,7 @@ through the "zoom history".
 from numpy import linspace
 from scipy.special import jn
 
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 
 # Enthought library imports
 from enable.tools.api import DragTool

--- a/examples/demo/edit_line.py
+++ b/examples/demo/edit_line.py
@@ -18,11 +18,9 @@ through the "zoom history".
 from numpy import linspace
 from scipy.special import jn
 
-from chaco.api import cbrewer as COLOR_PALETTE
-
 # Enthought library imports
-from enable.tools.api import DragTool
 from enable.api import Component, ComponentEditor
+from enable.tools.api import DragTool
 from traits.api import HasTraits, Instance, Int, Tuple
 from traitsui.api import UItem, View
 
@@ -30,10 +28,11 @@ from traitsui.api import UItem, View
 from chaco.api import (
     add_default_axes,
     add_default_grids,
+    cbrewer as COLOR_PALETTE,
+    create_line_plot,
     OverlayPlotContainer,
     PlotLabel,
     ScatterPlot,
-    create_line_plot,
 )
 from chaco.tools.api import PanTool, ZoomTool
 

--- a/examples/demo/financial/correlations.py
+++ b/examples/demo/financial/correlations.py
@@ -20,7 +20,7 @@ from traitsui.api import Item, View, HSplit, VGroup, EnumEditor
 from chaco.api import ArrayPlotData, Plot, PlotAxis, ScatterInspectorOverlay
 from chaco.scales.api import CalendarScaleSystem
 from chaco.scales_tick_generator import ScalesTickGenerator
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 from chaco.tools.api import (
     PanTool,
     ZoomTool,

--- a/examples/demo/financial/correlations.py
+++ b/examples/demo/financial/correlations.py
@@ -17,10 +17,15 @@ from traits.api import (
 from traitsui.api import Item, View, HSplit, VGroup, EnumEditor
 
 # Chaco imports
-from chaco.api import ArrayPlotData, Plot, PlotAxis, ScatterInspectorOverlay
+from chaco.api import (
+    ArrayPlotData,
+    Plot,
+    PlotAxis,
+    ScatterInspectorOverlay,
+    cbrewer as COLOR_PALETTE,
+)
 from chaco.scales.api import CalendarScaleSystem
 from chaco.scales_tick_generator import ScalesTickGenerator
-from chaco.api import cbrewer as COLOR_PALETTE
 from chaco.tools.api import (
     PanTool,
     ZoomTool,

--- a/examples/demo/multiaxis.py
+++ b/examples/demo/multiaxis.py
@@ -15,8 +15,6 @@ Interactive behavior:
 from numpy import arange
 from scipy.special import jn
 
-from chaco.api import cbrewer as COLOR_PALETTE
-
 # Enthought library imports
 from enable.api import Component, ComponentEditor
 from traits.api import HasTraits, Instance
@@ -24,6 +22,7 @@ from traitsui.api import Item, VGroup, View
 
 # Chaco imports
 from chaco.api import (
+    cbrewer as COLOR_PALETTE,
     create_line_plot,
     add_default_axes,
     add_default_grids,

--- a/examples/demo/multiaxis.py
+++ b/examples/demo/multiaxis.py
@@ -15,7 +15,7 @@ Interactive behavior:
 from numpy import arange
 from scipy.special import jn
 
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 
 # Enthought library imports
 from enable.api import Component, ComponentEditor

--- a/examples/demo/multiaxis_using_Plot.py
+++ b/examples/demo/multiaxis_using_Plot.py
@@ -13,17 +13,20 @@ Draws some x-y line and scatter plots. On the left hand plot:
 from numpy import linspace
 from scipy.special import jn
 
-from chaco.api import cbrewer as COLOR_PALETTE
-
 # Enthought library imports
 from enable.api import Component, ComponentEditor
 from traits.api import HasTraits, Instance
 from traitsui.api import Item, Group, View
 
 # Chaco imports
-from chaco.api import ArrayPlotData, Plot
+from chaco.api import (
+    add_default_axes,
+    ArrayPlotData,
+    cbrewer as COLOR_PALETTE,
+    create_line_plot,
+    Plot,
+)
 from chaco.tools.api import BroadcasterTool, PanTool, ZoomTool
-from chaco.api import create_line_plot, add_default_axes
 
 # ===============================================================================
 # # Create the Chaco plot.

--- a/examples/demo/multiaxis_using_Plot.py
+++ b/examples/demo/multiaxis_using_Plot.py
@@ -13,7 +13,7 @@ Draws some x-y line and scatter plots. On the left hand plot:
 from numpy import linspace
 from scipy.special import jn
 
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 
 # Enthought library imports
 from enable.api import Component, ComponentEditor

--- a/examples/demo/noninteractive.py
+++ b/examples/demo/noninteractive.py
@@ -18,7 +18,7 @@ from traits.etsconfig.api import ETSConfig
 
 # Chaco imports
 from chaco.api import ArrayPlotData, Plot, PlotGraphicsContext
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 
 DPI = 72.0
 

--- a/examples/demo/noninteractive.py
+++ b/examples/demo/noninteractive.py
@@ -17,8 +17,9 @@ from scipy.special import jn
 from traits.etsconfig.api import ETSConfig
 
 # Chaco imports
-from chaco.api import ArrayPlotData, Plot, PlotGraphicsContext
-from chaco.api import cbrewer as COLOR_PALETTE
+from chaco.api import (
+    ArrayPlotData, Plot, PlotGraphicsContext, cbrewer as COLOR_PALETTE,
+)
 
 DPI = 72.0
 

--- a/examples/demo/scales_test.py
+++ b/examples/demo/scales_test.py
@@ -21,7 +21,7 @@ from numpy import linspace
 from scipy.special import jn
 from time import time
 
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 
 # Enthought library imports
 from enable.api import Component, ComponentEditor

--- a/examples/demo/scales_test.py
+++ b/examples/demo/scales_test.py
@@ -21,8 +21,6 @@ from numpy import linspace
 from scipy.special import jn
 from time import time
 
-from chaco.api import cbrewer as COLOR_PALETTE
-
 # Enthought library imports
 from enable.api import Component, ComponentEditor
 from traits.api import HasTraits, Instance
@@ -33,6 +31,7 @@ from chaco.api import (
     create_line_plot,
     OverlayPlotContainer,
     PlotLabel,
+    cbrewer as COLOR_PALETTE,
     create_scatter_plot,
     Legend,
     PlotGrid,

--- a/examples/demo/simple_line.py
+++ b/examples/demo/simple_line.py
@@ -32,11 +32,11 @@ from chaco.api import (
     add_default_grids,
     OverlayPlotContainer,
     PlotLabel,
+    cbrewer as COLOR_PALETTE,
     create_scatter_plot,
     Legend,
 )
 from chaco.tools.api import PanTool, ZoomTool, LegendTool, TraitsTool, DragZoom
-from chaco.api import cbrewer as COLOR_PALETTE
 
 
 class OverlappingPlotContainer(OverlayPlotContainer):

--- a/examples/demo/simple_line.py
+++ b/examples/demo/simple_line.py
@@ -36,7 +36,7 @@ from chaco.api import (
     Legend,
 )
 from chaco.tools.api import PanTool, ZoomTool, LegendTool, TraitsTool, DragZoom
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 
 
 class OverlappingPlotContainer(OverlayPlotContainer):

--- a/examples/demo/stacked_axis.py
+++ b/examples/demo/stacked_axis.py
@@ -10,17 +10,21 @@ Interactions are the same as in multiaxis.py
 from numpy import linspace
 from scipy.special import jn
 
-from chaco.api import cbrewer as COLOR_PALETTE
-
 # Enthought library imports
 from enable.api import Component, ComponentEditor
 from traits.api import HasTraits, Instance
 from traitsui.api import Item, Group, View
 
 # Chaco imports
-from chaco.api import HPlotContainer, OverlayPlotContainer, PlotAxis, PlotGrid
+from chaco.api import (
+    HPlotContainer,
+    OverlayPlotContainer,
+    PlotAxis,
+    PlotGrid,
+    cbrewer as COLOR_PALETTE,
+    create_line_plot,
+)
 from chaco.tools.api import BroadcasterTool, PanTool
-from chaco.api import create_line_plot
 
 # ===============================================================================
 # # Create the Chaco plot.

--- a/examples/demo/stacked_axis.py
+++ b/examples/demo/stacked_axis.py
@@ -10,7 +10,7 @@ Interactions are the same as in multiaxis.py
 from numpy import linspace
 from scipy.special import jn
 
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 
 # Enthought library imports
 from enable.api import Component, ComponentEditor

--- a/examples/demo/tornado.py
+++ b/examples/demo/tornado.py
@@ -17,8 +17,8 @@ from chaco.api import (
     LinearMapper,
     OverlayPlotContainer,
     PlotAxis,
+    cbrewer as COLOR_PALETTE,
 )
-from chaco.api import cbrewer as COLOR_PALETTE
 
 
 class PlotExample(HasTraits):

--- a/examples/demo/tornado.py
+++ b/examples/demo/tornado.py
@@ -18,7 +18,7 @@ from chaco.api import (
     OverlayPlotContainer,
     PlotAxis,
 )
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 
 
 class PlotExample(HasTraits):

--- a/examples/demo/vertical_plot.py
+++ b/examples/demo/vertical_plot.py
@@ -11,8 +11,6 @@ by modifying lines 26 and 27.
 from numpy import arange
 from scipy.special import jn
 
-from chaco.api import cbrewer as COLOR_PALETTE
-
 # Enthought library imports
 from enable.api import Component, ComponentEditor
 from traits.api import HasTraits, Instance
@@ -21,6 +19,7 @@ from chaco.api import (
     PlotLabel,
     VPlotContainer,
     HPlotContainer,
+    cbrewer as COLOR_PALETTE,
     create_line_plot,
 )
 

--- a/examples/demo/vertical_plot.py
+++ b/examples/demo/vertical_plot.py
@@ -11,7 +11,7 @@ by modifying lines 26 and 27.
 from numpy import arange
 from scipy.special import jn
 
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 
 # Enthought library imports
 from enable.api import Component, ComponentEditor

--- a/examples/user_guide/grid_plot_container.py
+++ b/examples/user_guide/grid_plot_container.py
@@ -1,8 +1,9 @@
 from numpy import linspace
 from scipy.special import jn
 
-from chaco.api import ArrayPlotData, Plot, GridPlotContainer
-from chaco.api import cbrewer as COLOR_PALETTE
+from chaco.api import (
+    ArrayPlotData, Plot, GridPlotContainer, cbrewer as COLOR_PALETTE,
+)
 from enable.api import ComponentEditor
 from traits.api import HasTraits, Instance
 from traitsui.api import Item, View

--- a/examples/user_guide/grid_plot_container.py
+++ b/examples/user_guide/grid_plot_container.py
@@ -2,7 +2,7 @@ from numpy import linspace
 from scipy.special import jn
 
 from chaco.api import ArrayPlotData, Plot, GridPlotContainer
-from chaco.example_support import COLOR_PALETTE
+from chaco.api import cbrewer as COLOR_PALETTE
 from enable.api import ComponentEditor
 from traits.api import HasTraits, Instance
 from traitsui.api import Item, View


### PR DESCRIPTION
Some of the examples import `cbrewer` from `chaco.api` as `COLOR_PALETTE` from `chaco.example_support`. I am not sure `chaco.example_support` should be a public module and I don't think we should be promoting this usage. This PR replaces all instances of `from chaco.example_support import COLOR_PALETTE` with `from chaco.api import cbrewer as COLOR_PALETTE`.