### PR TITLE
Explicitly require enable 5.2.0 which is now on PyPI

### DIFF
--- a/chaco/__init__.py
+++ b/chaco/__init__.py
@@ -10,7 +10,7 @@ except ImportError:
 
 
 __requires__ = [
-    "traits>=6.2.0", "traitsui", "pyface>=7.2.0", "numpy", "enable"
+    "traits>=6.2.0", "traitsui", "pyface>=7.2.0", "numpy", "enable>=5.2.0"
 ]
 
 


### PR DESCRIPTION
Now that enable 5.2.0 has been uploaded to pypi, we can explicitly add the requirement. 

This PR should be pulled back into master as well 