### PR TITLE
Backport fix of chaco.axis 

### DIFF
--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -292,7 +292,7 @@ class PlotAxis(AbstractOverlay):
 
         if not self._cache_valid:
             self._calculate_geometry()
-            self._compute_tick_positions(gc, component)
+            self._compute_tick_positions(gc)
             self._compute_labels(gc)
 
         with gc:


### PR DESCRIPTION
This had been broken in PR #743 and was recently fixed on the maint/5.0 branch.  This PR simply pulls that fix back up into master