### PR TITLE
Remove backwards compatibily imports from enable

### DIFF
--- a/chaco/api.py
+++ b/chaco/api.py
@@ -481,8 +481,3 @@ from .default_colormaps import (
     Set3,
 )
 from .default_colors import cbrewer, palette11, palette14, PALETTES
-
-# Importing various symbols into the Chaco namespace for backwards
-# compatibility.  New code should directly import from Enable.
-from enable.base_tool import BaseTool, KeySpec
-from enable.markers import marker_trait

--- a/chaco/chaco_traits.py
+++ b/chaco/chaco_traits.py
@@ -14,7 +14,3 @@ box_edge_enum = Enum("left", "right", "top", "bottom")
 #: Values correspond to: top, bottom, left, right, top left, top right, bottom
 #: left, bottom right
 box_position_enum = Enum("T", "B", "L", "R", "TL", "TR", "BL", "BR")
-
-# For backwards compatibility, import LineStyle & LineStyleEditor from enable.
-# (They used to be defined here.)
-from enable.api import LineStyle, LineStyleEditor


### PR DESCRIPTION
This PR removes backwards compatibility imports from `enable` in `chaco.api` and `chaco.chaco_traits` .

fixes #638 and #628