### PR TITLE
Use oldest-supported-numpy in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["cython", "numpy", "setuptools", "wheel"]
+requires = ["cython", "oldest-supported-numpy", "setuptools", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
fixes #778 by following the suggestion of this comment: https://github.com/enthought/chaco/issues/778#issuecomment-859460130

We will want to backport this to `maint/5.0` prior to the 5.0.0 release