### PR TITLE
Add an ets-from-source cron job on GH Actions

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -1,0 +1,83 @@
+name: Test with ETS packages from source
+
+on:
+  pull_request:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  schedule:
+    # Every Friday at 00:00 UTC
+    - cron:  '0 0 * * 5'
+
+env:
+  INSTALL_EDM_VERSION: 3.2.3
+
+jobs:
+
+  # Test against EDM packages from source on Linux
+  test-with-edm:
+    strategy:
+      matrix:
+        os: ubuntu-latest
+        toolkit: ['null', 'pyqt5', 'pyside2']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Qt dependencies for Linux
+        run: |
+          sudo apt-get update
+          sudo apt-get install qt5-default
+          sudo apt-get install libxkbcommon-x11-0
+          sudo apt-get install libglu1-mesa-dev
+          sudo apt-get install libxcb-icccm4
+          sudo apt-get install libxcb-image0
+          sudo apt-get install libxcb-keysyms1
+          sudo apt-get install libxcb-randr0
+          sudo apt-get install libxcb-render-util0
+          sudo apt-get install libxcb-xinerama0
+        shell: bash
+        if: runner.os == 'Linux'
+      - name: Cache EDM packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}
+      - name: Set up EDM
+        uses: enthought/setup-edm-action@v1
+        with:
+          edm-version: ${{ env.INSTALL_EDM_VERSION }}
+      - name: Install click to the default EDM environment
+        run: edm install -y wheel click coverage
+      - name: Install test environment
+        run: edm run -- python etstool.py install --toolkit=${{ matrix.toolkit }} --source
+      - name: Run tests
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          # kiva agg requires at least 15-bit color depth.
+          # The --server-args assumes xvfb-run is called, hence Linux only.
+          run: --server-args="-screen 0 1024x768x24" edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }}
+
+
+# Test against EDM packages on Windows and OSX
+  test-with-edm:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+        toolkit: ['null', 'pyqt5', 'pyside2']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache EDM packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('ci/edmtool.py') }}
+      - name: Setup EDM
+        uses: enthought/setup-edm-action@v1
+        with:
+          edm-version: ${{ env.INSTALL_EDM_VERSION }}
+      - name: Install click to the default EDM environment
+        run: edm install -y wheel click coverage
+      - name: Install test environment
+        run: edm run -- python ci/edmtool.py install --toolkit=${{ matrix.toolkit }} --source
+      - name: Run tests
+        run: edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }}

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -17,7 +17,7 @@ jobs:
   test-with-edm:
     strategy:
       matrix:
-        os: ubuntu-latest
+        os: [ubuntu-latest]
         toolkit: ['null', 'pyqt5', 'pyside2']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -14,7 +14,7 @@ env:
 jobs:
 
   # Test against EDM packages from source on Linux
-  test-with-edm:
+  test-ets-source-linux:
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -57,8 +57,8 @@ jobs:
           run: --server-args="-screen 0 1024x768x24" edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }}
 
 
-# Test against EDM packages on Windows and OSX
-  test-with-edm:
+# Test against EDM packages from source on Windows and OSX
+  test-ets-source:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -1,7 +1,6 @@
 name: Test with ETS packages from source
 
 on:
-  pull_request:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   schedule:

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache
-          key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}
+          key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('ci/edmtool.py') }}
       - name: Set up EDM
         uses: enthought/setup-edm-action@v1
         with:
@@ -48,7 +48,7 @@ jobs:
       - name: Install click to the default EDM environment
         run: edm install -y wheel click coverage
       - name: Install test environment
-        run: edm run -- python etstool.py install --toolkit=${{ matrix.toolkit }} --source
+        run: edm run -- python ci/edmtool.py install --toolkit=${{ matrix.toolkit }} --source
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1
         with:

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -60,14 +60,8 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
-        toolkit: ['null', 'pyqt', 'pyqt5', 'pyside2']
+        toolkit: ['null', 'pyqt5', 'pyside2']
     runs-on: ${{ matrix.os }}
-    env:
-      # Set root directory, mainly for Windows, so that the EDM Python
-      # environment lives in the same drive as the cloned source. Otherwise
-      # 'pip install' raises an error while trying to compute
-      # relative path between the site-packages and the source directory.
-      EDM_ROOT_DIRECTORY: ${{ github.workspace }}/.edm
     steps:
       - uses: actions/checkout@v2
       - name: Cache EDM packages


### PR DESCRIPTION
This PR adds a cron job on GH Actions (ultimately we would like to drop travis).