### PR TITLE
Refactor chaco OverlayPlotContainer to inherit from enable OverlayContainer

### DIFF
--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -33,6 +33,7 @@ from traits.api import (
     Instance,
     List,
     Property,
+    Str,
     String,
     Trait,
     Tuple,
@@ -105,6 +106,8 @@ class OverlayPlotContainer(BasePlotContainer):
     #: Redefine the container layers to name the main layer as "plot" instead
     #: of the Enable default of "mainlayer"
     container_under_layers = Tuple("background", "image", "underlay", "plot")
+
+    draw_layer = Str("plot")
 
     def get_preferred_size(self, components=None):
         """Returns the size (width,height) that is preferred for this component.

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -39,11 +39,7 @@ from traits.api import (
     Tuple,
     Int,
 )
-from enable.api import Container
-from enable.simple_layout import (
-    simple_container_get_preferred_size,
-    simple_container_do_layout,
-)
+from enable.api import OverlayContainer
 
 try:
     from enable.api import ConstraintsContainer
@@ -90,7 +86,7 @@ if ConstraintsContainer is not None:
     __all__.append("ConstraintsPlotContainer")
 
 
-class OverlayPlotContainer(Container):
+class OverlayPlotContainer(OverlayContainer):
     """
     A plot container that stretches all its components to fit within its
     space.  All of its components must therefore be resizable.
@@ -109,17 +105,6 @@ class OverlayPlotContainer(Container):
     container_under_layers = Tuple("background", "image", "underlay", "plot")
 
     draw_layer = Str("plot")
-
-    def get_preferred_size(self, components=None):
-        """Returns the size (width,height) that is preferred for this component.
-
-        Overrides PlotComponent
-        """
-        return simple_container_get_preferred_size(self, components=components)
-
-    def _do_layout(self):
-        """Actually performs a layout (called by do_layout())."""
-        simple_container_do_layout(self)
 
 
 class StackedPlotContainer(BasePlotContainer):

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -39,6 +39,7 @@ from traits.api import (
     Tuple,
     Int,
 )
+from enable.api import Container
 from enable.simple_layout import (
     simple_container_get_preferred_size,
     simple_container_do_layout,
@@ -89,7 +90,7 @@ if ConstraintsContainer is not None:
     __all__.append("ConstraintsPlotContainer")
 
 
-class OverlayPlotContainer(BasePlotContainer):
+class OverlayPlotContainer(Container):
     """
     A plot container that stretches all its components to fit within its
     space.  All of its components must therefore be resizable.

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -102,6 +102,10 @@ class OverlayPlotContainer(BasePlotContainer):
     # Cache (width, height) of the container's preferred size.
     _cached_preferred_size = Tuple
 
+    #: Redefine the container layers to name the main layer as "plot" instead
+    #: of the Enable default of "mainlayer"
+    container_under_layers = Tuple("background", "image", "underlay", "plot")
+
     def get_preferred_size(self, components=None):
         """Returns the size (width,height) that is preferred for this component.
 


### PR DESCRIPTION
This PR refactors the chaco `OverlayPlotContainer` to inherit from the enable `OverlayContainer`. This PR makes small changes in each commit that slowly move `OverlayPlotContainer` away from the chaco `BasePlotContainer` by redefining the traits on the latter on the former. Finally, we update the inheritance and remove redundant methods on the `OverlayPlotContainer`.

Note that we would like this PR to be backported to the `maint/5.0` branch so that it can be included in the final `maint/5.0` release.