### PR TITLE
Make chaco v/h plot containers inherit from enable v/h stacked containers

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -32,6 +32,12 @@ jobs:
           sudo apt-get install libxcb-render-util0
           sudo apt-get install libxcb-xinerama0
         if: matrix.toolkit != 'null'
+        # NOTE : Temporarily needed for building enable from source
+        # Should be removed when enable 5.2 is released
+      - name: Install GL dependencies necessary to build enable
+        run: |
+          sudo apt-get update
+          sudo apt-get install libglu1-mesa-dev
       - name: Cache EDM packages
         uses: actions/cache@v2
         with:

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -121,6 +121,12 @@ class HPlotContainer(BasePlotContainer):
     # attribute.
     stack_index = 0
 
+    #: Redefine the container layers to name the main layer as "plot" instead
+    #: of the Enable default of "mainlayer"
+    container_under_layers = Tuple("background", "image", "underlay", "plot")
+
+    draw_layer = Str("plot")
+
     draw_order = Instance(list, args=(DEFAULT_DRAWING_ORDER,))
 
     # The dimension along which to stack components that are added to
@@ -182,6 +188,12 @@ class VPlotContainer(BasePlotContainer):
     """
     A plot container that stacks plot components vertically.
     """
+
+    #: Redefine the container layers to name the main layer as "plot" instead
+    #: of the Enable default of "mainlayer"
+    container_under_layers = Tuple("background", "image", "underlay", "plot")
+
+    draw_layer = Str("plot")
 
     draw_order = Instance(list, args=(DEFAULT_DRAWING_ORDER,))
 

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -163,6 +163,13 @@ class HPlotContainer(StackedPlotContainer):
 
     draw_order = Instance(list, args=(DEFAULT_DRAWING_ORDER,))
 
+    # The dimension along which to stack components that are added to
+    # this container.
+    stack_dimension = Str("h", transient=True)
+
+    # The "other" dimension, i.e., the dual of the stack dimension.
+    other_dimension = Str("v", transient=True)
+
     #: The order in which components in the plot container are laid out.
     stack_order = Enum("left_to_right", "right_to_left")
 
@@ -218,10 +225,12 @@ class VPlotContainer(StackedPlotContainer):
 
     draw_order = Instance(list, args=(DEFAULT_DRAWING_ORDER,))
 
-    #: Overrides StackedPlotContainer.
-    stack_dimension = "v"
-    #: Overrides StackedPlotContainer.
-    other_dimension = "h"
+    # The dimension along which to stack components that are added to
+    # this container.
+    stack_dimension = Str("v", transient=True)
+
+    # The "other" dimension, i.e., the dual of the stack dimension.
+    other_dimension = Str("h", transient=True)
 
     # The index into obj.position and obj.bounds that corresponds to
     # **stack_dimension**.  This is a class-level and not an instance-level

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -39,7 +39,7 @@ from traits.api import (
     Tuple,
     Int,
 )
-from enable.api import OverlayContainer
+from enable.api import Container, OverlayContainer
 from enable.stacked_layout import stack_layout, stacked_preferred_size
 
 try:
@@ -108,7 +108,7 @@ class OverlayPlotContainer(OverlayContainer):
     draw_layer = Str("plot")
 
 
-class HPlotContainer(BasePlotContainer):
+class HPlotContainer(Container):
     """
     A plot container that stacks all of its components horizontally. Resizable
     components share the free space evenly. All components are stacked from
@@ -184,7 +184,7 @@ class HPlotContainer(BasePlotContainer):
         return state
 
 
-class VPlotContainer(BasePlotContainer):
+class VPlotContainer(Container):
     """
     A plot container that stacks plot components vertically.
     """

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -108,47 +108,7 @@ class OverlayPlotContainer(OverlayContainer):
     draw_layer = Str("plot")
 
 
-class StackedPlotContainer(BasePlotContainer):
-    """
-    Base class for 1-D stacked plot containers, both horizontal and vertical.
-    """
-
-    draw_order = Instance(list, args=(DEFAULT_DRAWING_ORDER,))
-
-    # The dimension along which to stack components that are added to
-    # this container.
-    stack_dimension = Enum("h", "v", transient=True)
-
-    # The "other" dimension, i.e., the dual of the stack dimension.
-    other_dimension = Enum("v", "h", transient=True)
-
-    # The index into obj.position and obj.bounds that corresponds to
-    # **stack_dimension**.  This is a class-level and not an instance-level
-    # attribute. It must be 0 or 1.
-    stack_index = 0
-
-    def get_preferred_size(self, components=None):
-        """Returns the size (width,height) that is preferred for this component.
-
-        Overrides PlotComponent.
-        """
-        return stacked_preferred_size(container=self, components=components)
-
-    def _do_stack_layout(self, components, align):
-        """Helper method that does the actual work of layout."""
-        stack_layout(container=self, components=components, align=align)
-
-    ### Persistence ###########################################################
-
-    # PICKLE FIXME: blocked with _pickles, but not sure that was correct.
-    def __getstate__(self):
-        state = super().__getstate__()
-        if "stack_index" in state:
-            del state["stack_index"]
-        return state
-
-
-class HPlotContainer(StackedPlotContainer):
+class HPlotContainer(BasePlotContainer):
     """
     A plot container that stacks all of its components horizontally. Resizable
     components share the free space evenly. All components are stacked from
@@ -218,7 +178,7 @@ class HPlotContainer(StackedPlotContainer):
         return state
 
 
-class VPlotContainer(StackedPlotContainer):
+class VPlotContainer(BasePlotContainer):
     """
     A plot container that stacks plot components vertically.
     """

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -39,7 +39,8 @@ from traits.api import (
     Tuple,
     Int,
 )
-from enable.api import HStackedContainer, OverlayContainer, VStackedContainer
+from enable.api import OverlayContainer
+from enable.stacked_container import HStackedContainer, VStackedContainer
 
 try:
     from enable.api import ConstraintsContainer

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -39,7 +39,7 @@ from traits.api import (
     Tuple,
     Int,
 )
-from enable.api import Container, OverlayContainer
+from enable.api import Container, HStackedContainer, OverlayContainer
 from enable.stacked_layout import stack_layout, stacked_preferred_size
 
 try:
@@ -108,18 +108,13 @@ class OverlayPlotContainer(OverlayContainer):
     draw_layer = Str("plot")
 
 
-class HPlotContainer(Container):
+class HPlotContainer(HStackedContainer):
     """
     A plot container that stacks all of its components horizontally. Resizable
     components share the free space evenly. All components are stacked from
     according to **stack_order* in the same order that they appear in the
     **components** list.
     """
-
-    # The index into obj.position and obj.bounds that corresponds to
-    # **stack_dimension**.  This is a class-level and not an instance-level
-    # attribute.
-    stack_index = 0
 
     #: Redefine the container layers to name the main layer as "plot" instead
     #: of the Enable default of "mainlayer"
@@ -129,50 +124,7 @@ class HPlotContainer(Container):
 
     draw_order = Instance(list, args=(DEFAULT_DRAWING_ORDER,))
 
-    # The dimension along which to stack components that are added to
-    # this container.
-    stack_dimension = Str("h", transient=True)
-
-    # The "other" dimension, i.e., the dual of the stack dimension.
-    other_dimension = Str("v", transient=True)
-
-    #: The order in which components in the plot container are laid out.
-    stack_order = Enum("left_to_right", "right_to_left")
-
-    #: The amount of space to put between components.
-    spacing = Float(0.0)
-
-    #: The vertical alignment of objects that don't span the full height.
-    valign = Enum("bottom", "top", "center")
-
     _cached_preferred_size = Tuple(transient=True)
-
-    def get_preferred_size(self, components=None):
-        """Returns the size (width,height) that is preferred for this component.
-
-        Overrides PlotComponent.
-        """
-        return stacked_preferred_size(container=self, components=components)
-
-    def _do_stack_layout(self, components, align):
-        """Helper method that does the actual work of layout."""
-        stack_layout(container=self, components=components, align=align)
-
-    def _do_layout(self):
-        """Actually performs a layout (called by do_layout())."""
-        if self.stack_order == "left_to_right":
-            components = self.components
-        else:
-            components = self.components[::-1]
-
-        if self.valign == "bottom":
-            align = "min"
-        elif self.valign == "center":
-            align = "center"
-        else:
-            align = "max"
-
-        return self._do_stack_layout(components, align)
 
     ### Persistence ###########################################################
 

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -39,8 +39,7 @@ from traits.api import (
     Tuple,
     Int,
 )
-from enable.api import Container, HStackedContainer, OverlayContainer
-from enable.stacked_layout import stack_layout, stacked_preferred_size
+from enable.api import HStackedContainer, OverlayContainer, VStackedContainer
 
 try:
     from enable.api import ConstraintsContainer
@@ -136,7 +135,7 @@ class HPlotContainer(HStackedContainer):
         return state
 
 
-class VPlotContainer(Container):
+class VPlotContainer(VStackedContainer):
     """
     A plot container that stacks plot components vertically.
     """
@@ -148,55 +147,6 @@ class VPlotContainer(Container):
     draw_layer = Str("plot")
 
     draw_order = Instance(list, args=(DEFAULT_DRAWING_ORDER,))
-
-    # The dimension along which to stack components that are added to
-    # this container.
-    stack_dimension = Str("v", transient=True)
-
-    # The "other" dimension, i.e., the dual of the stack dimension.
-    other_dimension = Str("h", transient=True)
-
-    # The index into obj.position and obj.bounds that corresponds to
-    # **stack_dimension**.  This is a class-level and not an instance-level
-    # attribute.
-    stack_index = 1
-
-    # VPlotContainer attributes
-
-    #: The horizontal alignment of objects that don't span the full width.
-    halign = Enum("left", "right", "center")
-
-    #: The order in which components in the plot container are laid out.
-    stack_order = Enum("bottom_to_top", "top_to_bottom")
-
-    #: The amount of space to put between components.
-    spacing = Float(0.0)
-
-    def get_preferred_size(self, components=None):
-        """Returns the size (width,height) that is preferred for this component.
-
-        Overrides PlotComponent.
-        """
-        return stacked_preferred_size(container=self, components=components)
-
-    def _do_stack_layout(self, components, align):
-        """Helper method that does the actual work of layout."""
-        stack_layout(container=self, components=components, align=align)
-
-    def _do_layout(self):
-        """Actually performs a layout (called by do_layout())."""
-        if self.stack_order == "bottom_to_top":
-            components = self.components
-        else:
-            components = self.components[::-1]
-        if self.halign == "left":
-            align = "min"
-        elif self.halign == "center":
-            align = "center"
-        else:
-            align = "max"
-
-        return self._do_stack_layout(components, align)
 
     ### Persistence ###########################################################
 

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -148,6 +148,8 @@ class VPlotContainer(VStackedContainer):
 
     draw_order = Instance(list, args=(DEFAULT_DRAWING_ORDER,))
 
+    _cached_preferred_size = Tuple(transient=True)
+
     ### Persistence ###########################################################
 
     # PICKLE FIXME: blocked with _pickles, but not sure that was correct.

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -174,6 +174,17 @@ class HPlotContainer(StackedPlotContainer):
 
     _cached_preferred_size = Tuple(transient=True)
 
+    def get_preferred_size(self, components=None):
+        """Returns the size (width,height) that is preferred for this component.
+
+        Overrides PlotComponent.
+        """
+        return stacked_preferred_size(container=self, components=components)
+
+    def _do_stack_layout(self, components, align):
+        """Helper method that does the actual work of layout."""
+        stack_layout(container=self, components=components, align=align)
+
     def _do_layout(self):
         """Actually performs a layout (called by do_layout())."""
         if self.stack_order == "left_to_right":
@@ -227,6 +238,17 @@ class VPlotContainer(StackedPlotContainer):
 
     #: The amount of space to put between components.
     spacing = Float(0.0)
+
+    def get_preferred_size(self, components=None):
+        """Returns the size (width,height) that is preferred for this component.
+
+        Overrides PlotComponent.
+        """
+        return stacked_preferred_size(container=self, components=components)
+
+    def _do_stack_layout(self, components, align):
+        """Helper method that does the actual work of layout."""
+        stack_layout(container=self, components=components, align=align)
 
     def _do_layout(self):
         """Actually performs a layout (called by do_layout())."""

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -156,6 +156,11 @@ class HPlotContainer(StackedPlotContainer):
     **components** list.
     """
 
+    # The index into obj.position and obj.bounds that corresponds to
+    # **stack_dimension**.  This is a class-level and not an instance-level
+    # attribute.
+    stack_index = 0
+
     draw_order = Instance(list, args=(DEFAULT_DRAWING_ORDER,))
 
     #: The order in which components in the plot container are laid out.
@@ -185,6 +190,15 @@ class HPlotContainer(StackedPlotContainer):
 
         return self._do_stack_layout(components, align)
 
+    ### Persistence ###########################################################
+
+    # PICKLE FIXME: blocked with _pickles, but not sure that was correct.
+    def __getstate__(self):
+        state = super().__getstate__()
+        if "stack_index" in state:
+            del state["stack_index"]
+        return state
+
 
 class VPlotContainer(StackedPlotContainer):
     """
@@ -197,7 +211,10 @@ class VPlotContainer(StackedPlotContainer):
     stack_dimension = "v"
     #: Overrides StackedPlotContainer.
     other_dimension = "h"
-    #: Overrides StackedPlotContainer.
+
+    # The index into obj.position and obj.bounds that corresponds to
+    # **stack_dimension**.  This is a class-level and not an instance-level
+    # attribute.
     stack_index = 1
 
     # VPlotContainer attributes
@@ -225,6 +242,15 @@ class VPlotContainer(StackedPlotContainer):
             align = "max"
 
         return self._do_stack_layout(components, align)
+
+    ### Persistence ###########################################################
+
+    # PICKLE FIXME: blocked with _pickles, but not sure that was correct.
+    def __getstate__(self):
+        state = super().__getstate__()
+        if "stack_index" in state:
+            del state["stack_index"]
+        return state
 
 
 class GridPlotContainer(BasePlotContainer):

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -218,6 +218,25 @@ def install(runtime, toolkit, environment, editable, source):
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)
 
+    # NOTE : temporary code to install enable from source instead of relying on
+    # enable 5.1.1. This should be removed immediately after enable 5.2.0 is
+    # released.
+    command = "edm plumbing remove-package --environment {environment} --force enable"  # noqa
+    execute([command], parameters)
+    source_pkgs = [
+        "git+http://github.com/enthought/enable.git@maint/5.2#egg=enable"
+    ]
+    # Without the --no-dependencies flag such that new dependencies on
+    # master are brought in.
+    commands = [
+        "python -m pip install --force-reinstall {pkg} ".format(pkg=pkg)
+        for pkg in source_pkgs
+    ]
+    commands = [
+        "edm run -e {environment} -- " + command for command in commands
+    ]
+    execute(commands, parameters)
+
     if source:
         # Remove EDM ETS packages and install them from source
         cmd_fmt = (


### PR DESCRIPTION
This PR refactors the `HPlotContainer` and `VPlotContainer` classes in enable to inherit from the enable `HStackedContainer` and `VStackedContainer` respectively. This removes duplicate code between chaco and enable. In the end, in our opinion, the `*PlotContainer` classes in chaco are more-readable than they were before.

Note that this PR was written with enable main branch in mind - but it should work with the current release of `enable` as well. This PR is what will introduce the dependency on `enable >= 5.2` on the upcoming `chaco` major release.

This PR can be reviewed one commit at a time as we have taken great care to keep the commits self-contained. Each commit makes only one type of change, which we hope will make the review process simpler.

This is the last big PR extracted from #674.

Note that we would like this PR to be backported to the `maint/5.0` branch so that it can be included in the chaco 5.0.0 major release.