### PR TITLE
Remove unneeded __getstate__ methods

### DIFF
--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -126,15 +126,6 @@ class HPlotContainer(HStackedContainer):
 
     _cached_preferred_size = Tuple(transient=True)
 
-    ### Persistence ###########################################################
-
-    # PICKLE FIXME: blocked with _pickles, but not sure that was correct.
-    def __getstate__(self):
-        state = super().__getstate__()
-        if "stack_index" in state:
-            del state["stack_index"]
-        return state
-
 
 class VPlotContainer(VStackedContainer):
     """
@@ -150,15 +141,6 @@ class VPlotContainer(VStackedContainer):
     draw_order = Instance(list, args=(DEFAULT_DRAWING_ORDER,))
 
     _cached_preferred_size = Tuple(transient=True)
-
-    ### Persistence ###########################################################
-
-    # PICKLE FIXME: blocked with _pickles, but not sure that was correct.
-    def __getstate__(self):
-        state = super().__getstate__()
-        if "stack_index" in state:
-            del state["stack_index"]
-        return state
 
 
 class GridPlotContainer(BasePlotContainer):


### PR DESCRIPTION
These methods were pulled up into the `StackedContainer` base class in enable in PR https://github.com/enthought/enable/pull/841

Note that PR was merged into enable master and we test against enable maint/5.2.  Once https://github.com/enthought/enable/pull/845 is merged we can go ahead with this PR.

Note this PR should not block the release.  If it does get merged in time in can be backported into `maint/5.0`. 