### PR TITLE
Address deprecation warnings because of moved modules in chaco

### DIFF
--- a/chaco/base_2d_plot.py
+++ b/chaco/base_2d_plot.py
@@ -19,10 +19,10 @@ from traits.api import Enum, Event, Instance, Property, Range, Trait
 # Local relative imports
 from .abstract_plot_renderer import AbstractPlotRenderer
 from .base import reverse_map_1d
-from .plot_label import PlotLabel
 from .grid_data_source import GridDataSource
 from .grid_mapper import GridMapper
 from .image_data import ImageData
+from .overlays.plot_label import PlotLabel
 
 
 class Base2DPlot(AbstractPlotRenderer):

--- a/chaco/base_xy_plot.py
+++ b/chaco/base_xy_plot.py
@@ -26,7 +26,7 @@ from .array_data_source import ArrayDataSource
 from .axis import PlotAxis
 from .base import point_line_distance, reverse_map_1d
 from .grid import PlotGrid
-from .plot_label import PlotLabel
+from .overlays.plot_label import PlotLabel
 
 
 class BaseXYPlot(AbstractPlotRenderer):

--- a/chaco/plot.py
+++ b/chaco/plot.py
@@ -33,10 +33,10 @@ from .default_colormaps import Spectral
 from .grid_data_source import GridDataSource
 from .grid_mapper import GridMapper
 from .image_data import ImageData
-from .legend import Legend
 from .linear_mapper import LinearMapper
 from .log_mapper import LogMapper
-from .plot_label import PlotLabel
+from .overlays.legend import Legend
+from .overlays.plot_label import PlotLabel
 from .plots.barplot import BarPlot
 from .plots.candle_plot import CandlePlot
 from .plots.colormapped_scatterplot import ColormappedScatterPlot

--- a/chaco/selectable_legend.py
+++ b/chaco/selectable_legend.py
@@ -11,7 +11,7 @@
 from chaco.tools.select_tool import SelectTool
 from traits.api import List
 
-from .legend import Legend
+from .overlays.legend import Legend
 
 
 class SelectableLegend(Legend, SelectTool):

--- a/chaco/tests/test_array_or_none.py
+++ b/chaco/tests/test_array_or_none.py
@@ -15,11 +15,11 @@ import numpy as np
 
 from chaco.array_data_source import ArrayDataSource
 from chaco.axis import PlotAxis
-from chaco.data_label import DataLabel
 from chaco.data_range_1d import DataRange1D
 from chaco.label_axis import LabelAxis
-from chaco.legend import Legend
 from chaco.linear_mapper import LinearMapper
+from chaco.overlays.data_label import DataLabel
+from chaco.overlays.legend import Legend
 from chaco.plots.scatterplot import ScatterPlot
 
 

--- a/chaco/tools/image_inspector_tool.py
+++ b/chaco/tools/image_inspector_tool.py
@@ -17,8 +17,8 @@ from traits.api import Any, Bool, Enum, Event, Tuple
 
 # Chaco imports
 from chaco.abstract_overlay import AbstractOverlay
+from chaco.overlays.text_box_overlay import TextBoxOverlay
 from chaco.plots.image_plot import ImagePlot
-from chaco.text_box_overlay import TextBoxOverlay
 
 
 class ImageInspectorTool(BaseTool):

--- a/chaco/tools/regression_lasso.py
+++ b/chaco/tools/regression_lasso.py
@@ -21,8 +21,8 @@ from enable.api import ColorTrait, LineStyle
 from traits.api import Any, Float, Instance
 
 # Chaco imports
-from chaco.lasso_overlay import LassoOverlay
 from chaco.label import Label
+from chaco.overlays.lasso_overlay import LassoOverlay
 from .lasso_selection import LassoSelection
 
 


### PR DESCRIPTION
This PR addresses deprecation warnings raised in chaco because of the recent moves in chaco i.e. `chaco.plots` and `chaco.overlays`. Note that this PR needs to be backported to the `maint/5.0` branch and included in the 5.0 release.