### PR TITLE
Cleanup ci module and setup

### DIFF
--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -75,6 +75,7 @@ supported_combinations = {
 }
 
 dependencies = {
+    "coverage",
     "mock",
     "numpy",
     "pandas",
@@ -159,14 +160,14 @@ def install(runtime, toolkit, environment, source):
     )
 
     if toolkit == "pyside2":
-        additional_repositories = "--add-repository enthought/lgpl"
+        addn_repositories = "--add-repository enthought/lgpl"
     else:
-        additional_repositories = ""
+        addn_repositories = ""
 
     # edm commands to setup the development environment
     commands = [
         "edm environments create {environment} --force --version={runtime}",
-        "edm install -y -e {environment} {packages} " + additional_repositories,
+        "edm install -y -e {environment} {packages} " + addn_repositories,
         ("edm run -e {environment} -- pip install -r ci/requirements.txt"
          " --no-dependencies"),
     ]
@@ -222,8 +223,6 @@ def test(runtime, toolkit, environment):
         "edm run -e {environment} -- python -W default -m "
         "coverage run -m unittest discover -v chaco"
     ]
-
-    cwd = os.getcwd()
 
     # We run in a tempdir to avoid accidentally picking up wrong traitsui
     # code from a local dir.  We need to ensure a good .coveragerc is in
@@ -321,7 +320,8 @@ def docs(runtime, toolkit, environment):
         "Regenerating API docs in  '{environment}'".format(**parameters)
     )
     commands = [
-        "edm run -e {environment} -- python -m sphinx.ext.apidoc -e --no-toc -o "
+        "edm run -e {environment} -- "
+        + "python -m sphinx.ext.apidoc -e --no-toc -o "
         + api_path
         + " -t {templates_dir}"
         + " chaco "

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,1 +1,0 @@
-coverage

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ if not is_released:
     # write_version_py(), otherwise the import of _version messes
     # up the build under Python 3.
     fullversion = VERSION
-    chaco_version_path =  os.path.join(
+    chaco_version_path = os.path.join(
         os.path.dirname(__file__), 'chaco', '_version.py')
     if os.path.exists('.git'):
         git_rev, dev_num = git_version()
@@ -107,7 +107,6 @@ if not is_released:
             raise RuntimeError("Unable to read git_revision. Try removing "
                                "chaco/_version.py and the build directory "
                                "before building.")
-
 
         match = re.match(r'.*?\.dev(?P<dev_num>\d+)', fullversion)
         if match is None:
@@ -158,15 +157,15 @@ if __name__ == "__main__":
     extensions = [contour] + cython_extensions
 
     setup(
-        name = 'chaco',
-        version = __version__,
-        author = 'Peter Wang, et. al.',
-        author_email = 'info@enthought.com',
-        maintainer = 'ETS Developers',
-        maintainer_email = 'enthought-dev@enthought.com',
-        url = 'http://docs.enthought.com/chaco',
-        download_url = 'https://github.com/enthought/chaco',
-        classifiers = [c.strip() for c in """\
+        name='chaco',
+        version=__version__,
+        author='Peter Wang, et. al.',
+        author_email='info@enthought.com',
+        maintainer='ETS Developers',
+        maintainer_email='enthought-dev@enthought.com',
+        url='http://docs.enthought.com/chaco',
+        download_url='https://github.com/enthought/chaco',
+        classifiers=[c.strip() for c in """\
             Development Status :: 5 - Production/Stable
             Intended Audience :: Developers
             Intended Audience :: Science/Research
@@ -183,18 +182,19 @@ if __name__ == "__main__":
             Topic :: Software Development :: Libraries
             """.splitlines() if len(c.strip()) > 0],
         package_data={
-            'chaco': ['tools/toolbars/images/*.png',
-                      'layers/data/*.svg',
-                      'tests/data/PngSuite/*.png']
+            'chaco': [
+                'layers/data/*.svg',
+                'tests/data/PngSuite/*.png',
+                'tools/toolbars/images/*.png',
+            ]
         },
-        description = 'interactive 2-dimensional plotting',
-        long_description = open('README.rst').read(),
-        ext_modules = extensions,
-        include_package_data = True,
-        install_requires = __requires__,
-        license = 'BSD',
-        packages = find_packages(),
-        platforms = ["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
-        zip_safe = False,
-        use_2to3=False,
+        description='interactive 2-dimensional plotting',
+        long_description=open('README.rst').read(),
+        ext_modules=extensions,
+        include_package_data=True,
+        install_requires=__requires__,
+        license='BSD',
+        packages=find_packages(),
+        platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
+        zip_safe=False,
     )

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ per-file-ignores = */api.py:F401
 exclude =
     # The following list should eventually be empty.
     # list can be found with flake8 -q
-    setup.py
     ci/edmtool.py
     docs/source/conf.py
     chaco/quiverplot.py
@@ -150,7 +149,6 @@ exclude =
     examples/demo/coordinate_line_overlay_demo.py
     examples/demo/cursor_tool_demo.py
     examples/demo/toolbar_plot.py
-    examples/demo/vtk_example.py
     examples/demo/world_map.py
     examples/demo/financial_plot_dates.py
     examples/demo/advanced/asynchronous_updates.py
@@ -214,9 +212,6 @@ exclude =
     examples/demo/canvas/data_source_button.py
     examples/demo/canvas/plot_clone_tool.py
     examples/demo/canvas/canvas.py
-    examples/demo/vtk/spectrum.py
-    examples/demo/vtk/cmap_scatter.py
-    examples/demo/vtk/vtk_example.py
     examples/tutorials/tutorial10.py
     examples/tutorials/scipy2008/custom_tool_click.py
     examples/tutorials/scipy2008/data_chooser.py

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ per-file-ignores = */api.py:F401
 exclude =
     # The following list should eventually be empty.
     # list can be found with flake8 -q
-    ci/edmtool.py
     docs/source/conf.py
     chaco/quiverplot.py
     chaco/abstract_colormap.py

--- a/travis-ci-requirements.txt
+++ b/travis-ci-requirements.txt
@@ -1,6 +1,0 @@
-numpy
-coverage
-pillow
-git+http://github.com/nucleic/kiwi.git#egg=kiwi
-traits
-traitsui


### PR DESCRIPTION
This PR makes a number of changes to the ci module and setup script

- removes use of `use_2to3` in setup script
- fixes flake8 errors and failures in setup script
- fixes flake8 errors in ci module
- moves `coverage` from requirements file to edmtool so it can be installed via edm instead of pypi
- removes unused `travis-ci-requirements.txt`
- update tox config file to remove fixed up files from flake8 ignore list