### PR TITLE
Unskip no longer failing test

### DIFF
--- a/chaco/tests/test_colormapped_scatterplot.py
+++ b/chaco/tests/test_colormapped_scatterplot.py
@@ -59,11 +59,8 @@ class TestColormappedScatterplot(unittest.TestCase):
         actual = self.gc.bmp_array[:, :, :]
         self.assertFalse(alltrue(actual == 255))
 
-    @unittest.skip("Broken; see GH #232.")
     def test_scatter_custom(self):
-        """Coverage test to check custom markers work...
-
-        XXX ...which apparently they currently don't. See #232.
+        """Coverage test to check custom markers work.
         """
 
         # build path


### PR DESCRIPTION
This was fixed in #672 but I originally thought it needed https://github.com/enthought/enable/pull/782 in a released version of enable before the test could be unskipped.  

This is actually not the case (although the fix n enable is still needed, the changes in 672 avoid the problem ever getting reached.

This PR simply un skips the test that is now passing