### PR TITLE
Update "super" usage

### DIFF
--- a/chaco/abstract_controller.py
+++ b/chaco/abstract_controller.py
@@ -15,7 +15,7 @@ class AbstractController(Interactor):
 
     def __init__(self, component, *args, **kw):
         self.component = component
-        super(AbstractController, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
     def deactivate(self, component):
         """This method is called by the component when this controller is no

--- a/chaco/abstract_data_range.py
+++ b/chaco/abstract_data_range.py
@@ -54,7 +54,7 @@ class AbstractDataRange(HasTraits):
                 )
             else:
                 kwargs["sources"] = list(sources)
-        super(AbstractDataRange, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     # ------------------------------------------------------------------------
     # Abstract methods that subclasses must implement

--- a/chaco/abstract_overlay.py
+++ b/chaco/abstract_overlay.py
@@ -33,7 +33,7 @@ class AbstractOverlay(PlotComponent):
     def __init__(self, component=None, *args, **kw):
         if component is not None:
             self.component = component
-        super(AbstractOverlay, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
     def overlay(self, other_component, gc, view_bounds=None, mode="normal"):
         """Draws this component overlaid on another component."""
@@ -49,10 +49,10 @@ class AbstractOverlay(PlotComponent):
         if self.component is not None:
             self.overlay(self.component, gc, view_bounds, mode)
         else:
-            super(AbstractOverlay, self)._draw(gc, view_bounds, mode)
+            super()._draw(gc, view_bounds, mode)
 
     def _request_redraw(self):
         """Overrides Enable Component."""
         if self.component is not None:
             self.component.request_redraw()
-        super(AbstractOverlay, self)._request_redraw()
+        super()._request_redraw()

--- a/chaco/array_data_source.py
+++ b/chaco/array_data_source.py
@@ -294,7 +294,7 @@ class ArrayDataSource(AbstractDataSource):
     # ------------------------------------------------------------------------
 
     def __getstate__(self):
-        state = super(ArrayDataSource, self).__getstate__()
+        state = super().__getstate__()
         if not self.persist_data:
             state.pop("_data", None)
             state.pop("_cached_mask", None)
@@ -304,6 +304,6 @@ class ArrayDataSource(AbstractDataSource):
         return state
 
     def _post_load(self):
-        super(ArrayDataSource, self)._post_load()
+        super()._post_load()
         self._cached_bounds = ()
         self._cached_mask = None

--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -205,7 +205,7 @@ class PlotAxis(AbstractOverlay):
         self.tick_generator = DefaultTickGenerator()
         # Override init so that our component gets set last.  We want the
         # _component_changed() event handler to get run last.
-        super(PlotAxis, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if component is not None:
             self.component = component
 
@@ -235,7 +235,7 @@ class PlotAxis(AbstractOverlay):
         if self.component is not None:
             self._layout_as_overlay(*args, **kw)
         else:
-            super(PlotAxis, self)._do_layout(*args, **kw)
+            super()._do_layout(*args, **kw)
 
     def overlay(self, component, gc, view_bounds=None, mode="normal"):
         """Draws this component overlaid on another component.
@@ -686,12 +686,12 @@ class PlotAxis(AbstractOverlay):
     # ------------------------------------------------------------------------
 
     def _bounds_changed(self, old, new):
-        super(PlotAxis, self)._bounds_changed(old, new)
+        super()._bounds_changed(old, new)
         self._layout_needed = True
         self._invalidate()
 
     def _bounds_items_changed(self, event):
-        super(PlotAxis, self)._bounds_items_changed(event)
+        super()._bounds_items_changed(event)
         self._layout_needed = True
         self._invalidate()
 
@@ -709,11 +709,11 @@ class PlotAxis(AbstractOverlay):
         self._invalidate()
 
     def _position_changed(self, old, new):
-        super(PlotAxis, self)._position_changed(old, new)
+        super()._position_changed(old, new)
         self._cache_valid = False
 
     def _position_items_changed(self, event):
-        super(PlotAxis, self)._position_items_changed(event)
+        super()._position_items_changed(event)
         self._cache_valid = False
 
     def _position_changed_for_component(self):
@@ -832,7 +832,7 @@ class PlotAxis(AbstractOverlay):
     # ------------------------------------------------------------------------
 
     def __setstate__(self, state):
-        super(PlotAxis, self).__setstate__(state)
+        super().__setstate__(state)
         self._mapper_changed(None, self.mapper)
         self._reset_cache()
         self._cache_valid = False
@@ -845,7 +845,7 @@ class MinorPlotAxis(PlotAxis):
     """
 
     def __init__(self, *args, **kwargs):
-        super(MinorPlotAxis, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         if "tick_generator" not in kwargs:
             self.tick_generator = MinorTickGenerator()

--- a/chaco/barplot.py
+++ b/chaco/barplot.py
@@ -155,7 +155,7 @@ class BarPlot(AbstractPlotRenderer):
             if name in kw:
                 postponed[name] = kw.pop(name)
 
-        super(BarPlot, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
         # Set any keyword Traits that were postponed.
         self.trait_set(**postponed)
@@ -354,7 +354,7 @@ class BarPlot(AbstractPlotRenderer):
             gc.draw_path(FILL_STROKE)
 
     def _post_load(self):
-        super(BarPlot, self)._post_load()
+        super()._post_load()
 
     # ------------------------------------------------------------------------
     # Properties
@@ -438,11 +438,11 @@ class BarPlot(AbstractPlotRenderer):
         self._cache_valid = False
 
     def _bounds_changed(self, old, new):
-        super(BarPlot, self)._bounds_changed(old, new)
+        super()._bounds_changed(old, new)
         self._update_mappers()
 
     def _bounds_items_changed(self, event):
-        super(BarPlot, self)._bounds_items_changed(event)
+        super()._bounds_items_changed(event)
         self._update_mappers()
 
     def _orientation_changed(self):

--- a/chaco/base_1d_plot.py
+++ b/chaco/base_1d_plot.py
@@ -330,19 +330,19 @@ class Base1DPlot(AbstractPlotRenderer):
         self._screen_cache_valid = False
 
     def _bounds_changed(self, old, new):
-        super(Base1DPlot, self)._bounds_changed(old, new)
+        super()._bounds_changed(old, new)
         self._update_mappers()
 
     def _bounds_items_changed(self, event):
-        super(Base1DPlot, self)._bounds_items_changed(event)
+        super()._bounds_items_changed(event)
         self._update_mappers()
 
     def _position_changed(self, old, new):
-        super(Base1DPlot, self)._position_changed(old, new)
+        super()._position_changed(old, new)
         self._update_mappers()
 
     def _position_items_changed(self, event):
-        super(Base1DPlot, self)._position_items_changed(event)
+        super()._position_items_changed(event)
         self._update_mappers()
 
     def _updated_changed_for_index_mapper(self):

--- a/chaco/base_2d_plot.py
+++ b/chaco/base_2d_plot.py
@@ -87,7 +87,7 @@ class Base2DPlot(AbstractPlotRenderer):
             if trait_name in kwargs:
                 kwargs_tmp[trait_name] = kwargs.pop(trait_name)
         self.trait_set(**kwargs_tmp)
-        super(Base2DPlot, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if self.index is not None:
             self.index.observe(self._update_index_data, "data_changed")
         if self.index_mapper:
@@ -315,11 +315,11 @@ class Base2DPlot(AbstractPlotRenderer):
     # ------------------------------------------------------------------------
 
     def _bounds_changed(self, old, new):
-        super(Base2DPlot, self)._bounds_changed(old, new)
+        super()._bounds_changed(old, new)
         self._update_index_mapper()
 
     def _bounds_items_changed(self, event):
-        super(Base2DPlot, self)._bounds_items_changed(event)
+        super()._bounds_items_changed(event)
         self._update_index_mapper()
 
     def _orientation_changed(self):

--- a/chaco/base_contour_plot.py
+++ b/chaco/base_contour_plot.py
@@ -71,7 +71,7 @@ class BaseContourPlot(Base2DPlot):
     _color_map_trait = ColorTrait
 
     def __init__(self, *args, **kwargs):
-        super(BaseContourPlot, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if self.color_mapper:
             self.color_mapper.observe(self._update_color_mapper, "updated")
 

--- a/chaco/base_xy_plot.py
+++ b/chaco/base_xy_plot.py
@@ -508,7 +508,7 @@ class BaseXYPlot(AbstractPlotRenderer):
                     gc.stroke_path()
 
     def _post_load(self):
-        super(BaseXYPlot, self)._post_load()
+        super()._post_load()
         self._update_mappers()
         self.invalidate_draw()
         self._cache_valid = False
@@ -617,11 +617,11 @@ class BaseXYPlot(AbstractPlotRenderer):
         self._screen_cache_valid = False
 
     def _bounds_changed(self, old, new):
-        super(BaseXYPlot, self)._bounds_changed(old, new)
+        super()._bounds_changed(old, new)
         self._update_mappers()
 
     def _bounds_items_changed(self, event):
-        super(BaseXYPlot, self)._bounds_items_changed(event)
+        super()._bounds_items_changed(event)
         self._update_mappers()
 
     def _position_changed(self):
@@ -722,7 +722,7 @@ class BaseXYPlot(AbstractPlotRenderer):
     # ------------------------------------------------------------------------
 
     def __setstate__(self, state):
-        super(BaseXYPlot, self).__setstate__(state)
+        super().__setstate__(state)
         if self.index is not None:
             self.index.observe(self._either_data_updated, "data_changed")
         if self.value is not None:

--- a/chaco/cmap_image_plot.py
+++ b/chaco/cmap_image_plot.py
@@ -62,7 +62,7 @@ class CMapImagePlot(ImagePlot):
     # ------------------------------------------------------------------------
 
     def __init__(self, **kwargs):
-        super(CMapImagePlot, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if self.value_mapper:
             self.value_mapper.observe(self._update_value_mapper, "updated")
         if self.value:
@@ -181,11 +181,11 @@ class CMapImagePlot(ImagePlot):
         self._update_value_mapper()
 
     def _value_data_changed_fired(self):
-        super(CMapImagePlot, self)._value_data_changed_fired()
+        super()._value_data_changed_fired()
         self._mapped_image_cache_valid = False
 
     def _index_data_changed_fired(self):
-        super(CMapImagePlot, self)._index_data_changed_fired()
+        super()._index_data_changed_fired()
         self._mapped_image_cache_valid = False
 
     def _cache_full_map_changed(self):

--- a/chaco/color_bar.py
+++ b/chaco/color_bar.py
@@ -98,7 +98,7 @@ class ColorBar(AbstractPlotRenderer):
         grid_visible = kw.pop("grid_visible", True)
         axis_visible = kw.pop("axis_visible", True)
 
-        super(ColorBar, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
         if self.orientation == "h":
             if self.direction == "normal":
@@ -212,19 +212,19 @@ class ColorBar(AbstractPlotRenderer):
         self.index_mapper.range = self.color_mapper.range
 
     def _bounds_changed(self, old, new):
-        super(ColorBar, self)._bounds_changed(old, new)
+        super()._bounds_changed(old, new)
         self._update_mappers()
 
     def _bounds_items_changed(self, event):
-        super(ColorBar, self)._bounds_items_changed(event)
+        super()._bounds_items_changed(event)
         self._update_mappers()
 
     def _position_changed(self, old, new):
-        super(ColorBar, self)._position_changed(old, new)
+        super()._position_changed(old, new)
         self._update_mappers()
 
     def _position_items_changed(self, event):
-        super(ColorBar, self)._position_items_changed(event)
+        super()._position_items_changed(event)
         self._update_mappers()
 
     def _updated_changed_for_index_mapper(self):

--- a/chaco/color_mapper.py
+++ b/chaco/color_mapper.py
@@ -263,7 +263,7 @@ class ColorMapper(AbstractColormap):
         the transitions.
         """
         self._segmentdata = segmentdata
-        super(ColorMapper, self).__init__(**kwtraits)
+        super().__init__(**kwtraits)
 
     def map_screen(self, data_array):
         """Maps an array of data values to an array of colors."""

--- a/chaco/colormapped_scatterplot.py
+++ b/chaco/colormapped_scatterplot.py
@@ -32,7 +32,7 @@ class ColormappedScatterPlotView(ScatterPlotView):
     """TraitsUI View for customizing a color-mapped scatter plot."""
 
     def __init__(self):
-        super(ColormappedScatterPlotView, self).__init__()
+        super().__init__()
         vgroup = self.content
         vgroup.content[0].content.append(
             Item(
@@ -106,7 +106,7 @@ class ColormappedScatterPlot(ScatterPlot):
         if len(data_array) > 0:
             if data_array.shape[1] == 3:
                 data_array = data_array[:, :2]
-        return super(ColormappedScatterPlot, self).map_screen(data_array)
+        return super().map_screen(data_array)
 
     def _draw_plot(self, gc, view_bounds=None, mode="normal"):
         """Draws the 'plot' layer.
@@ -121,9 +121,7 @@ class ColormappedScatterPlot(ScatterPlot):
             # Take into account fill_alpha even if we are rendering with only two values
             old_color = self.color
             self.color = tuple(self.fill_alpha * array(self.color_))
-            super(ColormappedScatterPlot, self)._draw_component(
-                gc, view_bounds, mode
-            )
+            super()._draw_component(gc, view_bounds, mode)
             self.color = old_color
         else:
             colors = self._cached_data_pts[:, 2]
@@ -188,7 +186,7 @@ class ColormappedScatterPlot(ScatterPlot):
         """
         # If we don't have a color data set, then use the base class to render
         if (self.color_mapper is None) or (self.color_data is None):
-            return super(ColormappedScatterPlot, self)._render(gc, points)
+            return super()._render(gc, points)
 
         # If the GC doesn't have draw_*_at_points, then use bruteforce
         if hasattr(gc, "draw_marker_at_points") or hasattr(

--- a/chaco/colormapped_selection_overlay.py
+++ b/chaco/colormapped_selection_overlay.py
@@ -47,7 +47,7 @@ class ColormappedSelectionOverlay(AbstractOverlay):
     _old_line_width = Float(0.0)
 
     def __init__(self, component=None, **kw):
-        super(ColormappedSelectionOverlay, self).__init__(**kw)
+        super().__init__(**kw)
         self.component = component
 
     def overlay(self, component, gc, view_bounds=None, mode="normal"):

--- a/chaco/contour_line_plot.py
+++ b/chaco/contour_line_plot.py
@@ -137,7 +137,7 @@ class ContourLinePlot(BaseContourPlot):
 
     def _update_levels(self):
         """ Extends the parent method to also invalidate some other things """
-        super(ContourLinePlot, self)._update_levels()
+        super()._update_levels()
         self._contour_cache_valid = False
         self._widths_cache_valid = False
         self._styles_cache_valid = False

--- a/chaco/contour_poly_plot.py
+++ b/chaco/contour_poly_plot.py
@@ -95,7 +95,7 @@ class ContourPolyPlot(BaseContourPlot):
 
     def _update_levels(self):
         """ Extends the parent method to also invalidate some other things """
-        super(ContourPolyPlot, self)._update_levels()
+        super()._update_levels()
         self._poly_cache_valid = False
 
     def _update_colors(self):

--- a/chaco/data_range_2d.py
+++ b/chaco/data_range_2d.py
@@ -116,7 +116,7 @@ class DataRange2D(BaseDataRange):
     # ------------------------------------------------------------------------
 
     def __init__(self, *args, **kwargs):
-        super(DataRange2D, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def reset(self):
         """Resets the bounds of this range."""

--- a/chaco/data_view.py
+++ b/chaco/data_view.py
@@ -220,7 +220,7 @@ class DataView(OverlayPlotContainer):
     # ------------------------------------------------------------------------
 
     def __init__(self, **kwtraits):
-        super(DataView, self).__init__(**kwtraits)
+        super().__init__(**kwtraits)
         self._init_components()
 
         # If we are not resizable, we will not get a bounds update upon layout,
@@ -344,19 +344,19 @@ class DataView(OverlayPlotContainer):
         self.invalidate_draw()
 
     def _bounds_changed(self, old, new):
-        super(DataView, self)._bounds_changed(old, new)
+        super()._bounds_changed(old, new)
         self._update_mappers()
 
     def _bounds_items_changed(self, event):
-        super(DataView, self)._bounds_items_changed(event)
+        super()._bounds_items_changed(event)
         self._update_mappers()
 
     def _position_changed(self, old, new):
-        super(DataView, self)._position_changed(old, new)
+        super()._position_changed(old, new)
         self._update_mappers()
 
     def _position_items_changed(self, event):
-        super(DataView, self)._position_items_changed(event)
+        super()._position_items_changed(event)
         self._update_mappers()
 
     def _origin_changed(self):

--- a/chaco/function_image_data.py
+++ b/chaco/function_image_data.py
@@ -28,7 +28,7 @@ class FunctionImageData(ImageData):
     data_range = Instance(DataRange2D)
 
     def __init__(self, **kw):
-        super(FunctionImageData, self).__init__(**kw)
+        super().__init__(**kw)
         # Explicitly construct the initial data set for ImageData
         self.recalculate()
 

--- a/chaco/grid.py
+++ b/chaco/grid.py
@@ -181,7 +181,7 @@ class PlotGrid(AbstractOverlay):
     def __init__(self, **traits):
         # TODO: change this back to a factory in the instance trait some day
         self.tick_generator = DefaultTickGenerator()
-        super(PlotGrid, self).__init__(**traits)
+        super().__init__(**traits)
         self.bgcolor = "none"  # make sure we're transparent
 
     @observe("bounds.items,position.items")
@@ -201,7 +201,7 @@ class PlotGrid(AbstractOverlay):
         if self.component is not None:
             self._layout_as_overlay(*args, **kw)
         else:
-            super(PlotGrid, self).do_layout(*args, **kw)
+            super().do_layout(*args, **kw)
 
     # ------------------------------------------------------------------------
     # Private methods
@@ -445,7 +445,7 @@ class PlotGrid(AbstractOverlay):
     ### Persistence ###########################################################
 
     def _post_load(self):
-        super(PlotGrid, self)._post_load()
+        super()._post_load()
         self._mapper_changed(None, self.mapper)
         self._reset_cache()
         self._cache_valid = False

--- a/chaco/grid_data_source.py
+++ b/chaco/grid_data_source.py
@@ -60,7 +60,7 @@ class GridDataSource(AbstractDataSource):
         sort_order=("none", "none"),
         **kwargs
     ):
-        super(GridDataSource, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.set_data(xdata, ydata, sort_order)
 
     def set_data(self, xdata, ydata, sort_order=None):

--- a/chaco/grid_mapper.py
+++ b/chaco/grid_mapper.py
@@ -109,7 +109,7 @@ class GridMapper(AbstractMapper):
         # Now that the mappers are created, we can go to the normal HasTraits
         # constructor, which might set values that depend on us having a valid
         # range and mappers.
-        super(GridMapper, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def map_screen(self, data_pts):
         """map_screen(data_pts) -> screen_array

--- a/chaco/label.py
+++ b/chaco/label.py
@@ -79,7 +79,7 @@ class Label(HasTraits):
     _rot_matrix = Any()
 
     def __init__(self, **traits):
-        super(Label, self).__init__(**traits)
+        super().__init__(**traits)
         self._bounding_box = [0, 0]
 
     def get_width_height(self, gc):

--- a/chaco/layers/status_layer.py
+++ b/chaco/layers/status_layer.py
@@ -46,7 +46,7 @@ class StatusLayer(AbstractOverlay):
     fade_out_steps = Int(10)
 
     def __init__(self, component, *args, **kw):
-        super(StatusLayer, self).__init__(component, *args, **kw)
+        super().__init__(component, *args, **kw)
 
         if self.document is None:
             if self.filename == "":

--- a/chaco/multi_array_data_source.py
+++ b/chaco/multi_array_data_source.py
@@ -62,7 +62,7 @@ class MultiArrayDataSource(AbstractDataSource):
     _max_index = Int
 
     def __init__(self, data=array([]), sort_order="ascending", **traits):
-        super(MultiArrayDataSource, self).__init__(**traits)
+        super().__init__(**traits)
         self._set_data(data)
         self.sort_order = sort_order
         self.data_changed = True

--- a/chaco/overlays/container_overlay.py
+++ b/chaco/overlays/container_overlay.py
@@ -39,4 +39,4 @@ class ContainerOverlay(Container, PlotComponent):
     def _request_redraw(self):
         if self.component is not None:
             self.component.request_redraw()
-        super(ContainerOverlay, self)._request_redraw()
+        super()._request_redraw()

--- a/chaco/overlays/databox.py
+++ b/chaco/overlays/databox.py
@@ -56,7 +56,7 @@ class DataBox(AbstractOverlay):
     _updating = Bool(False)
 
     def __init__(self, *args, **kw):
-        super(DataBox, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
         if hasattr(self.component, "range2d"):
             self.component.range2d._xrange.observe(
                 self.my_component_moved, "updated"

--- a/chaco/plot.py
+++ b/chaco/plot.py
@@ -185,7 +185,7 @@ class Plot(DataView):
             title = kwtraits.pop("title")
         else:
             title = None
-        super(Plot, self).__init__(**kwtraits)
+        super().__init__(**kwtraits)
         if data is not None:
             if isinstance(data, AbstractPlotData):
                 self.data = data

--- a/chaco/plot_canvas_toolbar.py
+++ b/chaco/plot_canvas_toolbar.py
@@ -62,7 +62,7 @@ class PlotCanvasToolbar(VPlotContainer):
         # redraw event up to our overlaid component
         if self.component is not None:
             self.component.request_redraw()
-        super(PlotCanvasToolbar, self)._request_redraw()
+        super()._request_redraw()
 
 
 class PlotToolbarButton(PlotComponent, ToolbarButton):

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -280,7 +280,7 @@ class StackedPlotContainer(BasePlotContainer):
 
     # PICKLE FIXME: blocked with _pickles, but not sure that was correct.
     def __getstate__(self):
-        state = super(StackedPlotContainer, self).__getstate__()
+        state = super().__getstate__()
         if "stack_index" in state:
             del state["stack_index"]
         return state

--- a/chaco/plot_graphics_context.py
+++ b/chaco/plot_graphics_context.py
@@ -28,7 +28,7 @@ class PlotGraphicsContextMixin(object):
                 size_or_ary[1] * scale + 1,
             )
 
-        super(PlotGraphicsContextMixin, self).__init__(
+        super().__init__(
             size_or_ary, *args, **kw
         )
         self.translate_ctm(0.5, 0.5)
@@ -70,7 +70,7 @@ class PlotGraphicsContextMixin(object):
 
         Overrides Kiva GraphicsContext.
         """
-        super(PlotGraphicsContextMixin, self).clip_to_rect(
+        super().clip_to_rect(
             x - 0.5, y - 0.5, width + 1, height + 1
         )
 

--- a/chaco/plot_label.py
+++ b/chaco/plot_label.py
@@ -76,7 +76,7 @@ class PlotLabel(AbstractOverlay):
     _label = Instance(Label, args=())
 
     def __init__(self, text="", *args, **kw):
-        super(PlotLabel, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
         self.text = text
 
     def overlay(self, component, gc, view_bounds=None, mode="normal"):

--- a/chaco/plotscrollbar.py
+++ b/chaco/plotscrollbar.py
@@ -112,7 +112,7 @@ class PlotScrollBar(NativeScrollBar):
         self.request_redraw()
 
     def _scroll_position_changed(self):
-        super(PlotScrollBar, self)._scroll_position_changed()
+        super()._scroll_position_changed()
 
         # Notify our range that we've changed
         range = self.mapper.range

--- a/chaco/point_data_source.py
+++ b/chaco/point_data_source.py
@@ -76,7 +76,7 @@ class PointDataSource(ArrayDataSource):
                 + str(shape)
                 + " instead."
             )
-        super(PointDataSource, self).__init__(data, **kw)
+        super().__init__(data, **kw)
 
     def get_data(self):
         """Returns the data for this data source, or (0.0, 0.0) if it has no

--- a/chaco/polar_line_renderer.py
+++ b/chaco/polar_line_renderer.py
@@ -131,11 +131,11 @@ class PolarLineRenderer(AbstractPlotRenderer):
         self._render(gc, self._cached_data_pts)
 
     def _bounds_changed(self, old, new):
-        super(PolarLineRenderer, self)._bounds_changed(old, new)
+        super()._bounds_changed(old, new)
         self._update_mappers()
 
     def _bounds_items_changed(self, event):
-        super(PolarLineRenderer, self)._bounds_items_changed(event)
+        super()._bounds_items_changed(event)
         self._update_mappers()
 
     def _draw_default_axes(self, gc):

--- a/chaco/quiverplot.py
+++ b/chaco/quiverplot.py
@@ -46,7 +46,7 @@ class QuiverPlot(ScatterPlot):
     def _gather_points_old(self):
         # In addition to the standard scatterplot _gather_points, we need
         # to also grab the vectors that fall inside the view range
-        super(QuiverPlot, self)._gather_points_old()
+        super()._gather_points_old()
 
         if not self.index or not self.value:
             return

--- a/chaco/scales/time_scale.py
+++ b/chaco/scales/time_scale.py
@@ -427,7 +427,7 @@ class CalendarScaleSystem(ScaleSystem):
         """
         if len(scales) == 0:
             scales = HMSScales + MDYScales
-        super(CalendarScaleSystem, self).__init__(*scales, **kw)
+        super().__init__(*scales, **kw)
 
     def _get_scale(self, start, end, numticks):
         if len(self.scales) == 0:

--- a/chaco/scatterplot.py
+++ b/chaco/scatterplot.py
@@ -64,7 +64,7 @@ class ScatterPlotView(View):
             Item("marker_size", label="Size"),
             Item("color", label="Color", style="custom"),
         )
-        super(ScatterPlotView, self).__init__(vgroup)
+        super().__init__(vgroup)
         self.buttons = ["OK", "Cancel"]
 
 

--- a/chaco/scatterplot_1d.py
+++ b/chaco/scatterplot_1d.py
@@ -171,15 +171,15 @@ class ScatterPlot1D(Base1DPlot):
         return position
 
     def _bounds_changed(self, old, new):
-        super(ScatterPlot1D, self)._bounds_changed(old, new)
+        super()._bounds_changed(old, new)
         self._marker_position = self._get_marker_position()
 
     def _bounds_items_changed(self, event):
-        super(ScatterPlot1D, self)._bounds_items_changed(event)
+        super()._bounds_items_changed(event)
         self._marker_position = self._get_marker_position()
 
     def _orientation_changed(self):
-        super(ScatterPlot1D, self)._orientation_changed()
+        super()._orientation_changed()
         self._marker_position = self._get_marker_position()
 
     def _alignment_changed(self):

--- a/chaco/svg_graphics_context.py
+++ b/chaco/svg_graphics_context.py
@@ -27,7 +27,7 @@ class SVGGraphicsContext(GraphicsContext):
                 size_or_ary[1] * scale + 1,
             )
 
-        super(SVGGraphicsContext, self).__init__(size_or_ary, *args, **kw)
+        super().__init__(size_or_ary, *args, **kw)
         self.translate_ctm(0.5, 0.5)
         self.scale_ctm(scale, scale)
 

--- a/chaco/text_plot_1d.py
+++ b/chaco/text_plot_1d.py
@@ -177,19 +177,19 @@ class TextPlot1D(Base1DPlot):
         self._label_cache_valid = False
 
     def _bounds_changed(self, old, new):
-        super(TextPlot1D, self)._bounds_changed(old, new)
+        super()._bounds_changed(old, new)
         self._text_position = self._get_text_position()
 
     def _bounds_items_changed(self, event):
-        super(TextPlot1D, self)._bounds_items_changed(event)
+        super()._bounds_items_changed(event)
         self._text_position = self._get_text_position()
 
     def _orientation_changed(self):
-        super(TextPlot1D, self)._orientation_changed()
+        super()._orientation_changed()
         self._text_position = self._get_text_position()
 
     def _direction_changed(self):
-        super(TextPlot1D, self)._direction_changed()
+        super()._direction_changed()
         self._text_position = self._get_text_position()
 
     def _alignment_changed(self):

--- a/chaco/ticks.py
+++ b/chaco/ticks.py
@@ -184,7 +184,7 @@ class MinorTickGenerator(DefaultTickGenerator):
                 0, auto_interval(data_low, data_high), max_ticks=5
             )
 
-        return super(MinorTickGenerator, self).get_ticks(
+        return super().get_ticks(
             data_low,
             data_high,
             bounds_low,

--- a/chaco/toolbar_plot.py
+++ b/chaco/toolbar_plot.py
@@ -27,7 +27,7 @@ class ToolbarPlot(Plot):
         if "toolbar_class" in kw:
             self.toolbar_class = kw.pop("toolbar_class")
 
-        super(ToolbarPlot, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
         self.toolbar.component = self
         self.add_toolbar()
@@ -49,7 +49,7 @@ class ToolbarPlot(Plot):
 
     def _bounds_changed(self, old, new):
         self.toolbar.do_layout(force=True)
-        super(ToolbarPlot, self)._bounds_changed(old, new)
+        super()._bounds_changed(old, new)
 
     @observe("toolbar")
     def _update_toolbar(self, event):

--- a/chaco/tools/better_selecting_zoom.py
+++ b/chaco/tools/better_selecting_zoom.py
@@ -128,7 +128,7 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
                 event.handled = True
 
         if not event.handled:
-            super(BetterSelectingZoom, self).normal_key_pressed(event)
+            super().normal_key_pressed(event)
 
     def normal_left_down(self, event):
         """Handles the left mouse button being pressed while the tool is
@@ -443,12 +443,12 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
     # --------------------------------------------------------------------------
 
     def _prev_state_pressed(self):
-        super(BetterSelectingZoom, self)._prev_state_pressed()
+        super()._prev_state_pressed()
         # Reset the range settings
         if self._history_index == 0:
             self._reset_range_settings()
 
     def _reset_state_pressed(self):
-        super(BetterSelectingZoom, self)._reset_state_pressed()
+        super()._reset_state_pressed()
         # Reset the range settings
         self._reset_range_settings()

--- a/chaco/tools/drag_zoom.py
+++ b/chaco/tools/drag_zoom.py
@@ -71,7 +71,7 @@ class DragZoom(DragTool, BetterZoom):
     _prev_y = Float()
 
     def __init__(self, component=None, *args, **kw):
-        super(DragZoom, self).__init__(component, *args, **kw)
+        super().__init__(component, *args, **kw)
         c = component
         if c is not None:
             self._orig_screen_bounds = ((c.x, c.y), (c.x2, c.y2))

--- a/chaco/tools/line_segment_tool.py
+++ b/chaco/tools/line_segment_tool.py
@@ -85,7 +85,7 @@ class LineSegmentTool(AbstractOverlay):
     def __init__(self, component=None, **kwtraits):
         if "component" in kwtraits:
             component = kwtraits["component"]
-        super(LineSegmentTool, self).__init__(**kwtraits)
+        super().__init__(**kwtraits)
         self.component = component
         self.reset()
         self.line.line_dash = (4.0, 2.0)

--- a/chaco/tools/rectangular_selection.py
+++ b/chaco/tools/rectangular_selection.py
@@ -32,7 +32,7 @@ class RectangularSelection(LassoSelection):
         self.trait_property_changed("disjoint_selections", None)
 
     def selecting_mouse_up(self, event):
-        super(RectangularSelection, self).selecting_mouse_up(event)
+        super().selecting_mouse_up(event)
         # Clear the first click
         self.first_corner = None
 

--- a/chaco/tools/toolbars/plot_toolbar.py
+++ b/chaco/tools/toolbars/plot_toolbar.py
@@ -23,7 +23,7 @@ class PlotToolbarHover(HoverTool):
 
     def normal_mouse_move(self, event):
         self._last_xy = (event.x, event.y)
-        super(PlotToolbarHover, self).normal_mouse_move(event)
+        super().normal_mouse_move(event)
 
     def on_hover(self):
         """This gets called when all the conditions of the hover action have
@@ -76,7 +76,7 @@ class PlotToolbar(Container, AbstractOverlay):
     ############################################################
 
     def __init__(self, component=None, *args, **kw):
-        super(PlotToolbar, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
         self.component = component
 
         if component is not None and hasattr(component, "toolbar_location"):

--- a/chaco/tools/toolbars/toolbar_buttons.py
+++ b/chaco/tools/toolbars/toolbar_buttons.py
@@ -31,7 +31,7 @@ class ToolbarButton(Button):
     bounds = Property(List, observe="label, image")
 
     def __init__(self, *args, **kw):
-        super(ToolbarButton, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
         image_resource = ImageResource(self.image)
         self._image = Image(image_resource.absolute_path)

--- a/chaco/ui/popupable_plot.py
+++ b/chaco/ui/popupable_plot.py
@@ -32,4 +32,4 @@ class PopupablePlot(Plot):
     def plot(self, data, **kw):
         """Queue up the plot commands"""
         self.command_queue.append((data, kw))
-        super(PopupablePlot, self).plot(data, **kw)
+        super().plot(data, **kw)


### PR DESCRIPTION
On Python 3, we dont need to pass any arguments to `super` in the usual case where we are simply calling `super` with the defining class. This PR removes such instances.

Note that the changes were made using automated regex-based search and replace, similar to https://github.com/enthought/traits/pull/1280. After the changes were made, we checked each of the changes to ensure that we not passing a different class when calling `super` than the defining class e.g. calling `super(A, self)` in class `B` where `B` inherits from `A`.  There were a few such instances discovered in the code - which will be addressed in a later PR.