### PR TITLE
Replace bg_color with bgcolor

### DIFF
--- a/examples/demo/advanced/cmap_variable_sized_scatter.py
+++ b/examples/demo/advanced/cmap_variable_sized_scatter.py
@@ -96,7 +96,7 @@ def _create_plot_component():
 # Attributes to use for the plot view.
 size = (650, 650)
 title = "Variable size and color scatter plot"
-bg_color = "lightgray"
+bgcolor = "lightgray"
 
 # ===============================================================================
 # # Demo class that is used by the demo.py application.
@@ -108,7 +108,7 @@ class Demo(HasTraits):
         Group(
             Item(
                 "plot",
-                editor=ComponentEditor(size=size, bgcolor=bg_color),
+                editor=ComponentEditor(size=size, bgcolor=bgcolor),
                 show_label=False,
             ),
             orientation="vertical",

--- a/examples/demo/basic/contour_cmap_plot.py
+++ b/examples/demo/basic/contour_cmap_plot.py
@@ -62,7 +62,7 @@ def _create_plot_component():
     # Tweak some of the plot properties
     lplot.title = "Colormap and contours"
     lplot.padding = 20
-    lplot.bg_color = "white"
+    lplot.bgcolor = "white"
     lplot.fill_padding = True
 
     # Add some tools to the plot
@@ -110,7 +110,7 @@ def _create_plot_component():
     # Tweak some of the plot properties
     rplot.title = "Varying contour lines"
     rplot.padding = 20
-    rplot.bg_color = "white"
+    rplot.bgcolor = "white"
     rplot.fill_padding = True
 
     # Create a container and add our plots
@@ -127,7 +127,7 @@ def _create_plot_component():
 # Attributes to use for the plot view.
 size = (950, 650)
 title = "Some contour plots"
-bg_color = "lightgray"
+bgcolor = "lightgray"
 
 # ===============================================================================
 # # Demo class that is used by the demo.py application.
@@ -139,7 +139,7 @@ class Demo(HasTraits):
         Group(
             Item(
                 "plot",
-                editor=ComponentEditor(size=size, bgcolor=bg_color),
+                editor=ComponentEditor(size=size, bgcolor=bgcolor),
                 show_label=False,
             ),
             orientation="vertical",

--- a/examples/demo/basic/contour_plot.py
+++ b/examples/demo/basic/contour_plot.py
@@ -57,7 +57,7 @@ def _create_plot_component():
     # Tweak some of the plot properties
     plot.title = "My First Contour Plot"
     plot.padding = 50
-    plot.bg_color = "white"
+    plot.bgcolor = "white"
     plot.fill_padding = True
 
     # Attach some tools to the plot

--- a/examples/demo/basic/image_plot.py
+++ b/examples/demo/basic/image_plot.py
@@ -67,7 +67,7 @@ def _create_plot_component():
 # Attributes to use for the plot view.
 size = (600, 600)
 title = "Simple image plot"
-bg_color = "lightgray"
+bgcolor = "lightgray"
 
 # ===============================================================================
 # # Demo class that is used by the demo.py application.
@@ -79,7 +79,7 @@ class Demo(HasTraits):
         Group(
             Item(
                 "plot",
-                editor=ComponentEditor(size=size, bgcolor=bg_color),
+                editor=ComponentEditor(size=size, bgcolor=bgcolor),
                 show_label=False,
             ),
             orientation="vertical",

--- a/examples/demo/basic/line_drawing.py
+++ b/examples/demo/basic/line_drawing.py
@@ -91,7 +91,7 @@ def _create_plot_component():
 # Attributes to use for the plot view.
 size = (650, 650)
 title = "Line drawing example"
-bg_color = "lightgray"
+bgcolor = "lightgray"
 
 # ===============================================================================
 # # Demo class that is used by the demo.py application.
@@ -103,7 +103,7 @@ class Demo(HasTraits):
         Group(
             Item(
                 "plot",
-                editor=ComponentEditor(size=size, bgcolor=bg_color),
+                editor=ComponentEditor(size=size, bgcolor=bgcolor),
                 show_label=False,
             ),
             orientation="vertical",

--- a/examples/demo/basic/scatter.py
+++ b/examples/demo/basic/scatter.py
@@ -71,7 +71,7 @@ def _create_plot_component():
 # Attributes to use for the plot view.
 size = (650, 650)
 title = "Basic scatter plot"
-bg_color = "lightgray"
+bgcolor = "lightgray"
 
 # ===============================================================================
 # # Demo class that is used by the demo.py application.
@@ -83,7 +83,7 @@ class Demo(HasTraits):
         Group(
             Item(
                 "plot",
-                editor=ComponentEditor(size=size, bgcolor=bg_color),
+                editor=ComponentEditor(size=size, bgcolor=bgcolor),
                 show_label=False,
             ),
             orientation="vertical",

--- a/examples/demo/basic/scatter_1d.py
+++ b/examples/demo/basic/scatter_1d.py
@@ -97,7 +97,7 @@ def _create_plot_component():
 # Attributes to use for the plot view.
 size = (650, 650)
 title = "1D scatter plots"
-bg_color = "lightgray"
+bgcolor = "lightgray"
 
 # ===============================================================================
 # # Demo class that is used by the demo.py application.
@@ -109,7 +109,7 @@ class Demo(HasTraits):
         Group(
             Item(
                 "plot",
-                editor=ComponentEditor(size=size, bgcolor=bg_color),
+                editor=ComponentEditor(size=size, bgcolor=bgcolor),
                 show_label=False,
             ),
             orientation="vertical",

--- a/examples/demo/basic/scatter_alpha.py
+++ b/examples/demo/basic/scatter_alpha.py
@@ -69,7 +69,7 @@ def _create_scatter_renderer(plot):
 # Attributes to use for the plot view.
 size = (650, 650)
 title = "Basic scatter plot"
-bg_color = "lightgray"
+bgcolor = "lightgray"
 
 # ===============================================================================
 # # Demo class that is used by the demo.py application.
@@ -85,7 +85,7 @@ class Demo(HasTraits):
         Group(
             Item(
                 "plot",
-                editor=ComponentEditor(size=size, bgcolor=bg_color),
+                editor=ComponentEditor(size=size, bgcolor=bgcolor),
                 show_label=False,
             ),
             Group(

--- a/examples/demo/basic/scatter_custom_marker.py
+++ b/examples/demo/basic/scatter_custom_marker.py
@@ -86,7 +86,7 @@ def _create_plot_component():
 # Attributes to use for the plot view.
 size = (650, 650)
 title = "Scatter plot w/ custom markers"
-bg_color = "lightgray"
+bgcolor = "lightgray"
 
 # ===============================================================================
 # # Demo class that is used by the demo.py application.
@@ -98,7 +98,7 @@ class Demo(HasTraits):
         Group(
             Item(
                 "plot",
-                editor=ComponentEditor(size=size, bgcolor=bg_color),
+                editor=ComponentEditor(size=size, bgcolor=bgcolor),
                 show_label=False,
             ),
             orientation="vertical",

--- a/examples/demo/basic/scatter_rect_select.py
+++ b/examples/demo/basic/scatter_rect_select.py
@@ -96,7 +96,6 @@ def _create_plot_component():
 # Attributes to use for the plot view.
 size = (650, 650)
 title = "Scatter plot with selection"
-bg_color = "lightgray"
 
 
 # ===============================================================================

--- a/examples/demo/basic/scatter_rect_select.py
+++ b/examples/demo/basic/scatter_rect_select.py
@@ -96,6 +96,7 @@ def _create_plot_component():
 # Attributes to use for the plot view.
 size = (650, 650)
 title = "Scatter plot with selection"
+bgcolor = "lightgray"
 
 
 # ===============================================================================
@@ -106,7 +107,11 @@ class Demo(HasTraits):
 
     traits_view = View(
         Group(
-            Item("plot", editor=ComponentEditor(size=size), show_label=False),
+            Item(
+                "plot",
+                editor=ComponentEditor(size=size, bgcolor=bgcolor),
+                show_label=False
+            ),
             orientation="vertical",
         ),
         resizable=True,

--- a/examples/demo/basic/scatter_select.py
+++ b/examples/demo/basic/scatter_select.py
@@ -87,6 +87,7 @@ def _create_plot_component():
 # Attributes to use for the plot view.
 size = (650, 650)
 title = "Scatter plot with selection"
+bgcolor = "lightgray"
 
 # ===============================================================================
 # # Demo class that is used by the demo.py application.
@@ -96,7 +97,11 @@ class Demo(HasTraits):
 
     traits_view = View(
         Group(
-            Item("plot", editor=ComponentEditor(size=size), show_label=False),
+            Item(
+                "plot",
+                editor=ComponentEditor(size=size, bgcolor=bgcolor),
+                show_label=False
+            ),
             orientation="vertical",
         ),
         resizable=True,

--- a/examples/demo/basic/scatter_select.py
+++ b/examples/demo/basic/scatter_select.py
@@ -87,7 +87,6 @@ def _create_plot_component():
 # Attributes to use for the plot view.
 size = (650, 650)
 title = "Scatter plot with selection"
-bg_color = "lightgray"
 
 # ===============================================================================
 # # Demo class that is used by the demo.py application.

--- a/examples/demo/basic/scatter_toggle.py
+++ b/examples/demo/basic/scatter_toggle.py
@@ -97,7 +97,7 @@ def _create_plot_component():
 # Attributes to use for the plot view.
 size = (650, 650)
 title = "Scatter plot with selection"
-bg_color = "lightgray"
+bgcolor = "lightgray"
 
 # ===============================================================================
 # # Demo class that is used by the demo.py application.
@@ -110,7 +110,7 @@ class Demo(HasTraits):
             HGroup(spring, Label("Click point to select/unselect"), spring),
             Item(
                 "plot",
-                editor=ComponentEditor(size=size, bgcolor=bg_color),
+                editor=ComponentEditor(size=size, bgcolor=bgcolor),
                 show_label=False,
             ),
             orientation="vertical",

--- a/examples/demo/basic/scatter_variable_size.py
+++ b/examples/demo/basic/scatter_variable_size.py
@@ -65,7 +65,7 @@ def _create_plot_component():
 # Attributes to use for the plot view.
 size = (650, 650)
 title = "Basic scatter plot"
-bg_color = "lightgray"
+bgcolor = "lightgray"
 
 # ===============================================================================
 # # Demo class that is used by the demo.py application.
@@ -77,7 +77,7 @@ class Demo(HasTraits):
         Group(
             Item(
                 "plot",
-                editor=ComponentEditor(size=size, bgcolor=bg_color),
+                editor=ComponentEditor(size=size, bgcolor=bgcolor),
                 show_label=False,
             ),
             orientation="vertical",

--- a/examples/demo/basic/segment_plot.py
+++ b/examples/demo/basic/segment_plot.py
@@ -73,7 +73,7 @@ def _create_plot_component():
 # Attributes to use for the plot view.
 size = (650, 650)
 title = "Basic scatter plot"
-bg_color = "lightgray"
+bgcolor = "lightgray"
 
 # ===============================================================================
 # # Demo class that is used by the demo.py application.
@@ -85,7 +85,7 @@ class Demo(HasTraits):
         Group(
             Item(
                 "plot",
-                editor=ComponentEditor(size=size, bgcolor=bg_color),
+                editor=ComponentEditor(size=size, bgcolor=bgcolor),
                 show_label=False,
             ),
             orientation="vertical",


### PR DESCRIPTION
ref: https://github.com/enthought/enable/pull/816#pullrequestreview-661608507

This PR removes uses of the soon to be removed, deprecated `bg_color` trait from enable.  For consistency it renames all uses of `bg_color` in the codebase with `bgcolor` (even just temp variables), in order to keep consistent.  Note, all changes occur in example code