### PR TITLE
Add/Update copyright headers

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 This software is OSI Certified Open Source Software.
 OSI Certified is a certification mark of the Open Source Initiative.
 
-Copyright (c) 2006-2021, Enthought, Inc.
+Copyright (c) 2005-2021, Enthought, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/chaco/_cython_speedups.pyx
+++ b/chaco/_cython_speedups.pyx
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import sys
 import numpy as np
 cimport numpy as np

--- a/chaco/_speedups_fallback.py
+++ b/chaco/_speedups_fallback.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Module that implements pure-python equivalents of the functions in the
 _speedups extension module.

--- a/chaco/abstract_colormap.py
+++ b/chaco/abstract_colormap.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the base class for color maps
 """
 from traits.api import Enum, Event, HasTraits, Instance

--- a/chaco/abstract_controller.py
+++ b/chaco/abstract_controller.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the base class for controllers.
 """
 # Enthought library imports

--- a/chaco/abstract_data_range.py
+++ b/chaco/abstract_data_range.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Defines the base class for data ranges.
 """

--- a/chaco/abstract_data_source.py
+++ b/chaco/abstract_data_source.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Defines the AbstractDataSource class.
 """

--- a/chaco/abstract_mapper.py
+++ b/chaco/abstract_mapper.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the base class for mappings.
 """
 # Major library imports

--- a/chaco/abstract_overlay.py
+++ b/chaco/abstract_overlay.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Abstract base class for plot decorators and overlays.
 
 This class is primarily used so that tools can easily distinguish between

--- a/chaco/abstract_plot_data.py
+++ b/chaco/abstract_plot_data.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the base class for plot data.
 """
 from traits.api import Bool, Event, HasTraits

--- a/chaco/abstract_plot_renderer.py
+++ b/chaco/abstract_plot_renderer.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines a base class for plot renderers.
 """
 # Enthought library imports.

--- a/chaco/api.py
+++ b/chaco/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 """
 Defines the publicly accessible items of the Chaco API.
 

--- a/chaco/array_data_source.py
+++ b/chaco/array_data_source.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the ArrayDataSource class."""
 
 # Major library imports

--- a/chaco/array_plot_data.py
+++ b/chaco/array_plot_data.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines ArrayPlotData.
 """
 from numpy import array, ndarray

--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the PlotAxis class, and associated validator and UI.
 """
 # Major library import

--- a/chaco/axis_view.py
+++ b/chaco/axis_view.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the TraitsUI view for a PlotAxis """
 from traits.api import TraitError
 from traitsui.api import View, HGroup, Group, VGroup, Item, TextEditor

--- a/chaco/barplot.py
+++ b/chaco/barplot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.barplot import BarPlot  # noqa: F401

--- a/chaco/base.py
+++ b/chaco/base.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Defines basic traits and functions for the data model.
 """

--- a/chaco/base_1d_mapper.py
+++ b/chaco/base_1d_mapper.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the Base1DMapper class.
 """
 # Enthought library imports

--- a/chaco/base_1d_plot.py
+++ b/chaco/base_1d_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Abstract base class for 1-D plots which only use one axis
 """

--- a/chaco/base_2d_plot.py
+++ b/chaco/base_2d_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the base class for 2-D plots.
 """
 # Standard library imports

--- a/chaco/base_candle_plot.py
+++ b/chaco/base_candle_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 # Major library imports
 from numpy import array, column_stack
 

--- a/chaco/base_contour_plot.py
+++ b/chaco/base_contour_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from numpy import array, isscalar, issubsctype, linspace, number
 
 # Enthought library imports

--- a/chaco/base_data_range.py
+++ b/chaco/base_data_range.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Defines the BaseDataRange class.
 """

--- a/chaco/base_plot_container.py
+++ b/chaco/base_plot_container.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the BasePlotContainer class.
 """
 import warnings

--- a/chaco/base_xy_plot.py
+++ b/chaco/base_xy_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the base class for XY plots.
 """
 from math import sqrt

--- a/chaco/candle_plot.py
+++ b/chaco/candle_plot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.candle_plot import CandlePlot  # noqa: F401

--- a/chaco/chaco_traits.py
+++ b/chaco/chaco_traits.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines various traits that are used in many places in Chaco.
 """
 

--- a/chaco/cmap_image_plot.py
+++ b/chaco/cmap_image_plot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.cmap_image_plot import CMapImagePlot  # noqa: F401

--- a/chaco/color_bar.py
+++ b/chaco/color_bar.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.color_bar import ColorBar  # noqa: F401

--- a/chaco/color_mapper.py
+++ b/chaco/color_mapper.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the ColorMapper and ColorMapTemplate classes.
 """
 

--- a/chaco/color_spaces.py
+++ b/chaco/color_spaces.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Conversion functions between various color spaces.
 
 The implementations and data are mostly taken from the old

--- a/chaco/colormap_generators.py
+++ b/chaco/colormap_generators.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Generate parameteric colormaps.
 
 Diverging colormaps can be generated via Kenneth Moreland's procedure using

--- a/chaco/colormapped_scatterplot.py
+++ b/chaco/colormapped_scatterplot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.colormapped_scatterplot import (  # noqa: F401

--- a/chaco/colormapped_selection_overlay.py
+++ b/chaco/colormapped_selection_overlay.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.overlays.colormapped_selection_overlay import (  # noqa: F401

--- a/chaco/contour_line_plot.py
+++ b/chaco/contour_line_plot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.contour.contour_line_plot import ContourLinePlot  # noqa: F401

--- a/chaco/contour_poly_plot.py
+++ b/chaco/contour_poly_plot.py
@@ -1,6 +1,4 @@
-""" Defines the ContourPolyPlot class.
-"""
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -9,6 +7,10 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
+""" Defines the ContourPolyPlot class.
+"""
+
 import warnings
 
 from chaco.plots.contour.contour_poly_plot import ContourPolyPlot  # noqa: F401

--- a/chaco/data_frame_plot_data.py
+++ b/chaco/data_frame_plot_data.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines DataFramePlotData.
 """
 

--- a/chaco/data_label.py
+++ b/chaco/data_label.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.overlays.data_label import DataLabel, draw_arrow, find_region

--- a/chaco/data_range_1d.py
+++ b/chaco/data_range_1d.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Defines the DataRange1D class.
 """

--- a/chaco/data_range_2d.py
+++ b/chaco/data_range_2d.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Defines the DataRange2D class.
 """

--- a/chaco/data_view.py
+++ b/chaco/data_view.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the DataView class, and associated property traits and property
 functions.
 """

--- a/chaco/default_colormaps.py
+++ b/chaco/default_colormaps.py
@@ -1,17 +1,15 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2005-2014, Enthought, Inc.
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 #
 # Portions of this software are:
 # Copyright (c) 2002-2004 John D. Hunter
-# All Rights Reserved.
-# ------------------------------------------------------------------------------
 
 """
 A collection of pre-defined colormap generator functions.

--- a/chaco/default_colors.py
+++ b/chaco/default_colors.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """List of nice color palettes for Chaco"""
 
 

--- a/chaco/discrete_color_mapper.py
+++ b/chaco/discrete_color_mapper.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from numpy import asarray, floor, ones
 
 from traits.api import Array, Str, observe

--- a/chaco/downsample/_lttb.pyx
+++ b/chaco/downsample/_lttb.pyx
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 cimport cython
 
 from libc.math cimport isnan, fabs, floor

--- a/chaco/downsample/lttb.py
+++ b/chaco/downsample/lttb.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import logging
 
 logger = logging.getLogger(__name__)

--- a/chaco/downsample/tests/test_lttb.py
+++ b/chaco/downsample/tests/test_lttb.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 import timeit
 

--- a/chaco/errorbar_plot.py
+++ b/chaco/errorbar_plot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.errorbar_plot import ErrorBarPlot  # noqa: F401

--- a/chaco/example_support.py
+++ b/chaco/example_support.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 doc = """
 This file contains a support class that wraps up the boilerplate toolkit calls
 that virtually all the demo programs have to use, and doesn't actually do

--- a/chaco/filled_line_plot.py
+++ b/chaco/filled_line_plot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.filled_line_plot import FilledLinePlot  # noqa: F401

--- a/chaco/function_data_source.py
+++ b/chaco/function_data_source.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the FunctionDataSource class to create an ArrayDataSource from a
 callable.
 """

--- a/chaco/function_image_data.py
+++ b/chaco/function_image_data.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from numpy import array
 from traits.api import Instance, Callable, observe
 from .data_range_2d import DataRange2D

--- a/chaco/grid.py
+++ b/chaco/grid.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the PlotGrid class, and associated TraitsUI View and validator
 function.
 """

--- a/chaco/grid_data_source.py
+++ b/chaco/grid_data_source.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the GridDataSource class.
 """
 

--- a/chaco/grid_mapper.py
+++ b/chaco/grid_mapper.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Defines the GridMapper class, which maps from a 2-D region in data space
 into a structured (gridded) 1-D output space.

--- a/chaco/horizon_plot.py
+++ b/chaco/horizon_plot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.horizon_plot import BandedMapper, HorizonPlot  # noqa: F401

--- a/chaco/image_data.py
+++ b/chaco/image_data.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the ImageData class.
 """
 # Standard library imports

--- a/chaco/image_plot.py
+++ b/chaco/image_plot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.image_plot import ImagePlot  # noqa: F401

--- a/chaco/image_utils.py
+++ b/chaco/image_utils.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 X_PARAMS = (0, 2)  # index for x-position and width
 Y_PARAMS = (1, 3)  # index for y-position and height
 

--- a/chaco/jitterplot.py
+++ b/chaco/jitterplot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.jitterplot import JitterPlot  # noqa: F401

--- a/chaco/label.py
+++ b/chaco/label.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the Label class.
 """
 

--- a/chaco/label_axis.py
+++ b/chaco/label_axis.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the LabelAxis class.
 """
 # Major library imports

--- a/chaco/lasso_overlay.py
+++ b/chaco/lasso_overlay.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.overlays.lasso_overlay import LassoOverlay  # noqa: F401

--- a/chaco/layers/api.py
+++ b/chaco/layers/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.overlays.api import ErrorLayer, StatusLayer, WarningLayer

--- a/chaco/layers/status_layer.py
+++ b/chaco/layers/status_layer.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.overlays.layers.status_layer import (  # noqa: F401

--- a/chaco/layers/svg_range_selection_overlay.py
+++ b/chaco/layers/svg_range_selection_overlay.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.overlays.layers.svg_range_selection_overlay import (  # noqa: F401

--- a/chaco/legend.py
+++ b/chaco/legend.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.overlays.legend import (  # noqa: F401

--- a/chaco/line_scatterplot_1d.py
+++ b/chaco/line_scatterplot_1d.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.line_scatterplot_1d import LineScatterPlot1D  # noqa: F401

--- a/chaco/linear_mapper.py
+++ b/chaco/linear_mapper.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Defines the LinearMapper class, which maps from a 1-D region in data space
 into a 1-D output space.

--- a/chaco/lineplot.py
+++ b/chaco/lineplot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.lineplot import LinePlot  # noqa: F401

--- a/chaco/log_mapper.py
+++ b/chaco/log_mapper.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the LogMapper and InvalidDataRangeException classes.
 """
 # Major library imports

--- a/chaco/multi_array_data_source.py
+++ b/chaco/multi_array_data_source.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the MultiArrayDataSource class.
 """
 import warnings

--- a/chaco/multi_line_plot.py
+++ b/chaco/multi_line_plot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.multi_line_plot import MultiLinePlot  # noqa: F401

--- a/chaco/overlays/aligned_container_overlay.py
+++ b/chaco/overlays/aligned_container_overlay.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """An overlay that aligns itself to the plot
 """
 

--- a/chaco/overlays/api.py
+++ b/chaco/overlays/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 """
 Defines the publicly accessible overlays in Chaco.
 

--- a/chaco/overlays/colormapped_selection_overlay.py
+++ b/chaco/overlays/colormapped_selection_overlay.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 """ Defines the ColormappedSelectionOverlay class.
 """
 import functools

--- a/chaco/overlays/container_overlay.py
+++ b/chaco/overlays/container_overlay.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """Plot overlay which is an Enable Container
 
 This module provides an Enable Container subclass which renders itself

--- a/chaco/overlays/coordinate_line_overlay.py
+++ b/chaco/overlays/coordinate_line_overlay.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ An overlay for drawing "infinite" vertical and horizontal lines.
 
 This module defines the CoordinateLineOverlay class, a Chaco overlay

--- a/chaco/overlays/data_label.py
+++ b/chaco/overlays/data_label.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the DataLabel class and related trait and function.
 """
 # Major library imports

--- a/chaco/overlays/databox.py
+++ b/chaco/overlays/databox.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from traits.api import Bool, Enum, Float, Int, CList, Property, Trait, observe
 from enable.api import ColorTrait
 from chaco.abstract_overlay import AbstractOverlay

--- a/chaco/overlays/lasso_overlay.py
+++ b/chaco/overlays/lasso_overlay.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 """ Defines the LassoOverlay class.
 """
 

--- a/chaco/overlays/layers/api.py
+++ b/chaco/overlays/layers/api.py
@@ -1,1 +1,11 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from .status_layer import ErrorLayer, StatusLayer, WarningLayer

--- a/chaco/overlays/layers/status_layer.py
+++ b/chaco/overlays/layers/status_layer.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import os.path
 import xml.etree.cElementTree as etree
 

--- a/chaco/overlays/layers/svg_range_selection_overlay.py
+++ b/chaco/overlays/layers/svg_range_selection_overlay.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import os
 import numpy
 

--- a/chaco/overlays/legend.py
+++ b/chaco/overlays/legend.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the Legend, AbstractCompositeIconRenderer, and
 CompositeIconRenderer classes.
 """

--- a/chaco/overlays/plot_label.py
+++ b/chaco/overlays/plot_label.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 """ Defines the PlotLabel class.
 """
 

--- a/chaco/overlays/scatter_inspector_overlay.py
+++ b/chaco/overlays/scatter_inspector_overlay.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 # Major library imports
 from numpy import array, asarray
 

--- a/chaco/overlays/simple_inspector_overlay.py
+++ b/chaco/overlays/simple_inspector_overlay.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """A simple inspector overlay for plots
 
 This module provides the SimpleInspectorOverlay for displaying

--- a/chaco/overlays/tests/test_data_label.py
+++ b/chaco/overlays/tests/test_data_label.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from chaco.api import create_scatter_plot, PlotGraphicsContext, DataLabel

--- a/chaco/overlays/tests/test_databox.py
+++ b/chaco/overlays/tests/test_databox.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import numpy as np
 import unittest
 

--- a/chaco/overlays/text_box_overlay.py
+++ b/chaco/overlays/text_box_overlay.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 """ Defines the TextBoxOverlay class.
 """
 

--- a/chaco/overlays/text_grid_overlay.py
+++ b/chaco/overlays/text_grid_overlay.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ An overlay containing a TextGrid
 """
 

--- a/chaco/overlays/tooltip.py
+++ b/chaco/overlays/tooltip.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 """ Defines the ToolTip class.
 """
 

--- a/chaco/pdf_graphics_context.py
+++ b/chaco/pdf_graphics_context.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 # Major library imports
 import warnings
 

--- a/chaco/plot.py
+++ b/chaco/plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the Plot class.
 """
 # Major library imports

--- a/chaco/plot_canvas.py
+++ b/chaco/plot_canvas.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 # Enthought library imports
 from enable.api import Canvas
 from traits.api import Instance, Tuple

--- a/chaco/plot_canvas_toolbar.py
+++ b/chaco/plot_canvas_toolbar.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from traits.api import Any, Enum, Int
 from enable.drawing.api import ToolbarButton
 

--- a/chaco/plot_component.py
+++ b/chaco/plot_component.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the PlotComponent class.
 """
 # Enthought library imports

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines various plot container classes, including stacked, grid, and overlay.
 """
 # Major library imports

--- a/chaco/plot_factory.py
+++ b/chaco/plot_factory.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Contains convenience functions to create ready-made PlotRenderer instances of
 various types.

--- a/chaco/plot_graphics_context.py
+++ b/chaco/plot_graphics_context.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the PlotGraphicsContext class.
 """
 

--- a/chaco/plot_label.py
+++ b/chaco/plot_label.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.overlays.plot_label import PlotLabel  # noqa: F401

--- a/chaco/plots/api.py
+++ b/chaco/plots/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -6,6 +6,8 @@
 # the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
+# Thanks for using Enthought open source!
+
 """
 Defines the publicly accessible PlotRenderers in Chaco.
 

--- a/chaco/plots/barplot.py
+++ b/chaco/plots/barplot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the BarPlot class.
 """
 import logging

--- a/chaco/plots/candle_plot.py
+++ b/chaco/plots/candle_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 # Major library imports
 from numpy import array, compress, concatenate, searchsorted
 

--- a/chaco/plots/cmap_image_plot.py
+++ b/chaco/plots/cmap_image_plot.py
@@ -1,10 +1,12 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-# (C) Copyright 2013 Enthought, Inc., Austin, TX
-# All right reserved.
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-# This file is open source software distributed according to the terms in
-# LICENSE.txt
-#
+# Thanks for using Enthought open source!
 
 from numpy import zeros
 

--- a/chaco/plots/color_bar.py
+++ b/chaco/plots/color_bar.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the ColorBar class.
 """
 # Major library imports

--- a/chaco/plots/colormapped_scatterplot.py
+++ b/chaco/plots/colormapped_scatterplot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the ColormappedScatterPlot and ColormappedScatterPlotView classes.
 """
 

--- a/chaco/plots/contour/cntr.c
+++ b/chaco/plots/contour/cntr.c
@@ -1,4 +1,14 @@
 /*
+  (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+  All rights reserved.
+
+  This software is provided without warranty under the terms of the BSD
+  license included in LICENSE.txt and may be redistributed only under
+  the conditions described in the aforementioned license. The license
+  is also available online at http://www.enthought.com/licenses/BSD.txt
+
+  Thanks for using Enthought open source!
+
   cntr.c
   General purpose contour tracer for quadrilateral meshes.
   Handles single level contours, or region between a pair of levels.

--- a/chaco/plots/contour/contour_line_plot.py
+++ b/chaco/plots/contour/contour_line_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the ContourLinePlot class.
 """
 

--- a/chaco/plots/contour/contour_poly_plot.py
+++ b/chaco/plots/contour/contour_poly_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the ContourPolyPlot class.
 """
 

--- a/chaco/plots/contour/setup.py
+++ b/chaco/plots/contour/setup.py
@@ -1,4 +1,13 @@
-#!/usr/bin/env python
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 def configuration(parent_package="", top_path=None):
     from numpy.distutils.misc_util import Configuration
 

--- a/chaco/plots/contour/tests/test_contour.py
+++ b/chaco/plots/contour/tests/test_contour.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 import numpy as np

--- a/chaco/plots/errorbar_plot.py
+++ b/chaco/plots/errorbar_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 # Major library imports
 from numpy import column_stack, compress, invert, isnan, transpose
 import logging

--- a/chaco/plots/filled_line_plot.py
+++ b/chaco/plots/filled_line_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from numpy import empty
 from traits.api import Property, Enum
 

--- a/chaco/plots/horizon_plot.py
+++ b/chaco/plots/horizon_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from numpy import array, float64, full_like, ndarray, transpose
 from traits.api import Instance, DelegatesTo, Bool, Int
 

--- a/chaco/plots/image_plot.py
+++ b/chaco/plots/image_plot.py
@@ -1,10 +1,12 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-# (C) Copyright 2013 Enthought, Inc., Austin, TX
-# All right reserved.
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-# This file is open source software distributed according to the terms in
-# LICENSE.txt
-#
+# Thanks for using Enthought open source!
 
 """ Defines the ImagePlot class.
 """

--- a/chaco/plots/jitterplot.py
+++ b/chaco/plots/jitterplot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from math import sqrt
 
 import numpy as np

--- a/chaco/plots/line_scatterplot_1d.py
+++ b/chaco/plots/line_scatterplot_1d.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 A 1D scatterplot that draws lines across the renderer at the index values
 

--- a/chaco/plots/lineplot.py
+++ b/chaco/plots/lineplot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the LinePlot class.
 """
 

--- a/chaco/plots/multi_line_plot.py
+++ b/chaco/plots/multi_line_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the MultiLinePlot class.
 """
 

--- a/chaco/plots/polar_line_renderer.py
+++ b/chaco/plots/polar_line_renderer.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the PolarLineRenderer class.
 """
 

--- a/chaco/plots/polygon_plot.py
+++ b/chaco/plots/polygon_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the PolygonPlot class.
 """
 

--- a/chaco/plots/quiverplot.py
+++ b/chaco/plots/quiverplot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from numpy import array, compress, matrix, newaxis, sqrt, zeros
 
 # Enthought library imports

--- a/chaco/plots/scatterplot.py
+++ b/chaco/plots/scatterplot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the ScatterPlot class, and associated TraitsUI view and helper
 function.
 """

--- a/chaco/plots/scatterplot_1d.py
+++ b/chaco/plots/scatterplot_1d.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Scatterplot in one dimension only
 """

--- a/chaco/plots/segment_plot.py
+++ b/chaco/plots/segment_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import numpy as np
 
 from enable.api import ColorTrait, LineStyle, black_color_trait

--- a/chaco/plots/tests/test_cmap_image_plot.py
+++ b/chaco/plots/tests/test_cmap_image_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 from unittest.mock import Mock
 

--- a/chaco/plots/tests/test_colormapped_scatterplot.py
+++ b/chaco/plots/tests/test_colormapped_scatterplot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy import alltrue, arange

--- a/chaco/plots/tests/test_errorbarplot.py
+++ b/chaco/plots/tests/test_errorbarplot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 import numpy as np

--- a/chaco/plots/tests/test_image_plot.py
+++ b/chaco/plots/tests/test_image_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import os
 
 import tempfile

--- a/chaco/plots/tests/test_jitterplot.py
+++ b/chaco/plots/tests/test_jitterplot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy import alltrue, arange, array

--- a/chaco/plots/tests/test_line_scatterplot.py
+++ b/chaco/plots/tests/test_line_scatterplot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy import alltrue, arange, array

--- a/chaco/plots/tests/test_scatterplot_1d.py
+++ b/chaco/plots/tests/test_scatterplot_1d.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy import alltrue, arange, array

--- a/chaco/plots/tests/test_scatterplot_renderers.py
+++ b/chaco/plots/tests/test_scatterplot_renderers.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy import alltrue

--- a/chaco/plots/tests/test_segment_plot.py
+++ b/chaco/plots/tests/test_segment_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy import alltrue, arange, array

--- a/chaco/plots/tests/test_text_plot.py
+++ b/chaco/plots/tests/test_text_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy import alltrue, arange, array

--- a/chaco/plots/tests/test_text_plot_1d.py
+++ b/chaco/plots/tests/test_text_plot_1d.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy import alltrue, arange, array

--- a/chaco/plots/text_plot.py
+++ b/chaco/plots/text_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 A plot that renders text values in two dimensions
 

--- a/chaco/plots/text_plot_1d.py
+++ b/chaco/plots/text_plot_1d.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 A plot that renders text values along one dimension
 

--- a/chaco/plotscrollbar.py
+++ b/chaco/plotscrollbar.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from traits.api import Any, Enum, Int, Property, Trait
 
 from enable.api import NativeScrollBar

--- a/chaco/point_data_source.py
+++ b/chaco/point_data_source.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Defines the PointDataSource class.
 """

--- a/chaco/polar_line_renderer.py
+++ b/chaco/polar_line_renderer.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.polar_line_renderer import PolarLineRenderer  # noqa: F401

--- a/chaco/polar_mapper.py
+++ b/chaco/polar_mapper.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Defines the PolarMapper class, which maps from a 1-D region in data space
 into a 1-D output space.

--- a/chaco/polygon_plot.py
+++ b/chaco/polygon_plot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.polygon_plot import PolygonPlot  # noqa: F401

--- a/chaco/quiverplot.py
+++ b/chaco/quiverplot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.quiverplot import QuiverPlot  # noqa: F401

--- a/chaco/scales/api.py
+++ b/chaco/scales/api.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from .formatters import *
 from .scales import *
 from .time_scale import *

--- a/chaco/scales/formatters.py
+++ b/chaco/scales/formatters.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Classes for formatting labels for values or times.
 """

--- a/chaco/scales/safetime.py
+++ b/chaco/scales/safetime.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ This module wraps the standard library time module to gracefully
 handle bad input values for time.
 """

--- a/chaco/scales/scales.py
+++ b/chaco/scales/scales.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Functions and classes that compute ticks and labels for graph axes, with
 special handling of time and calendar axes.

--- a/chaco/scales/tests/test_formatters.py
+++ b/chaco/scales/tests/test_formatters.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from chaco.scales.formatters import strftimeEx, TimeFormatter

--- a/chaco/scales/tests/test_scales.py
+++ b/chaco/scales/tests/test_scales.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy import array

--- a/chaco/scales/tests/test_time_scale.py
+++ b/chaco/scales/tests/test_time_scale.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import datetime
 import os
 import contextlib

--- a/chaco/scales/tests/test_time_scale_resolution.py
+++ b/chaco/scales/tests/test_time_scale_resolution.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from itertools import starmap
 from datetime import datetime as DT
 

--- a/chaco/scales/time_scale.py
+++ b/chaco/scales/time_scale.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 A scale for time and calendar intervals.
 """

--- a/chaco/scales_tick_generator.py
+++ b/chaco/scales_tick_generator.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the ScalesTickGenerator class.
 """
 

--- a/chaco/scaly_plot.py
+++ b/chaco/scaly_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ A Plot which uses ScaleSystems for its ticks.
 """
 

--- a/chaco/scatter_inspector_overlay.py
+++ b/chaco/scatter_inspector_overlay.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.overlays.scatter_inspector_overlay import (  # noqa: F401

--- a/chaco/scatterplot.py
+++ b/chaco/scatterplot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.scatterplot import (  # noqa: F401

--- a/chaco/scatterplot_1d.py
+++ b/chaco/scatterplot_1d.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.scatterplot_1d import ScatterPlot1D  # noqa: F401

--- a/chaco/segment_plot.py
+++ b/chaco/segment_plot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.segment_plot import (  # noqa: F401

--- a/chaco/selectable_legend.py
+++ b/chaco/selectable_legend.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from chaco.tools.select_tool import SelectTool
 from traits.api import List
 

--- a/chaco/speedups.py
+++ b/chaco/speedups.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 # This contains python implementations of all the speedups
 from ._speedups_fallback import *
 

--- a/chaco/svg_graphics_context.py
+++ b/chaco/svg_graphics_context.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the PlotGraphicsContext class.
 """
 

--- a/chaco/tests/_tools.py
+++ b/chaco/tests/_tools.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from contextlib import contextmanager
 
 import sys

--- a/chaco/tests/test_2d_case.py
+++ b/chaco/tests/test_2d_case.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from chaco.api import Plot, ArrayPlotData

--- a/chaco/tests/test_array_or_none.py
+++ b/chaco/tests/test_array_or_none.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 import warnings
 

--- a/chaco/tests/test_array_plot_data.py
+++ b/chaco/tests/test_array_plot_data.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import contextlib
 import unittest
 

--- a/chaco/tests/test_arraydatasource.py
+++ b/chaco/tests/test_arraydatasource.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Tests of ArrayDataSource behavior.
 """

--- a/chaco/tests/test_base_utils.py
+++ b/chaco/tests/test_base_utils.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Unit tests for utility functions in chaco.base
 """

--- a/chaco/tests/test_border.py
+++ b/chaco/tests/test_border.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Needed Tests
 
     Component.draw_border() tests

--- a/chaco/tests/test_colormapper.py
+++ b/chaco/tests/test_colormapper.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy import allclose, array, ravel

--- a/chaco/tests/test_data_frame_plot_data.py
+++ b/chaco/tests/test_data_frame_plot_data.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import contextlib
 import unittest
 

--- a/chaco/tests/test_data_view.py
+++ b/chaco/tests/test_data_view.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from chaco.api import DataRange2D, DataView, GridDataSource

--- a/chaco/tests/test_datarange_1d.py
+++ b/chaco/tests/test_datarange_1d.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy import arange, array, zeros, inf

--- a/chaco/tests/test_datarange_2d.py
+++ b/chaco/tests/test_datarange_2d.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy import alltrue, arange, array, ravel, transpose, zeros, inf, isinf

--- a/chaco/tests/test_default_colormaps.py
+++ b/chaco/tests/test_default_colormaps.py
@@ -1,14 +1,13 @@
-# ------------------------------------------------------------------------------
-# Copyright (c) 2014, Enthought, Inc.
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
+
 import unittest
 
 import numpy as np

--- a/chaco/tests/test_discrete_colormapper.py
+++ b/chaco/tests/test_discrete_colormapper.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy import array, empty, uint8

--- a/chaco/tests/test_function_data_source.py
+++ b/chaco/tests/test_function_data_source.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Test of FunctionDataSource behavior.
 """

--- a/chaco/tests/test_grid_data_source.py
+++ b/chaco/tests/test_grid_data_source.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Tests of GridDataSource behavior.
 """

--- a/chaco/tests/test_grid_mapper.py
+++ b/chaco/tests/test_grid_mapper.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 from numpy import array, transpose
 from numpy.testing import assert_equal

--- a/chaco/tests/test_highlight_tool.py
+++ b/chaco/tests/test_highlight_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from traits.api import HasTraits, Instance

--- a/chaco/tests/test_hittest.py
+++ b/chaco/tests/test_hittest.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Test cases for the LinePlot's hittest() function
 """

--- a/chaco/tests/test_image_data.py
+++ b/chaco/tests/test_image_data.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Test of ImageData behavior.
 """

--- a/chaco/tests/test_image_utils.py
+++ b/chaco/tests/test_image_utils.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy.testing import assert_allclose, assert_equal

--- a/chaco/tests/test_instantiation_order.py
+++ b/chaco/tests/test_instantiation_order.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Tests that various plot and data objects can be instantiated, assigned, and
 re-assigned in any order.

--- a/chaco/tests/test_linearmapper.py
+++ b/chaco/tests/test_linearmapper.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 from numpy import array, ndarray
 from numpy.testing import assert_array_almost_equal, assert_equal

--- a/chaco/tests/test_logmapper.py
+++ b/chaco/tests/test_logmapper.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 from numpy import array, nan
 from numpy.testing import assert_array_almost_equal, assert_equal

--- a/chaco/tests/test_multi_array_data_source.py
+++ b/chaco/tests/test_multi_array_data_source.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Test of MultiArrayDataSource behavior.
 """

--- a/chaco/tests/test_plot.py
+++ b/chaco/tests/test_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy import alltrue, arange, array

--- a/chaco/tests/test_plot_factory.py
+++ b/chaco/tests/test_plot_factory.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from unittest import TestCase
 import numpy as np
 

--- a/chaco/tests/test_plotcontainer.py
+++ b/chaco/tests/test_plotcontainer.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import sys
 import unittest
 

--- a/chaco/tests/test_speedups.py
+++ b/chaco/tests/test_speedups.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from numpy import alltrue, array, ravel, zeros, isinf, linspace

--- a/chaco/tests/test_ticks.py
+++ b/chaco/tests/test_ticks.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 from chaco.ticks import DefaultTickGenerator, MinorTickGenerator, auto_interval

--- a/chaco/text_box_overlay.py
+++ b/chaco/text_box_overlay.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.overlays.text_box_overlay import TextBoxOverlay  # noqa: F401

--- a/chaco/text_plot.py
+++ b/chaco/text_plot.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 """
 A plot that renders text values in two dimensions
 """

--- a/chaco/text_plot_1d.py
+++ b/chaco/text_plot_1d.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.plots.text_plot_1d import TextPlot1D  # noqa: F401

--- a/chaco/ticks.py
+++ b/chaco/ticks.py
@@ -1,13 +1,13 @@
-# -------------------------------------------------------------------------------
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-#  Written by: David C. Morrill (based on similar routines written by Eric Jones)
-#
-#  Date: 2007-05-01
-#
-#  (c) Copyright 2002-7 by Enthought, Inc.
-#
-# -------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
+
 """ Tick generator classes and helper functions for calculating axis
 tick-related values (i.e., bounds and intervals).
 

--- a/chaco/toolbar_plot.py
+++ b/chaco/toolbar_plot.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from chaco.plot import Plot
 from chaco.tools.toolbars.plot_toolbar import PlotToolbar
 from traits.api import Type, DelegatesTo, Instance, Enum, observe

--- a/chaco/tools/api.py
+++ b/chaco/tools/api.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from .better_zoom import BetterZoom
 from .better_selecting_zoom import BetterSelectingZoom
 from .broadcaster import BroadcasterTool

--- a/chaco/tools/better_selecting_zoom.py
+++ b/chaco/tools/better_selecting_zoom.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import numpy
 
 from chaco.abstract_overlay import AbstractOverlay

--- a/chaco/tools/better_zoom.py
+++ b/chaco/tools/better_zoom.py
@@ -1,13 +1,12 @@
-# Copyright (c) 2005-2014, Enthought, Inc.
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
+# Thanks for using Enthought open source!
 
 from chaco.grid_mapper import GridMapper
 from enable.api import BaseTool, KeySpec

--- a/chaco/tools/broadcaster.py
+++ b/chaco/tools/broadcaster.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the BroadcasterTool class.
 """
 from enable.api import BaseTool

--- a/chaco/tools/cursor_tool.py
+++ b/chaco/tools/cursor_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """
 Defines some chaco tools to provide draggable cursor functionality
 

--- a/chaco/tools/data_label_tool.py
+++ b/chaco/tools/data_label_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the DataLabelTool class.
 """
 # Major library imports

--- a/chaco/tools/dataprinter.py
+++ b/chaco/tools/dataprinter.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the DataPrinter tool class.
 """
 

--- a/chaco/tools/drag_zoom.py
+++ b/chaco/tools/drag_zoom.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines a the DragZoom tool class
 """
 

--- a/chaco/tools/draw_points_tool.py
+++ b/chaco/tools/draw_points_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the DrawPointsTool class.
 """
 # Major library imports

--- a/chaco/tools/highlight_tool.py
+++ b/chaco/tools/highlight_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the HighlightTool class.
 """
 # Major library imports

--- a/chaco/tools/image_inspector_tool.py
+++ b/chaco/tools/image_inspector_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the ImageInspectorTool, ImageInspectorOverlay, and
 ImageInspectorColorbarOverlay classes.
 """

--- a/chaco/tools/lasso_selection.py
+++ b/chaco/tools/lasso_selection.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the LassoSelection controller class.
 """
 # Major library imports

--- a/chaco/tools/legend_highlighter.py
+++ b/chaco/tools/legend_highlighter.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from itertools import chain
 
 # ETS imports

--- a/chaco/tools/legend_tool.py
+++ b/chaco/tools/legend_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the LegendTool class.
 """
 

--- a/chaco/tools/line_inspector.py
+++ b/chaco/tools/line_inspector.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the LineInspector tool class.
 """
 

--- a/chaco/tools/line_segment_tool.py
+++ b/chaco/tools/line_segment_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the LineSegmentTool class.
 """
 

--- a/chaco/tools/move_tool.py
+++ b/chaco/tools/move_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the MoveTool class.
 """
 # Enthought library imports

--- a/chaco/tools/pan_tool.py
+++ b/chaco/tools/pan_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the PanTool class.
 """
 

--- a/chaco/tools/pan_tool2.py
+++ b/chaco/tools/pan_tool2.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from numpy import inf
 
 from enable.api import Pointer

--- a/chaco/tools/point_marker.py
+++ b/chaco/tools/point_marker.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the PointMarker tool class.
 """
 

--- a/chaco/tools/range_selection.py
+++ b/chaco/tools/range_selection.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the RangeSelection controller class.
 """
 # Major library imports

--- a/chaco/tools/range_selection_2d.py
+++ b/chaco/tools/range_selection_2d.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the RangeSelection controller class.
 """
 # Major library imports

--- a/chaco/tools/range_selection_overlay.py
+++ b/chaco/tools/range_selection_overlay.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the RangeSelectionOverlay class.
 """
 

--- a/chaco/tools/rect_zoom.py
+++ b/chaco/tools/rect_zoom.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the RectZoomTool class.
 """
 from .zoom_tool import ZoomTool

--- a/chaco/tools/rectangular_selection.py
+++ b/chaco/tools/rectangular_selection.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the RectangularSelection controller class.
 """
 import numpy as np

--- a/chaco/tools/regression_lasso.py
+++ b/chaco/tools/regression_lasso.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the RegressionLasso class.
 """
 

--- a/chaco/tools/save_tool.py
+++ b/chaco/tools/save_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the SaveTool class.
 """
 

--- a/chaco/tools/scatter_inspector.py
+++ b/chaco/tools/scatter_inspector.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the ScatterInspector tool class.
 """
 

--- a/chaco/tools/select_tool.py
+++ b/chaco/tools/select_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 # Enthought library imports
 from enable.api import BaseTool, KeySpec
 from traits.api import Enum, Float, Instance

--- a/chaco/tools/simple_inspector.py
+++ b/chaco/tools/simple_inspector.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """Simple Inspector tool for plots
 
 This module provides a simple tool that reports the data-space coordinates of

--- a/chaco/tools/tests/test_better_zoom_tool.py
+++ b/chaco/tools/tests/test_better_zoom_tool.py
@@ -1,13 +1,12 @@
-# Copyright (c) 2014, Enthought, Inc.
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-# Thanks for using Enthought open source!
 #
-# Author: Enthought, Inc.
+# Thanks for using Enthought open source!
 
 """ Tests for the BetterZoom Chaco tool """
 

--- a/chaco/tools/tests/test_image_inspector.py
+++ b/chaco/tools/tests/test_image_inspector.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Tests for the ImageInspectorTool and ImageInspectorOverlay tools.
 """
 

--- a/chaco/tools/tests/test_pan_tool.py
+++ b/chaco/tools/tests/test_pan_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 import numpy as np

--- a/chaco/tools/tests/test_range_selection.py
+++ b/chaco/tools/tests/test_range_selection.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 import warnings
 

--- a/chaco/tools/tests/test_range_zoom.py
+++ b/chaco/tools/tests/test_range_zoom.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from unittest import TestCase
 from unittest.mock import call
 

--- a/chaco/tools/tests/test_rectangular_selection_tool.py
+++ b/chaco/tools/tests/test_rectangular_selection_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import unittest
 
 import numpy as np

--- a/chaco/tools/tests/test_scatter_inspector.py
+++ b/chaco/tools/tests/test_scatter_inspector.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Tests for the ScatterInspector Chaco tool
 """
 

--- a/chaco/tools/tool_history_mixin.py
+++ b/chaco/tools/tool_history_mixin.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the ToolHistoryMixin class.
 """
 from traits.api import HasTraits, Instance, Int, List

--- a/chaco/tools/tool_states.py
+++ b/chaco/tools/tool_states.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from chaco.grid_mapper import GridMapper
 from traits.api import HasTraits
 

--- a/chaco/tools/toolbars/plot_toolbar.py
+++ b/chaco/tools/toolbars/plot_toolbar.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import numpy
 
 from chaco.abstract_overlay import AbstractOverlay

--- a/chaco/tools/toolbars/toolbar_buttons.py
+++ b/chaco/tools/toolbars/toolbar_buttons.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import numpy
 
 from traits.etsconfig.api import ETSConfig

--- a/chaco/tools/tracking_pan_tool.py
+++ b/chaco/tools/tracking_pan_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the TrackingPanTool class.
 """
 # Chaco imports

--- a/chaco/tools/tracking_zoom.py
+++ b/chaco/tools/tracking_zoom.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the TrackingZoom class.
 """
 

--- a/chaco/tools/traits_tool.py
+++ b/chaco/tools/traits_tool.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Defines the TraitsTool and Fifo classes, and get_nested_components90
 function.
 """

--- a/chaco/tools/zoom_tool.py
+++ b/chaco/tools/zoom_tool.py
@@ -1,1 +1,11 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from .better_selecting_zoom import BetterSelectingZoom as ZoomTool

--- a/chaco/tooltip.py
+++ b/chaco/tooltip.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2006-2021 Enthought, Inc., Austin, TX
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -7,6 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+
 import warnings
 
 from chaco.overlays.tooltip import ToolTip  # noqa: F401

--- a/chaco/transform_color_mapper.py
+++ b/chaco/transform_color_mapper.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from numpy import clip, isinf, ones_like, empty
 
 from chaco.color_mapper import ColorMapper

--- a/chaco/ui/axis_ui.py
+++ b/chaco/ui/axis_ui.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ This file contains the ui specifications for the chaco.axis.Axis objects.
 
     Much of it is defined in re-usable chunks so that elements of it can be

--- a/chaco/ui/plot_window.py
+++ b/chaco/ui/plot_window.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 # Enthought library imports
 from traits.api import Instance, HasTraits
 from traitsui.api import View, Item

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,13 @@
-# Copyright (c) 2008-2019 by Enthought, Inc.
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
 # All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import os
 import re
 import runpy


### PR DESCRIPTION
fixes #526 

This PR adds copyright headers to files that dont have them and it updates copyright headers that do have them but have the wrong format/wrong year range etc.

Note that the year range has been updated to 2005-2021 - and there is only one instance of an older year range and it was 2002 in `chaco.ticks`.

Note that this PR will be backported to the `maint/5.0` branch.