### PR TITLE
Fix a couple more links in documentation

### DIFF
--- a/docs/source/user_manual/basic_elements/tools.rst
+++ b/docs/source/user_manual/basic_elements/tools.rst
@@ -126,8 +126,8 @@ The event data contains 3 keys: `indices` with the 2D coordinates of the mouse
 in data space, `color_value` containing the color of the tile where the mouse
 is, and `data_value` with the scalar value being displayed in that tile.
 
-For a complete example, see :download:`examples/demo/basic/image_inspector.py
-<../../../examples/demo/basic/image_inspector.py>`.
+For a complete example, see :download:`chaco/examples/demo/basic/image_inspector.py
+<../../../chaco/examples/demo/basic/image_inspector.py>`.
 
 .. todo:: Fill in the below sections
 

--- a/docs/source/user_manual/tutorial_hyetograph.rst
+++ b/docs/source/user_manual/tutorial_hyetograph.rst
@@ -353,5 +353,5 @@ Source Code
 The final version of the program,
 `hyetograph.py <https://github.com/enthought/chaco/blob/master/chaco/examples/demo/hyetograph.py>`_. 
 
-.. literalinclude:: /../../examples/demo/hyetograph.py
+.. literalinclude:: /../../chaco/examples/demo/hyetograph.py
    :language: python

--- a/docs/source/user_manual/tutorial_van_der_waal.rst
+++ b/docs/source/user_manual/tutorial_van_der_waal.rst
@@ -321,5 +321,5 @@ Source Code
 The final version of the program,
 `vanderwaals.py <https://github.com/enthought/chaco/blob/master/chaco/examples/demo/vanderwaals.py>`_
 
-.. literalinclude:: /../../examples/demo/vanderwaals.py
+.. literalinclude:: /../../chaco/examples/demo/vanderwaals.py
    :language: python


### PR DESCRIPTION
Ref: #792 

This PR fixes a couple other links to examples in the documentation.  Note these changes _were_ included in the gh-pages PR