### PR TITLE
Backport pyproject toml fix 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -149,8 +149,7 @@ Build/CI
 * Skip test_dont_crash_on_click on windows/pyqt (#666)
 * Cleanup ci module and setup (#695)
 * Unskip no longer failing test (#714)
-* Add pyproject.toml specifying numpy and cython as build deps (#730)
-* Add pyproject.toml to MANIFEST.in (#747)
+* Add pyproject.toml specifying numpy and cython as build deps (#730, #747, #779)
 
 Release 4.8.0
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["cython", "numpy", "setuptools", "wheel"]
+requires = ["cython", "oldest-supported-numpy", "setuptools", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR backports the recent fix to `pyproject.toml` to the `maint/5.0` branch and updates the changelog.