### PR TITLE
Specify size_or_ary contains ints

### DIFF
--- a/chaco/plot_graphics_context.py
+++ b/chaco/plot_graphics_context.py
@@ -34,8 +34,8 @@ class PlotGraphicsContextMixin(object):
         scale = kw.pop("dpi", 72.0) / 72.0
         if type(size_or_ary) in (list, tuple) and len(size_or_ary) == 2:
             size_or_ary = (
-                size_or_ary[0] * scale + 1,
-                size_or_ary[1] * scale + 1,
+                int(size_or_ary[0] * scale + 1),
+                int(size_or_ary[1] * scale + 1),
             )
 
         super().__init__(


### PR DESCRIPTION
part of #785 
As mentioned in the issue, we can resolve many test suite errors with celiagg by enforcing these be ints.  Note that scale itself I think can be a float (e.g. the `scale_ctm` method expects floats as arguments), however, `size_or_ary` gets used as a `_width` and `_height` and is assumed to contain integers. 

~Note, with this change I now see 2 failures in the test suite:~ EDIT: I only see the one error mentioned on the issue:
```
======================================================================
FAIL: test_draw_border_simple (chaco.tests.test_border.DrawBorderTestCase)
Borders should have the correct height and width.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/aayres/Desktop/chaco/chaco/tests/test_border.py", line 52, in test_draw_border_simple
    self.assertRavelEqual(actual, desired)
  File "/Users/aayres/Desktop/chaco/chaco/tests/test_border.py", line 29, in assertRavelEqual
    alltrue(ravel(x) == ravel(y)), "\n%s\n !=\n%s" % (x, y)
AssertionError: False is not true : 
[[  0   0   0   0   0   0]
 [  0   0   0   0   0   0]
 [  0   0 255 255   0   0]
 [  0   0 255 255   0   0]
 [  0   0   0   0   0   0]
 [  0   0   0   0   0   0]]
 !=
[[255 255 255 255 255 255]
 [255   0   0   0   0 255]
 [255   0 255 255   0 255]
 [255   0 255 255   0 255]
 [255   0   0   0   0 255]
 [255 255 255 255 255 255]]
```
