### PR TITLE
Link to "how do i", not "faq", from home page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,7 +48,7 @@ give a good overview of the capabilities of Chaco:
   - :ref:`Modeling Van del Waal's Equations <tutorial_van_der_waal>`
   - :ref:`Creating an interactive Hyetograph <tutorial_hyetograph>`
 
-There is also a :ref:`FAQ <faq>` which provides answers to issues and common
+There is also a :ref:`How Do I...? <how_do_i>` which provides answers to issues and common
 tricks that help when building Chaco applications.
 
 For comprehensive documentation, we have:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,8 +48,8 @@ give a good overview of the capabilities of Chaco:
   - :ref:`Modeling Van del Waal's Equations <tutorial_van_der_waal>`
   - :ref:`Creating an interactive Hyetograph <tutorial_hyetograph>`
 
-There is also a :ref:`How Do I...? <how_do_i>` which provides answers to issues and common
-tricks that help when building Chaco applications.
+There is also a :ref:`How Do I...? <how_do_i>` page which provides answers to
+issues and common tricks that help when building Chaco applications.
 
 For comprehensive documentation, we have:
 


### PR DESCRIPTION
part of #587 

The FAQ page does not have very useful information, and it makes more sense to link to the How do I page from the home page of the docs (although it is still a WIP)