### PR TITLE
Bump version and set IS_RELEASED to False for development of 5.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ from Cython.Build import cythonize
 
 MAJOR = 5
 MINOR = 0
-MICRO = 0
+MICRO = 1
 PRERELEASE = ""
-IS_RELEASED = True
+IS_RELEASED = False
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
This PR simply bumps the version number in setup.py for continued development.