### PR TITLE
remove calls to Component._draw_component

### DIFF
--- a/chaco/layers/status_layer.py
+++ b/chaco/layers/status_layer.py
@@ -114,8 +114,6 @@ class StatusLayer(AbstractOverlay):
 
             self.document.render(gc)
 
-            self._draw_component(gc, view_bounds, mode)
-
     def fade_out(self):
         interval = self.fade_out_time / self.fade_out_steps
         self.timer = Timer(interval, self._fade_out_step)

--- a/chaco/layers/svg_range_selection_overlay.py
+++ b/chaco/layers/svg_range_selection_overlay.py
@@ -84,8 +84,6 @@ class SvgRangeSelectionOverlay(StatusLayer):
 
             self.document.render(gc)
 
-            self._draw_component(gc, view_bounds, mode)
-
     def _get_selection_screencoords(self):
         """Returns a tuple of (x1, x2) screen space coordinates of the start
         and end selection points.


### PR DESCRIPTION
Part of #736 (maybe this is enough to close the issue?  We may want to remove all use of _draw_component, even uses that won't break)

These 2 calls actually were calling `Component._draw_component` living in `enable` which currently is a no-op:
https://github.com/enthought/enable/blob/21c299e1229d74e9db701487a613934e332a7225/enable/component.py#L344-L350

There are other uses of `_draw_component` across chaco that can be removed, but they will not cause a break if `_draw_component` is removed in `enable` (ref https://github.com/enthought/enable/pull/814), because the method gets overwritten in chaco.