### PR TITLE
Update requirements to be more specific

### DIFF
--- a/chaco/__init__.py
+++ b/chaco/__init__.py
@@ -9,5 +9,5 @@ except ImportError:
     __version__ = "not-built"
 
 __requires__ = [
-    "traits>=6.2.0", "traitsui", "pyface>=7.2.0", "numpy", "enable>=5.2.0"
+    "traits>=6.2.0", "traitsui", "pyface>=7.2.0", "numpy", "enable"
 ]

--- a/chaco/__init__.py
+++ b/chaco/__init__.py
@@ -8,4 +8,6 @@ try:
 except ImportError:
     __version__ = "not-built"
 
-__requires__ = ["traits", "traitsui", "pyface", "numpy", "enable"]
+__requires__ = [
+    "traits>=6.2.0", "traitsui", "pyface>=7.2.0", "numpy", "enable>=5.2.0"
+]


### PR DESCRIPTION
[targeting maint/5.0]
This PR updates `__requires__` to be more specific. 
We use `Property(observe=...)` and so depend on traits >= 6.2.  Also recent changes are such that we require enable 5.2 (only rc currently available).  Also enable 5.2 (and actually I think 5.1) require pyface >=7.2 as it uses `pyface.undo`.  So, chaco implicitly requires pyface >= 7.2
TBH I am not exactly sure on what traitsui is necessary (we didnt specify for enable either)

This PR will eventually need to be backported into master along with the recent changelog updates