### PR TITLE
Bump version for continued development

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ from numpy import get_include
 from setuptools import setup, Extension, find_packages
 from Cython.Build import cythonize
 
-MAJOR = 4
-MINOR = 8
-MICRO = 1
+MAJOR = 5
+MINOR = 1
+MICRO = 0
 PRERELEASE = ""
 IS_RELEASED = False
 


### PR DESCRIPTION
part of #745 
This PR bumps the version for continued development of 5.1.0.

I will create a branch maint/5.0 from the commit just before this on master

~EDIT: This PR may have jumped the gun too soon as we might need #743 merged before the release candidate~ EDIT again: things won't break because of #737.  #743 changes remove `_draw_component` use that is unnecessary but not breaking.

