### PR TITLE
Backport Remove all definitions / uses of _draw_component (#743)

### DIFF
--- a/chaco/base_xy_plot.py
+++ b/chaco/base_xy_plot.py
@@ -484,12 +484,6 @@ class BaseXYPlot(AbstractPlotRenderer):
 
     def _draw_plot(self, gc, view_bounds=None, mode="normal"):
         """Draws the 'plot' layer."""
-        self._draw_component(gc, view_bounds, mode)
-
-    def _draw_component(self, gc, view_bounds=None, mode="normal"):
-        # This method should be folded into self._draw_plot(), but is here for
-        # backwards compatibilty with non-draw-order stuff.
-
         pts = self.get_screen_points()
         self._render(gc, pts)
 

--- a/chaco/plots/colormapped_scatterplot.py
+++ b/chaco/plots/colormapped_scatterplot.py
@@ -131,7 +131,7 @@ class ColormappedScatterPlot(ScatterPlot):
             # Take into account fill_alpha even if we are rendering with only two values
             old_color = self.color
             self.color = tuple(self.fill_alpha * array(self.color_))
-            super()._draw_component(gc, view_bounds, mode)
+            super()._draw_plot(gc, view_bounds, mode)
             self.color = old_color
         else:
             colors = self._cached_data_pts[:, 2]

--- a/chaco/plots/polar_line_renderer.py
+++ b/chaco/plots/polar_line_renderer.py
@@ -132,11 +132,6 @@ class PolarLineRenderer(AbstractPlotRenderer):
 
     def _draw_plot(self, *args, **kw):
         """Draws the 'plot' layer."""
-        # Simple compatibility with new-style rendering loop
-        return self._draw_component(*args, **kw)
-
-    def _draw_component(self, gc, view_bounds=None, mode="normal"):
-        """Renders the component."""
         self._gather_points()
         self._render(gc, self._cached_data_pts)
 

--- a/chaco/tools/regression_lasso.py
+++ b/chaco/tools/regression_lasso.py
@@ -70,8 +70,8 @@ class RegressionOverlay(LassoOverlay):
         ),
     )
 
-    def _draw_component(self, gc, view_bounds=None, mode="normal"):
-        super()._draw_component(gc, view_bounds, mode)
+    def overlay(self, other_component, gc, view_bounds=None, mode="normal"):
+        super().overlay(other_component, gc, view_bounds, mode)
         selection = self.lasso_selection
 
         if selection.fit_params is not None:


### PR DESCRIPTION
targeting `maint/5.0`

This PR backports the recent PR #743, which removed unnecessary definitions and uses of the `_draw_component` method,  to the `maint/5.0` branch.