### PR TITLE
Remove is_qt4 checks

### DIFF
--- a/chaco/plots/tests/test_image_plot.py
+++ b/chaco/plots/tests/test_image_plot.py
@@ -45,16 +45,6 @@ TRIM_RENDERED = (slice(1, -1), slice(1, -1), 0)
 is_null = ETSConfig.toolkit == "null"
 
 
-def is_qt4():
-    if not ETSConfig.toolkit.startswith('qt'):
-        return False
-
-    # Only AFTER confirming Qt's availability...
-    # We lean on Pyface here since the check is complicated.
-    import pyface.qt
-    return pyface.qt.is_qt4
-
-
 @contextmanager
 def temp_image_file(suffix=".tif", prefix="test", dir=None):
     fd, filename = tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=dir)
@@ -197,7 +187,7 @@ class TestResultImage(unittest.TestCase):
         )
 
     # regression test for enthought/chaco#528
-    @unittest.skipIf(is_null or is_qt4(), "Skip on 'null' or 'qt4' toolkit")
+    @unittest.skipIf(is_null, "Skip on 'null' toolkit")
     def test_resize_to_zero(self):
         class TestResize(HasTraits):
             plot = Instance(Component)

--- a/chaco/tests/test_plot.py
+++ b/chaco/tests/test_plot.py
@@ -24,16 +24,6 @@ from chaco.default_colormaps import viridis
 from chaco.tools.api import PanTool, ZoomTool
 
 
-def is_qt4():
-    if not ETSConfig.toolkit.startswith('qt'):
-        return False
-
-    # Only AFTER confirming Qt's availability...
-    # We lean on Pyface here since the check is complicated.
-    import pyface.qt
-    return pyface.qt.is_qt4
-
-
 class PlotTestCase(unittest.TestCase):
     def test_plot_from_unsupported_array_shape(self):
         arr = arange(8).reshape(2, 2, 2)
@@ -143,7 +133,6 @@ class EmptyLinePlot(HasTraits):
 @unittest.skipIf(ETSConfig.toolkit == "null", "Skip on 'null' toolkit")
 class TestEmptyPlot(unittest.TestCase, EnableTestAssistant):
 
-    @unittest.skipIf(is_qt4(), "Test breaks on pyqt")
     def test_dont_crash_on_click(self):
         from traitsui.testing.api import UITester
         tester = UITester()


### PR DESCRIPTION
targeting `stop-testing-pyqt4`.  This PR sits on top of #782 and removes unneeded (unneeded once pyqt is no longer tested on CI) checks / code blocks for pyqt4.