### PR TITLE
Backport #795 - Use enable from edm instead of git/github source

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -32,12 +32,6 @@ jobs:
           sudo apt-get install libxcb-render-util0
           sudo apt-get install libxcb-xinerama0
         if: matrix.toolkit != 'null'
-        # NOTE : Temporarily needed for building enable from source
-        # Should be removed when enable 5.2 is released
-      - name: Install GL dependencies necessary to build enable
-        run: |
-          sudo apt-get update
-          sudo apt-get install libglu1-mesa-dev
       - name: Cache EDM packages
         uses: actions/cache@v2
         with:

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -218,25 +218,6 @@ def install(runtime, toolkit, environment, editable, source):
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)
 
-    # NOTE : temporary code to install enable from source instead of relying on
-    # enable 5.1.1. This should be removed immediately after enable 5.2.0 is
-    # released.
-    command = "edm plumbing remove-package --environment {environment} --force enable"  # noqa
-    execute([command], parameters)
-    source_pkgs = [
-        "git+http://github.com/enthought/enable.git@maint/5.2#egg=enable"
-    ]
-    # Without the --no-dependencies flag such that new dependencies on
-    # master are brought in.
-    commands = [
-        "python -m pip install --force-reinstall {pkg} ".format(pkg=pkg)
-        for pkg in source_pkgs
-    ]
-    commands = [
-        "edm run -e {environment} -- " + command for command in commands
-    ]
-    execute(commands, parameters)
-
     if source:
         # Remove EDM ETS packages and install them from source
         cmd_fmt = (


### PR DESCRIPTION
This PR backports PR #795 to the `maint/5.0` branch - updating CI to use enable from EDM instead of installing it from git/github source.