### PR TITLE
Use a plot default method instead of overriding the init method in examples part 2

### DIFF
--- a/examples/demo/advanced/spec_waterfall.py
+++ b/examples/demo/advanced/spec_waterfall.py
@@ -231,9 +231,8 @@ class Demo(HasTraits):
         handler=DemoHandler,
     )
 
-    def __init__(self, **traits):
-        super(Demo, self).__init__(**traits)
-        self.plot = _create_plot_component(self.controller)
+    def _plot_default(self):
+        return _create_plot_component(self.controller)
 
     def edit_traits(self, *args, **kws):
         # Start up the timer! We should do this only when the demo actually

--- a/examples/demo/advanced/spec_waterfall.py
+++ b/examples/demo/advanced/spec_waterfall.py
@@ -102,7 +102,7 @@ def _create_plot_component(obj):
     # Setup the spectrum plot
     frequencies = linspace(0.0, float(SAMPLING_RATE) / 2, num=NUM_SAMPLES / 2)
     obj.spectrum_data = ArrayPlotData(frequency=frequencies)
-    empty_amplitude = zeros(NUM_SAMPLES / 2)
+    empty_amplitude = zeros(NUM_SAMPLES // 2)
     obj.spectrum_data.set_data("amplitude", empty_amplitude)
 
     obj.spectrum_plot = Plot(obj.spectrum_data)
@@ -135,7 +135,7 @@ def _create_plot_component(obj):
     time_range.high = 0.2
 
     # Spectrogram plot
-    values = [zeros(NUM_SAMPLES / 2) for i in range(SPECTROGRAM_LENGTH)]
+    values = [zeros(NUM_SAMPLES // 2) for i in range(SPECTROGRAM_LENGTH)]
     p = WaterfallRenderer(
         index=spec_renderer.index,
         values=values,
@@ -178,7 +178,7 @@ def get_audio_data():
     audio_data = fromstring(stream.read(NUM_SAMPLES), dtype=short)
     stream.close()
     normalized_data = audio_data / 32768.0
-    return (abs(fft(normalized_data))[: NUM_SAMPLES / 2], normalized_data)
+    return (abs(fft(normalized_data))[: NUM_SAMPLES // 2], normalized_data)
 
 
 # HasTraits class that supplies the callable for the timer event.

--- a/examples/demo/advanced/spectrum.py
+++ b/examples/demo/advanced/spectrum.py
@@ -181,9 +181,8 @@ class Demo(HasTraits):
         handler=DemoHandler,
     )
 
-    def __init__(self, **traits):
-        super(Demo, self).__init__(**traits)
-        self.plot = _create_plot_component(self.controller)
+    def _plot_default(self):
+        return _create_plot_component(self.controller)
 
     def edit_traits(self, *args, **kws):
         # Start up the timer! We should do this only when the demo actually

--- a/examples/demo/basic/image_from_file.py
+++ b/examples/demo/basic/image_from_file.py
@@ -87,24 +87,6 @@ class DemoView(HasTraits):
     # Public 'DemoView' interface
     # ---------------------------------------------------------------------------
 
-    def __init__(self, *args, **kwargs):
-        super(DemoView, self).__init__(*args, **kwargs)
-
-        # Create the plot object, set some options, and add some tools
-        plot = self.plot = Plot(self.pd, default_origin="top left")
-        plot.x_axis.orientation = "top"
-        plot.padding = 50
-        plot.padding_top = 75
-        plot.tools.append(PanTool(plot))
-        zoom = ZoomTool(component=plot, tool_mode="box", always_on=False)
-        plot.overlays.append(zoom)
-
-        # Load the default image
-        self._load()
-
-        # Plot the image plot with this image
-        self.plot.img_plot("imagedata")
-
     def default_traits_view(self):
         """Returns the default view to use for this class."""
         # NOTE: I moved the view to this method so we can declare a handler
@@ -138,6 +120,24 @@ class DemoView(HasTraits):
     # Private 'DemoView' interface
     # ---------------------------------------------------------------------------
 
+    def _plot_default(self):
+        # Create the plot object, set some options, and add some tools
+        plot = Plot(self.pd, default_origin="top left")
+        plot.x_axis.orientation = "top"
+        plot.padding = 50
+        plot.padding_top = 75
+        plot.tools.append(PanTool(plot))
+        zoom = ZoomTool(component=plot, tool_mode="box", always_on=False)
+        plot.overlays.append(zoom)
+
+        # Load the default image
+        self._load(plot)
+
+        # Plot the image plot with this image
+        plot.img_plot("imagedata")
+
+        return plot
+
     def _save(self):
         # Create a graphics context of the right size
         win_size = self.plot.outer_bounds
@@ -149,7 +149,9 @@ class DemoView(HasTraits):
         # Save out to the user supplied filename
         plot_gc.save(self._save_file)
 
-    def _load(self):
+    def _load(self, plot=None):
+        if plot is None:
+            plot = self.plot
         # Load the image with the user supplied filename
         image = ImageData.fromfile(self._load_file)
 
@@ -158,8 +160,8 @@ class DemoView(HasTraits):
         self.pd.set_data("imagedata", image._data)
 
         # Set the title and redraw
-        self.plot.title = os.path.basename(self._load_file)
-        self.plot.request_redraw()
+        plot.title = os.path.basename(self._load_file)
+        plot.request_redraw()
 
 
 # -------------------------------------------------------------------------------

--- a/examples/demo/canvas/cliptest.py
+++ b/examples/demo/canvas/cliptest.py
@@ -27,9 +27,6 @@ class Box(Component):
 
     resizable = ""
 
-    def __init__(self, *args, **kw):
-        Component.__init__(self, *args, **kw)
-
     def _draw_mainlayer(self, gc, view_bounds=None, mode="default"):
         with gc:
             gc.set_fill_color(self.fill_color)
@@ -70,7 +67,7 @@ class Box(Component):
 
 
 class MainFrame(DemoFrame):
-    def _create_window(self):
+    def _create_component(self):
         a = Box(bounds=[75, 75], position=[50, 50], fill_color=(1, 0, 0, 1))
         b = Box(bounds=[75, 75], position=[200, 50], fill_color=(0, 1, 0, 1))
         c = Box(bounds=[75, 75], position=[50, 200], fill_color=(0, 0, 1, 1))
@@ -90,7 +87,7 @@ class MainFrame(DemoFrame):
         cont.tools.append(MoveTool(cont, drag_button="left"))
         cont2.tools.append(MoveTool(cont2, drag_button="left"))
         outer = Container(cont, cont2, fit_window=True)
-        return Window(self, -1, component=outer)
+        return outer
 
 
 if __name__ == "__main__":

--- a/examples/demo/updating_plot/updating_plot2.py
+++ b/examples/demo/updating_plot/updating_plot2.py
@@ -37,12 +37,10 @@ PLOT_SIZE = 250
 
 class AnimatedPlot(HasTraits):
     x_values = Array()
-    x_values = Array()
+    y_values = Array()
     color = Str()
 
     plot = Instance(Component)
-
-        
 
     def _plot_default(self):
         self.numpoints = len(self.x_values)

--- a/examples/demo/updating_plot/updating_plot2.py
+++ b/examples/demo/updating_plot/updating_plot2.py
@@ -61,7 +61,7 @@ class AnimatedPlot(HasTraits):
 
         plot.unified_draw = True
 
-        self.current_index = int(self.numpoints / 2)
+        self.current_index = self.numpoints // 2
         self.increment = 2
 
         return plot
@@ -74,8 +74,8 @@ class AnimatedPlot(HasTraits):
         self.current_index += self.increment
         if self.current_index > self.numpoints:
             self.current_index = self.numpoints
-        self.plot.index.set_data(self.x_values[: int(self.current_index)])
-        self.plot.value.set_data(self.y_values[: int(self.current_index)])
+        self.plot.index.set_data(self.x_values[: self.current_index])
+        self.plot.value.set_data(self.y_values[: self.current_index])
         self.plot.request_redraw()
 
 

--- a/examples/demo/updating_plot/updating_plot3.py
+++ b/examples/demo/updating_plot/updating_plot3.py
@@ -9,9 +9,9 @@ from numpy import arange
 from scipy.special import jn
 
 # Enthought library imports
-from enable.api import Window
+from enable.api import Component
 from enable.example_support import DemoFrame, demo_main
-from traits.api import HasTraits
+from traits.api import Any, Array, HasTraits, Instance, Str
 from pyface.timer.api import Timer
 
 # Chaco imports
@@ -32,23 +32,28 @@ PLOT_SIZE = 250
 
 
 class AnimatedPlot(HasTraits):
-    def __init__(self, x, y, color="blue", bgcolor="white"):
-        self.y_values = y[:]
-        if type(x) == ArrayDataSource:
-            self.x_values = x.get_data()[:]
+
+    x_values = Any()  # Array or ArraryDataSource
+    y_values = Array()
+    color = Str()
+
+    plot = Instance(Component)
+
+    def _plot_default(self):
+        if type(self.x_values) == ArrayDataSource:
+            self.x_values = self.x_values.get_data()[:]
             plot = create_line_plot(
-                (x, self.y_values),
-                color=color,
-                bgcolor=bgcolor,
+                (self.x_values, self.y_values),
+                color=self.color,
+                bgcolor="white",
                 add_grid=True,
                 add_axis=True,
             )
         else:
-            self.x_values = x[:]
             plot = create_line_plot(
                 (self.x_values, self.y_values),
-                color=color,
-                bgcolor=bgcolor,
+                color=self.color,
+                bgcolor="white",
                 add_grid=True,
                 add_axis=True,
             )
@@ -61,10 +66,11 @@ class AnimatedPlot(HasTraits):
         plot.tools.append(MoveTool(plot))
         plot.overlays.append(ZoomTool(plot, tool_mode="box", always_on=False))
 
-        self.plot = plot
         self.numpoints = len(self.x_values)
-        self.current_index = self.numpoints / 2
+        self.current_index = int(self.numpoints / 2)
         self.increment = 2
+
+        return plot
 
     def timer_tick(self):
         if self.current_index <= self.numpoints / 3:
@@ -80,7 +86,7 @@ class AnimatedPlot(HasTraits):
 
 
 class PlotFrame(DemoFrame):
-    def _create_window(self):
+    def _create_component(self):
         numpoints = 50
         low = -5
         high = 15.0
@@ -93,12 +99,16 @@ class PlotFrame(DemoFrame):
         self.animated_plots = []
         for i, color in enumerate(COLOR_PALETTE):
             if not common_index:
-                animated_plot = AnimatedPlot(x, jn(i, x), color)
+                animated_plot = AnimatedPlot(
+                    x_values=x, y_values=jn(i, x), color=color
+                )
                 common_index = animated_plot.plot.index
                 index_range = animated_plot.plot.index_mapper.range
                 value_range = animated_plot.plot.value_mapper.range
             else:
-                animated_plot = AnimatedPlot(common_index, jn(i, x), color)
+                animated_plot = AnimatedPlot(
+                    x_values=common_index, y_values=jn(i, x), color=color
+                )
                 animated_plot.plot.index_mapper.range = index_range
                 animated_plot.plot.value_mapper.range = value_range
             container.add(animated_plot.plot)
@@ -112,7 +122,7 @@ class PlotFrame(DemoFrame):
 
         self.timer = Timer(100.0, self.onTimer)
         self.container = container
-        return Window(self, -1, component=container)
+        return container
 
     def onTimer(self, *args):
         for plot in self.animated_plots:

--- a/examples/demo/updating_plot/updating_plot3.py
+++ b/examples/demo/updating_plot/updating_plot3.py
@@ -67,7 +67,7 @@ class AnimatedPlot(HasTraits):
         plot.overlays.append(ZoomTool(plot, tool_mode="box", always_on=False))
 
         self.numpoints = len(self.x_values)
-        self.current_index = int(self.numpoints / 2)
+        self.current_index = self.numpoints // 2
         self.increment = 2
 
         return plot

--- a/examples/demo/updating_plot/updating_plot4.py
+++ b/examples/demo/updating_plot/updating_plot4.py
@@ -12,9 +12,9 @@ from numpy import arange
 from scipy.special import jn
 
 # Enthought library imports
-from enable.api import Window
+from enable.api import Component
 from enable.example_support import DemoFrame, demo_main
-from traits.api import HasTraits
+from traits.api import Any, Array, Enum, HasTraits, Instance, Str
 from pyface.timer.api import Timer
 
 # Chaco imports
@@ -35,27 +35,32 @@ PLOT_SIZE = 250
 
 
 class AnimatedPlot(HasTraits):
-    def __init__(self, x, y, color="blue", bgcolor="white", orientation="h"):
-        self.y_values = y[:]
-        if type(x) == ArrayDataSource:
-            self.x_values = x.get_data()[:]
-            plot = create_line_plot(
-                (x, self.y_values),
-                color=color,
-                bgcolor=bgcolor,
-                add_grid=True,
-                add_axis=True,
-                orientation=orientation,
-            )
-        else:
-            self.x_values = x[:]
+    x_values = Any()  # Array or ArraryDataSource
+    y_values = Array()
+    color = Str()
+    orientation = Enum("h", "v")
+
+    plot = Instance(Component)
+
+    def _plot_default(self):
+        if type(self.x_values) == ArrayDataSource:
+            self.x_values = self.x_values.get_data()[:]
             plot = create_line_plot(
                 (self.x_values, self.y_values),
-                color=color,
-                bgcolor=bgcolor,
+                color=self.color,
+                bgcolor="white",
                 add_grid=True,
                 add_axis=True,
-                orientation=orientation,
+                orientation=self.orientation,
+            )
+        else:
+            plot = create_line_plot(
+                (self.x_values, self.y_values),
+                color=self.color,
+                bgcolor="white",
+                add_grid=True,
+                add_axis=True,
+                orientation=self.orientation,
             )
 
         plot.resizable = ""
@@ -66,10 +71,11 @@ class AnimatedPlot(HasTraits):
         plot.tools.append(MoveTool(plot))
         plot.overlays.append(ZoomTool(plot, tool_mode="box", always_on=False))
 
-        self.plot = plot
         self.numpoints = len(self.x_values)
-        self.current_index = self.numpoints / 2
+        self.current_index = int(self.numpoints / 2)
         self.increment = 2
+
+        return plot
 
     def timer_tick(self):
         if self.current_index <= self.numpoints / 3:
@@ -85,7 +91,7 @@ class AnimatedPlot(HasTraits):
 
 
 class PlotFrame(DemoFrame):
-    def _create_window(self):
+    def _create_component(self):
         numpoints = 50
         low = -5
         high = 15.0
@@ -98,7 +104,9 @@ class PlotFrame(DemoFrame):
         self.animated_plots = []
         for i, color in enumerate(COLOR_PALETTE):
             if not common_index:
-                animated_plot = AnimatedPlot(x, jn(i, x), color)
+                animated_plot = AnimatedPlot(
+                    x_values=x, y_values=jn(i, x), color=color
+                )
                 plot = animated_plot.plot
                 common_index = plot.index
                 index_range = plot.index_mapper.range
@@ -109,7 +117,10 @@ class PlotFrame(DemoFrame):
                 else:
                     orientation = "h"
                 animated_plot = AnimatedPlot(
-                    common_index, jn(i, x), color, orientation=orientation
+                    x_values=common_index,
+                    y_values=jn(i, x),
+                    color=color,
+                    orientation=orientation
                 )
                 plot = animated_plot.plot
                 plot.index_mapper.range = index_range
@@ -126,7 +137,7 @@ class PlotFrame(DemoFrame):
 
         self.timer = Timer(100.0, self.onTimer)
         self.container = container
-        return Window(self, -1, component=container)
+        return container
 
     def onTimer(self, *args):
         for plot in self.animated_plots:

--- a/examples/demo/updating_plot/updating_plot4.py
+++ b/examples/demo/updating_plot/updating_plot4.py
@@ -72,7 +72,7 @@ class AnimatedPlot(HasTraits):
         plot.overlays.append(ZoomTool(plot, tool_mode="box", always_on=False))
 
         self.numpoints = len(self.x_values)
-        self.current_index = int(self.numpoints / 2)
+        self.current_index = self.numpoints // 2
         self.increment = 2
 
         return plot

--- a/examples/demo/updating_plot/updating_plot5.py
+++ b/examples/demo/updating_plot/updating_plot5.py
@@ -9,9 +9,9 @@ from numpy import arange
 from scipy.special import jn
 
 # Enthought library imports
-from enable.api import Window
+from enable.api import Component
 from enable.example_support import DemoFrame, demo_main
-from traits.api import HasTraits
+from traits.api import Any, Array, Enum, HasTraits, Instance, Str
 from pyface.timer.api import Timer
 
 # Chaco imports
@@ -32,27 +32,32 @@ PLOT_SIZE = 250
 
 
 class AnimatedPlot(HasTraits):
-    def __init__(self, x, y, color="blue", bgcolor="none", orientation="h"):
-        self.y_values = y[:]
-        if type(x) == ArrayDataSource:
-            self.x_values = x.get_data()[:]
-            plot = create_line_plot(
-                (x, self.y_values),
-                color=color,
-                bgcolor=bgcolor,
-                add_grid=True,
-                add_axis=True,
-                orientation=orientation,
-            )
-        else:
-            self.x_values = x[:]
+    x_values = Any()  # Array or ArraryDataSource
+    y_values = Array()
+    color = Str()
+    orientation = Enum("h", "v")
+
+    plot = Instance(Component)
+
+    def _plot_default(self):
+        if type(self.x_values) == ArrayDataSource:
+            self.x_values = self.x_values.get_data()[:]
             plot = create_line_plot(
                 (self.x_values, self.y_values),
-                color=color,
-                bgcolor=bgcolor,
+                color=self.color,
+                bgcolor="none",
                 add_grid=True,
                 add_axis=True,
-                orientation=orientation,
+                orientation=self.orientation,
+            )
+        else:
+            plot = create_line_plot(
+                (self.x_values, self.y_values),
+                color=self.color,
+                bgcolor="none",
+                add_grid=True,
+                add_axis=True,
+                orientation=self.orientation,
             )
 
         plot.resizable = ""
@@ -63,10 +68,11 @@ class AnimatedPlot(HasTraits):
         plot.tools.append(MoveTool(plot))
         plot.overlays.append(ZoomTool(plot, tool_mode="box", always_on=False))
 
-        self.plot = plot
         self.numpoints = len(self.x_values)
-        self.current_index = self.numpoints / 2
+        self.current_index = int(self.numpoints / 2)
         self.increment = 2
+
+        return plot
 
     def timer_tick(self):
         if self.current_index <= self.numpoints / 3:
@@ -82,7 +88,7 @@ class AnimatedPlot(HasTraits):
 
 
 class PlotFrame(DemoFrame):
-    def _create_window(self):
+    def _create_component(self):
         numpoints = 50
         low = -5
         high = 15.0
@@ -95,19 +101,23 @@ class PlotFrame(DemoFrame):
         self.animated_plots = []
         for i, color in enumerate(COLOR_PALETTE):
             if i == 0:
-                animated_plot = AnimatedPlot(x, jn(i, x), color)
+                animated_plot = AnimatedPlot(
+                    x_values=x, y_values=jn(i, x), color=color
+                )
                 plot = animated_plot.plot
                 common_index = plot.index
                 index_range = plot.index_mapper.range
                 value_range = plot.value_mapper.range
             elif i % 2 == 0:
-                animated_plot = AnimatedPlot(common_index, jn(i, x), color)
+                animated_plot = AnimatedPlot(
+                    x_values=common_index, y_values=jn(i, x), color=color
+                )
                 plot = animated_plot.plot
                 plot.index_mapper.range = index_range
                 plot.value_mapper.range = value_range
             else:
                 animated_plot = AnimatedPlot(
-                    x, jn(i, x), color, orientation="v"
+                    x_values=x, y_values=jn(i, x), color=color, orientation="v"
                 )
                 plot = animated_plot.plot
 
@@ -122,7 +132,7 @@ class PlotFrame(DemoFrame):
 
         self.timer = Timer(100.0, self.onTimer)
         self.container = container
-        return Window(self, -1, component=container)
+        return container
 
     def onTimer(self, *args):
         for plot in self.animated_plots:

--- a/examples/demo/updating_plot/updating_plot5.py
+++ b/examples/demo/updating_plot/updating_plot5.py
@@ -45,7 +45,7 @@ class AnimatedPlot(HasTraits):
             plot = create_line_plot(
                 (self.x_values, self.y_values),
                 color=self.color,
-                bgcolor="none",
+                bgcolor="white",
                 add_grid=True,
                 add_axis=True,
                 orientation=self.orientation,
@@ -54,7 +54,7 @@ class AnimatedPlot(HasTraits):
             plot = create_line_plot(
                 (self.x_values, self.y_values),
                 color=self.color,
-                bgcolor="none",
+                bgcolor="white",
                 add_grid=True,
                 add_axis=True,
                 orientation=self.orientation,
@@ -69,7 +69,7 @@ class AnimatedPlot(HasTraits):
         plot.overlays.append(ZoomTool(plot, tool_mode="box", always_on=False))
 
         self.numpoints = len(self.x_values)
-        self.current_index = int(self.numpoints / 2)
+        self.current_index = self.numpoints // 2
         self.increment = 2
 
         return plot

--- a/examples/user_guide/h_plot_container.py
+++ b/examples/user_guide/h_plot_container.py
@@ -17,7 +17,7 @@ class ContainerExample(HasTraits):
         resizable=True,
     )
 
-    def __init__(self):
+    def _plot_default(self):
         # Create the data and the PlotData object
         x = linspace(-14, 14, 100)
         y = sin(x) * x ** 3
@@ -33,7 +33,7 @@ class ContainerExample(HasTraits):
 
         # Create a horizontal container and put the two plots inside it
         container = HPlotContainer(line_plot, scatter_plot, spacing=100)
-        self.plot = container
+        return container
 
 
 if __name__ == "__main__":

--- a/examples/user_guide/h_plot_container_add_multiple_times.py
+++ b/examples/user_guide/h_plot_container_add_multiple_times.py
@@ -19,7 +19,7 @@ class ContainerExample(HasTraits):
         resizable=True,
     )
 
-    def __init__(self):
+    def _plot_default(self):
         # Create the data and the PlotData object
         x = linspace(-14, 14, 100)
         y = sin(x) * x ** 3
@@ -49,7 +49,7 @@ class ContainerExample(HasTraits):
         # from the first, as each plot can only have one container
         h_container2.add(line_plot1)
 
-        self.plot = outer_container
+        return outer_container
 
 
 if __name__ == "__main__":

--- a/examples/user_guide/h_plot_container_colorbar.py
+++ b/examples/user_guide/h_plot_container_colorbar.py
@@ -20,7 +20,7 @@ class ColorbarExample(HasTraits):
         resizable=True,
     )
 
-    def __init__(self):
+    def _plot_default(self):
         # Create some data
         x = np.random.random(N_POINTS)
         y = np.random.random(N_POINTS)
@@ -53,7 +53,7 @@ class ColorbarExample(HasTraits):
 
         # Create a container to position the plot and the colorbar side-by-side
         container = HPlotContainer(plot, colorbar)
-        self.plot = container
+        return container
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
closes #658 

There are still some examples which define an `__init__` method.  However they either are ding something where they likely need to keep it or they belong to `examples/tutorials/scipy2008/` in which I didn't touch them.

This PR also fixes many of these examples which previously had been broken (trivial changes eg defining `_create_component` not `_create_window`, or using ints instead of floats).