### PR TITLE
Bring back marker_trait to chaco.api

### DIFF
--- a/chaco/api.py
+++ b/chaco/api.py
@@ -527,3 +527,7 @@ from .default_colormaps import (
     Set3,
 )
 from .default_colors import cbrewer, palette11, palette14, PALETTES
+
+# Importing into the Chaco namespace for backwards compatibility.  New code
+# should directly import from Enable.
+from enable.markers import marker_trait


### PR DESCRIPTION
[targeting `maint/5.0`]

closes #771 

There are still users trying to import `marker_trait` from chaco not enable.  To avoid causing breakages with the upcoming release, we are undoing this change for now.