### PR TITLE
Fix _draw_overlay in chaco.axis

### DIFF
--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -292,7 +292,7 @@ class PlotAxis(AbstractOverlay):
 
         if not self._cache_valid:
             self._calculate_geometry()
-            self._compute_tick_positions(gc, component)
+            self._compute_tick_positions(gc)
             self._compute_labels(gc)
 
         with gc:


### PR DESCRIPTION
This got broken in #743 

`component` was always None in this case (hence the removed `if component is not None:`.  I had just missed this before.