### PR TITLE
Use a plot default method instead of overriding the init method in examples

### DIFF
--- a/examples/demo/advanced/data_cube.py
+++ b/examples/demo/advanced/data_cube.py
@@ -26,13 +26,12 @@ from chaco.api import (
     ArrayPlotData,
     Plot,
     GridPlotContainer,
-    BaseTool,
     DataRange1D,
 )
 from chaco.default_colormaps import *
 from chaco.tools.api import LineInspector, ZoomTool
 from enable.example_support import DemoFrame, demo_main
-from enable.api import Window
+from enable.api import BaseTool, Window
 from traits.api import (
     Any,
     Array,

--- a/examples/demo/aspect_ratio.py
+++ b/examples/demo/aspect_ratio.py
@@ -68,8 +68,7 @@ class MyPlot(HasTraits):
         title="Aspect Ratio Example",
     )
 
-    def __init__(self, *args, **kw):
-        HasTraits.__init__(self, *args, **kw)
+    def _plot_default(self):
         numpoints = 200
         plotdata = ArrayPlotData(
             x=sort(random(numpoints)), y=random(numpoints)
@@ -78,7 +77,7 @@ class MyPlot(HasTraits):
         plot.plot(("x", "y"), type="scatter")
         plot.tools.append(PanTool(plot))
         plot.overlays.append(ZoomTool(plot))
-        self.plot = plot
+        return plot
 
     def _screen_enabled_changed(self):
         if self.screen_enabled:

--- a/examples/demo/basic/bar_plot_stacked.py
+++ b/examples/demo/basic/bar_plot_stacked.py
@@ -16,7 +16,7 @@ from chaco.api import LabelAxis, Plot, ArrayPlotData, ArrayDataSource
 
 class PlotExample(HasTraits):
 
-    plot = Instance(Plot)     
+    plot = Instance(Plot)
 
     def _plot_default(self):
         index = numpy.array([1, 2, 3, 4, 5])
@@ -72,7 +72,7 @@ class PlotExample(HasTraits):
         width=400,
         height=400,
         resizable=True,
-    ) 
+    )
 
 
 demo = PlotExample()

--- a/examples/demo/basic/bar_plot_stacked.py
+++ b/examples/demo/basic/bar_plot_stacked.py
@@ -15,17 +15,12 @@ from chaco.api import LabelAxis, Plot, ArrayPlotData, ArrayDataSource
 
 
 class PlotExample(HasTraits):
-    plot = Instance(Plot)
-    traits_view = View(
-        UItem("plot", editor=ComponentEditor()),
-        width=400,
-        height=400,
-        resizable=True,
-    )
 
-    def __init__(self, index, series_a, series_b, series_c, **kw):
-        super(PlotExample, self).__init__(**kw)
+    plot = Instance(Plot)     
 
+    def _plot_default(self):
+        index = numpy.array([1, 2, 3, 4, 5])
+        series_a, series_b, series_c = (index * 10, index * 5, index * 2)
         # Stack them up
         series_c = series_c + series_b + series_a
         series_b = series_b + series_a
@@ -34,18 +29,18 @@ class PlotExample(HasTraits):
         plot_data.set_data("series_a", series_a)
         plot_data.set_data("series_b", series_b)
         plot_data.set_data("series_c", series_c)
-        self.plot = Plot(plot_data)
-        self.plot.plot(
+        plot = Plot(plot_data)
+        plot.plot(
             ("index", "series_a"), type="bar", bar_width=0.8, color="auto"
         )
-        self.plot.plot(
+        plot.plot(
             ("index", "series_b"),
             type="bar",
             bar_width=0.8,
             color="auto",
             starting_value=ArrayDataSource(series_a),
         )
-        self.plot.plot(
+        plot.plot(
             ("index", "series_c"),
             type="bar",
             bar_width=0.8,
@@ -54,11 +49,11 @@ class PlotExample(HasTraits):
         )
 
         # set the plot's value range to 0, otherwise it may pad too much
-        self.plot.value_range.low = 0
+        plot.value_range.low = 0
 
         # replace the index values with some nicer labels
         label_axis = LabelAxis(
-            self.plot,
+            plot,
             orientation="bottom",
             title="Months",
             positions=list(range(1, 10)),
@@ -66,13 +61,21 @@ class PlotExample(HasTraits):
             small_haxis_style=True,
         )
 
-        self.plot.underlays.remove(self.plot.index_axis)
-        self.plot.index_axis = label_axis
-        self.plot.underlays.append(label_axis)
+        plot.underlays.remove(plot.index_axis)
+        plot.index_axis = label_axis
+        plot.underlays.append(label_axis)
+
+        return plot
+
+    traits_view = View(
+        UItem("plot", editor=ComponentEditor()),
+        width=400,
+        height=400,
+        resizable=True,
+    ) 
 
 
-index = numpy.array([1, 2, 3, 4, 5])
-demo = PlotExample(index, index * 10, index * 5, index * 2)
+demo = PlotExample()
 
 if __name__ == "__main__":
     demo.configure_traits()

--- a/examples/demo/depth.py
+++ b/examples/demo/depth.py
@@ -6,7 +6,7 @@ import numpy
 from chaco.api import ToolbarPlot, ArrayPlotData
 from chaco.tools.api import LineInspector
 from enable.api import ComponentEditor
-from traits.api import Array, HasTraits, Instance
+from traits.api import HasTraits, Instance
 from traitsui.api import UItem, View
 
 
@@ -14,10 +14,6 @@ class MyPlot(HasTraits):
     """Plot where depth is the index such that the plot is vertical
     and the origin is the upper left
     """
-
-    data_series = Array()
-
-    depth = Array()
 
     plot = Instance(ToolbarPlot)
 
@@ -29,6 +25,8 @@ class MyPlot(HasTraits):
     )
 
     def _plot_default(self):
+        depth = numpy.arange(1.0, 100.0, 0.1)
+        data_series = numpy.sin(depth) + depth / 10.0
         plot_data = ArrayPlotData(index=depth)
         plot_data.set_data("data_series", data_series)
         plot = ToolbarPlot(plot_data, orientation="v", origin="top left")
@@ -41,9 +39,5 @@ class MyPlot(HasTraits):
         return plot
 
 
-
-depth = numpy.arange(1.0, 100.0, 0.1)
-data_series = numpy.sin(depth) + depth / 10.0
-
-my_plot = MyPlot(depth=depth, data_series=data_series)
+my_plot = MyPlot()
 my_plot.configure_traits()

--- a/examples/demo/depth.py
+++ b/examples/demo/depth.py
@@ -6,7 +6,7 @@ import numpy
 from chaco.api import ToolbarPlot, ArrayPlotData
 from chaco.tools.api import LineInspector
 from enable.api import ComponentEditor
-from traits.api import HasTraits, Instance
+from traits.api import Array, HasTraits, Instance
 from traitsui.api import UItem, View
 
 
@@ -14,6 +14,10 @@ class MyPlot(HasTraits):
     """Plot where depth is the index such that the plot is vertical
     and the origin is the upper left
     """
+
+    data_series = Array()
+
+    depth = Array()
 
     plot = Instance(ToolbarPlot)
 
@@ -24,21 +28,22 @@ class MyPlot(HasTraits):
         resizable=True,
     )
 
-    def __init__(self, depth, data_series, **kw):
-        super(MyPlot, self).__init__(**kw)
-
+    def _plot_default(self):
         plot_data = ArrayPlotData(index=depth)
         plot_data.set_data("data_series", data_series)
-        self.plot = ToolbarPlot(plot_data, orientation="v", origin="top left")
-        line = self.plot.plot(("index", "data_series"))[0]
+        plot = ToolbarPlot(plot_data, orientation="v", origin="top left")
+        line = plot.plot(("index", "data_series"))[0]
 
         line_inspector = LineInspector(component=line, write_metadata=True)
         line.tools.append(line_inspector)
         line.overlays.append(line_inspector)
 
+        return plot
+
+
 
 depth = numpy.arange(1.0, 100.0, 0.1)
 data_series = numpy.sin(depth) + depth / 10.0
 
-my_plot = MyPlot(depth, data_series)
+my_plot = MyPlot(depth=depth, data_series=data_series)
 my_plot.configure_traits()

--- a/examples/demo/domain_limits.py
+++ b/examples/demo/domain_limits.py
@@ -9,7 +9,7 @@ from chaco.plot import Plot, ArrayPlotData
 from chaco.api import ToolbarPlot
 from chaco.tools.api import PanTool, ZoomTool
 from enable.api import ComponentEditor
-from traits.api import Instance, HasTraits
+from traits.api import Array, Instance, HasTraits
 from traitsui.api import View, Item
 
 
@@ -28,14 +28,18 @@ class ExamplePlotApp(HasTraits):
         resizable=True,
     )
 
-    def __init__(self, index, series1, series2, **kw):
-        super(ExamplePlotApp, self).__init__(**kw)
+
+    def _plot_default(self):
+        index = numpy.arange(1.0, 10.0, 0.01)
+        series1 = (100.0 + index) / (100.0 - 20 * index ** 2 + 5.0 * index ** 4)
+        series2 = (100.0 + index) / (100.0 - 20 * index ** 2 + 5.0 * index ** 3)
+
         plot_data = ArrayPlotData(index=index)
         plot_data.set_data("series1", series1)
         plot_data.set_data("series2", series2)
 
-        self.plot = ToolbarPlot(plot_data)
-        line_plot = self.plot.plot(("index", "series1"), color="auto")[0]
+        plot = ToolbarPlot(plot_data)
+        line_plot = plot.plot(("index", "series1"), color="auto")[0]
 
         # Add pan and zoom tools
         line_plot.tools.append(PanTool(line_plot))
@@ -44,11 +48,11 @@ class ExamplePlotApp(HasTraits):
         # Set the domain_limits
         line_plot.index_mapper.domain_limits = (3.3, 6.6)
 
+        return plot
 
-index = numpy.arange(1.0, 10.0, 0.01)
-series1 = (100.0 + index) / (100.0 - 20 * index ** 2 + 5.0 * index ** 4)
-series2 = (100.0 + index) / (100.0 - 20 * index ** 2 + 5.0 * index ** 3)
-demo = ExamplePlotApp(index, series1, series2)
+
+
+demo = ExamplePlotApp()
 
 if __name__ == "__main__":
     demo.configure_traits()

--- a/examples/demo/domain_limits.py
+++ b/examples/demo/domain_limits.py
@@ -9,7 +9,7 @@ from chaco.plot import Plot, ArrayPlotData
 from chaco.api import ToolbarPlot
 from chaco.tools.api import PanTool, ZoomTool
 from enable.api import ComponentEditor
-from traits.api import Array, Instance, HasTraits
+from traits.api import Instance, HasTraits
 from traitsui.api import View, Item
 
 

--- a/examples/demo/domain_limits.py
+++ b/examples/demo/domain_limits.py
@@ -19,8 +19,8 @@ class ExamplePlotApp(HasTraits):
 
     def _plot_default(self):
         index = numpy.arange(1.0, 10.0, 0.01)
-        series1 = (100.0 + index) / (100.0 - 20 * index ** 2 + 5.0 * index ** 4)
-        series2 = (100.0 + index) / (100.0 - 20 * index ** 2 + 5.0 * index ** 3)
+        series1 = (100.0 + index) / (100.0 - 20 * index ** 2 + 5.0 * index**4)
+        series2 = (100.0 + index) / (100.0 - 20 * index ** 2 + 5.0 * index**3)
 
         plot_data = ArrayPlotData(index=index)
         plot_data.set_data("series1", series1)

--- a/examples/demo/domain_limits.py
+++ b/examples/demo/domain_limits.py
@@ -17,18 +17,6 @@ class ExamplePlotApp(HasTraits):
 
     plot = Instance(Plot)
 
-    traits_view = View(
-        Item(
-            "plot",
-            editor=ComponentEditor(),
-            width=600,
-            height=600,
-            show_label=False,
-        ),
-        resizable=True,
-    )
-
-
     def _plot_default(self):
         index = numpy.arange(1.0, 10.0, 0.01)
         series1 = (100.0 + index) / (100.0 - 20 * index ** 2 + 5.0 * index ** 4)
@@ -50,6 +38,16 @@ class ExamplePlotApp(HasTraits):
 
         return plot
 
+    traits_view = View(
+        Item(
+            "plot",
+            editor=ComponentEditor(),
+            width=600,
+            height=600,
+            show_label=False,
+        ),
+        resizable=True,
+    )
 
 
 demo = ExamplePlotApp()

--- a/examples/demo/multi_line_plot.py
+++ b/examples/demo/multi_line_plot.py
@@ -19,13 +19,6 @@ class MyPlot(HasTraits):
 
     plot = Instance(Plot)
 
-    traits_view = View(
-        UItem("plot", editor=ComponentEditor()),
-        width=700,
-        height=600,
-        resizable=True,
-    )
-
     def _plot_default(self):
         x_index = np.arange(0, 100, 1)
         y_index = np.arange(0, 1000, 10)
@@ -59,6 +52,13 @@ class MyPlot(HasTraits):
         plot.add(mlp)
 
         return plot
+
+    traits_view = View(
+        UItem("plot", editor=ComponentEditor()),
+        width=700,
+        height=600,
+        resizable=True,
+    )
 
 my_plot = MyPlot()
 my_plot.configure_traits()

--- a/examples/demo/multi_line_plot.py
+++ b/examples/demo/multi_line_plot.py
@@ -60,5 +60,6 @@ class MyPlot(HasTraits):
         resizable=True,
     )
 
+
 my_plot = MyPlot()
 my_plot.configure_traits()

--- a/examples/demo/multi_line_plot.py
+++ b/examples/demo/multi_line_plot.py
@@ -26,8 +26,13 @@ class MyPlot(HasTraits):
         resizable=True,
     )
 
-    def __init__(self, x_index, y_index, data, **kw):
-        super(MyPlot, self).__init__(**kw)
+    def _plot_default(self):
+        x_index = np.arange(0, 100, 1)
+        y_index = np.arange(0, 1000, 10)
+        data = np.sin(np.arange(0, x_index.size * y_index.size))
+        # add a random chunk of nan values
+        data[1532:1588] = np.nan
+        data = data.reshape(x_index.size, y_index.size)
 
         # Create the data source for the MultiLinePlot.
         ds = MultiArrayDataSource(data=data)
@@ -48,19 +53,12 @@ class MyPlot(HasTraits):
             value=ds,
             global_max=np.nanmax(data),
             global_min=np.nanmin(data),
-            **kw
         )
 
-        self.plot = Plot()
-        self.plot.add(mlp)
+        plot = Plot()
+        plot.add(mlp)
 
+        return plot
 
-x_index = np.arange(0, 100, 1)
-y_index = np.arange(0, 1000, 10)
-data = np.sin(np.arange(0, x_index.size * y_index.size))
-# add a random chunk of nan values
-data[1532:1588] = np.nan
-data = data.reshape(x_index.size, y_index.size)
-
-my_plot = MyPlot(x_index, y_index, data)
+my_plot = MyPlot()
 my_plot.configure_traits()

--- a/examples/demo/status_overlay.py
+++ b/examples/demo/status_overlay.py
@@ -21,7 +21,7 @@ class MyPlot(HasTraits):
     error_button = Button("Error")
     warn_button = Button("Warning")
     no_problem_button = Button("No problem")
-        
+
     def _plot_default(self):
         index = numpy.array([1, 2, 3, 4, 5])
         data_series = index ** 2
@@ -68,7 +68,7 @@ class MyPlot(HasTraits):
         if self.status_overlay in self.plot.overlays:
             # fade_out will remove the overlay when its done
             self.status_overlay.fade_out()
-    
+
     traits_view = View(
         HGroup(
             UItem("error_button"),

--- a/examples/demo/status_overlay.py
+++ b/examples/demo/status_overlay.py
@@ -21,26 +21,17 @@ class MyPlot(HasTraits):
     error_button = Button("Error")
     warn_button = Button("Warning")
     no_problem_button = Button("No problem")
-
-    traits_view = View(
-        HGroup(
-            UItem("error_button"),
-            UItem("warn_button"),
-            UItem("no_problem_button"),
-        ),
-        UItem("plot", editor=ComponentEditor()),
-        width=700,
-        height=600,
-        resizable=True,
-    )
-
-    def __init__(self, index, data_series, **kw):
-        super(MyPlot, self).__init__(**kw)
+        
+    def _plot_default(self):
+        index = numpy.array([1, 2, 3, 4, 5])
+        data_series = index ** 2
 
         plot_data = ArrayPlotData(index=index)
         plot_data.set_data("data_series", data_series)
-        self.plot = Plot(plot_data)
-        self.plot.plot(("index", "data_series"))
+        plot = Plot(plot_data)
+        plot.plot(("index", "data_series"))
+
+        return plot
 
     def _error_button_fired(self, event):
         """removes the old overlay and replaces it with
@@ -77,10 +68,19 @@ class MyPlot(HasTraits):
         if self.status_overlay in self.plot.overlays:
             # fade_out will remove the overlay when its done
             self.status_overlay.fade_out()
+    
+    traits_view = View(
+        HGroup(
+            UItem("error_button"),
+            UItem("warn_button"),
+            UItem("no_problem_button"),
+        ),
+        UItem("plot", editor=ComponentEditor()),
+        width=700,
+        height=600,
+        resizable=True,
+    )
 
 
-index = numpy.array([1, 2, 3, 4, 5])
-data_series = index ** 2
-
-my_plot = MyPlot(index, data_series)
+my_plot = MyPlot()
 my_plot.configure_traits()

--- a/examples/demo/toolbar_plot.py
+++ b/examples/demo/toolbar_plot.py
@@ -23,6 +23,21 @@ class ExamplePlotApp(HasTraits):
 
     plot = Instance(Plot)
 
+    def _plot_default(self):
+        index = numpy.arange(1.0, 10.0, 0.01)
+        series1 = (100.0 + index) / (100.0 - 20 * index ** 2 + 5.0 * index**4)
+        series2 = (100.0 + index) / (100.0 - 20 * index ** 2 + 5.0 * index**3)
+
+        plot_data = ArrayPlotData(index=index)
+        plot_data.set_data("series1", series1)
+        plot_data.set_data("series2", series2)
+
+        plot = ToolbarPlot(plot_data)
+        plot.plot(("index", "series1"), color="auto")
+        plot.plot(("index", "series2"), color="auto")
+
+        return plot
+
     traits_view = View(
         Item(
             "plot",
@@ -34,21 +49,8 @@ class ExamplePlotApp(HasTraits):
         resizable=True,
     )
 
-    def __init__(self, index, series1, series2, **kw):
-        super(ExamplePlotApp, self).__init__(**kw)
-        plot_data = ArrayPlotData(index=index)
-        plot_data.set_data("series1", series1)
-        plot_data.set_data("series2", series2)
 
-        self.plot = ToolbarPlot(plot_data)
-        self.plot.plot(("index", "series1"), color="auto")
-        self.plot.plot(("index", "series2"), color="auto")
-
-
-index = numpy.arange(1.0, 10.0, 0.01)
-series1 = (100.0 + index) / (100.0 - 20 * index ** 2 + 5.0 * index ** 4)
-series2 = (100.0 + index) / (100.0 - 20 * index ** 2 + 5.0 * index ** 3)
-demo = ExamplePlotApp(index, series1, series2)
+demo = ExamplePlotApp()
 
 if __name__ == "__main__":
     demo.configure_traits()

--- a/examples/demo/xray_plot.py
+++ b/examples/demo/xray_plot.py
@@ -152,25 +152,25 @@ class PlotExample(HasTraits):
 
     plot = Instance(Plot)
 
-    traits_view = View(
-        Item("plot", editor=ComponentEditor()), width=600, height=600
-    )
-
-    def __init__(self, index, value, *args, **kw):
-        super(PlotExample, self).__init__(*args, **kw)
+    def _plot_default(self):
+        index = numpy.arange(0, 25, 0.25)
+        value = numpy.sin(index) + numpy.arange(0, 10, 0.1)
 
         plot_data = ArrayPlotData(index=index)
         plot_data.set_data("value", value)
 
-        self.plot = Plot(plot_data)
-        line = self.plot.plot(("index", "value"))[0]
+        plot = Plot(plot_data)
+        line = plot.plot(("index", "value"))[0]
 
         line.overlays.append(XRayOverlay(line))
         line.tools.append(BoxSelectTool(line))
 
+        return plot
 
-index = numpy.arange(0, 25, 0.25)
-value = numpy.sin(index) + numpy.arange(0, 10, 0.1)
+    traits_view = View(
+        Item("plot", editor=ComponentEditor()), width=600, height=600
+    )
 
-example = PlotExample(index, value)
+
+example = PlotExample()
 example.configure_traits()


### PR DESCRIPTION
Part of #658 

This PR replaces the `__init__` method in many examples with the `_plot_default` approach.  This is not all the examples, but the remaining can be done in a follow up PR.