### PR TITLE
flip IS_RELEASED back to false for continued development

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ from Cython.Build import cythonize
 MAJOR = 5
 MINOR = 0
 MICRO = 0
-PRERELEASE = "rc2"
-IS_RELEASED = True
+PRERELEASE = ""
+IS_RELEASED = False
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from Cython.Build import cythonize
 MAJOR = 5
 MINOR = 0
 MICRO = 0
-PRERELEASE = ""
+PRERELEASE = "rc3"
 IS_RELEASED = False
 
 # If this file is part of a Git export (for example created with "git archive",


### PR DESCRIPTION
This PR simply flips `IS_RELEASED` back to `False` following the 5.0.0rc2, for continued development in advance of the full 5.0.0 release