### PR TITLE
fix broken test and handle case when _data is None in ArrayDataSource.get_data_mask()

### DIFF
--- a/chaco/array_data_source.py
+++ b/chaco/array_data_source.py
@@ -155,7 +155,10 @@ class ArrayDataSource(AbstractDataSource):
         Implements AbstractDataSource.
         """
         if self._cached_mask is None:
-            return self._data, ones(len(self._data), dtype=bool)
+            if self._data is None:
+                return self._data, ones(0, dtype=bool)
+            else:
+                return self._data, ones(len(self._data), dtype=bool)
         else:
             return self._data, self._cached_mask
 

--- a/chaco/tests/test_arraydatasource.py
+++ b/chaco/tests/test_arraydatasource.py
@@ -99,13 +99,12 @@ class ArrayDataSourceTestCase(UnittestTools, unittest.TestCase):
         assert_array_equal(data, self.myarray)
         assert_array_equal(mask, self.mymask)
 
-    @unittest.skip("get_data_mask() fails in this case")
     def test_get_data_mask_no_data(self):
         data_source = ArrayDataSource(None)
 
         data, mask = data_source.get_data_mask()
-        assert_array_equal(data, 0.0)
-        assert_array_equal(mask, True)
+        self.assertEqual(data, None)
+        assert_array_equal(mask, ones(shape=0, dtype=bool))
 
     def test_get_data_mask_no_mask(self):
         data, mask = self.data_source.get_data_mask()


### PR DESCRIPTION
closes #245 

I updated the method to handle the case when _data is None to avoid an error.

I also rewrote the assertions of the test.  I couldn't make sense of the old ones given the current code