### PR TITLE
use plot_range_event (aka event.new) not just event in stock_prices

### DIFF
--- a/examples/demo/financial/stock_prices.py
+++ b/examples/demo/financial/stock_prices.py
@@ -144,7 +144,7 @@ class PlotFrame(DemoFrame):
     def _plot_range_handler(self, event):
         plot_range_event = event.new
         if plot_range_event is not None:
-            low, high = event
+            low, high = plot_range_event
             if "auto" not in (low, high):
                 self.range_tool.selection = (low, high)
 


### PR DESCRIPTION
fixes #719 

During the on_trait_change to observe changes, we defined `plot_range_event = event.new`, but missed a place where it needed to be used in place of event.

With this simple change I no longer see the error and zooming appears to work as expected.