### PR TITLE
use mock through unittest

### DIFF
--- a/chaco/tests/test_cmap_image_plot.py
+++ b/chaco/tests/test_cmap_image_plot.py
@@ -1,7 +1,5 @@
 import unittest
 
-import mock
-
 import numpy
 
 from enable.api import AbstractWindow
@@ -38,7 +36,7 @@ class TestCMapImagePlot(unittest.TestCase):
             value=color_source,
             value_mapper=color_mapper,
         )
-        cmap_plot._window = window = mock.Mock(spec=AbstractWindow)
+        cmap_plot._window = window = unittest.mock.Mock(spec=AbstractWindow)
 
         # when
         cmap_plot.color_mapper.updated = True

--- a/chaco/tests/test_cmap_image_plot.py
+++ b/chaco/tests/test_cmap_image_plot.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import Mock
 
 import numpy
 
@@ -36,7 +37,7 @@ class TestCMapImagePlot(unittest.TestCase):
             value=color_source,
             value_mapper=color_mapper,
         )
-        cmap_plot._window = window = unittest.mock.Mock(spec=AbstractWindow)
+        cmap_plot._window = window = Mock(spec=AbstractWindow)
 
         # when
         cmap_plot.color_mapper.updated = True

--- a/chaco/tools/tests/test_range_zoom.py
+++ b/chaco/tools/tests/test_range_zoom.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
+from unittest.mock import call
 
-import mock
 import numpy
 
 from chaco.api import create_line_plot
@@ -44,7 +44,7 @@ class BackgroundColorTestCase(EnableTestAssistant, TestCase):
         tool.overlay(self.plot, gc)
 
         self.assertEqual(
-            gc.set_fill_color.call_args, mock.call([1.0, 0.0, 0.0, 0.3])
+            gc.set_fill_color.call_args, call([1.0, 0.0, 0.0, 0.3])
         )
 
     def test_rgba_background_range(self):
@@ -61,5 +61,5 @@ class BackgroundColorTestCase(EnableTestAssistant, TestCase):
         tool.overlay(self.plot, gc)
 
         self.assertEqual(
-            gc.set_fill_color.call_args, mock.call([1.0, 0.0, 0.0, 0.3])
+            gc.set_fill_color.call_args, call([1.0, 0.0, 0.0, 0.3])
         )

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -82,7 +82,6 @@ supported_combinations = {
 
 dependencies = {
     "coverage",
-    "mock",
     "numpy",
     "pandas",
     "pyface",


### PR DESCRIPTION
`mock` is now in the standard library since python 3.3. This PR updates the codebase to use mock via unittest.

Python 2 is end of life and we plan to drop support for 5.0.0 release