### PR TITLE
Add regression test / fix for DataLabelTool

### DIFF
--- a/chaco/tools/data_label_tool.py
+++ b/chaco/tools/data_label_tool.py
@@ -71,7 +71,7 @@ class DataLabelTool(DragTool):
         """
         if self.component:
             label = self.component
-            pointx, pointy = label.component.map_screen(label.data_point)
+            pointx, pointy = label.component.map_screen(label.data_point)[0]
             self._original_offset = (label.x - pointx, label.y - pointy)
             event.window.set_mouse_owner(self, event.net_transform())
             event.handled = True

--- a/chaco/tools/tests/test_data_label_tool.py
+++ b/chaco/tools/tests/test_data_label_tool.py
@@ -1,0 +1,50 @@
+import unittest
+
+import numpy as np
+
+from enable.api import ComponentEditor
+from enable.testing import EnableTestAssistant
+from traits.api import HasTraits, Instance
+from traitsui.api import Item, View
+
+from chaco.api import ArrayPlotData, DataLabel, Plot
+from chaco.tools.api import DataLabelTool
+
+IMAGE = np.random.random_integers(0, 255, size=(100, 200)).astype(np.uint8)
+RGB = np.dstack([IMAGE] * 3)
+
+
+class TestDataLabelTool(unittest.TestCase, EnableTestAssistant):
+
+    # regression test for enthought/chaco#550
+    def test_use_with_2d_plot(self):
+        class Test2DPlot(HasTraits):
+            plot = Instance(Plot)
+
+            traits_view = View(
+                Item('plot', editor=ComponentEditor(), show_label=False),
+                width=500,
+                height=500,
+                resizable=True
+            )
+
+            def _plot_default(self):
+                pd = ArrayPlotData(image=RGB)
+                plot = Plot(pd)
+                self.renderer = plot.img_plot('image')[0]
+
+                label = DataLabel(
+                    component=self.renderer,
+                    data_point=(25, 12)
+                )
+                plot.overlays.append(label)
+                tool = DataLabelTool(label)
+                label.tools.append(tool)
+                return plot
+
+        test_2d_plot = Test2DPlot()
+        # should not fail
+        self.press_move_release(
+            test_2d_plot.plot,
+            [(0, 0), (200, 200), (300, 300)],
+        )

--- a/chaco/tools/tests/test_data_label_tool.py
+++ b/chaco/tools/tests/test_data_label_tool.py
@@ -7,7 +7,7 @@ from enable.testing import EnableTestAssistant
 from traits.api import HasTraits, Instance
 from traitsui.api import Item, View
 
-from chaco.api import ArrayPlotData, DataLabel, Plot
+from chaco.api import ArrayPlotData, create_line_plot, DataLabel, Plot
 from chaco.tools.api import DataLabelTool
 
 IMAGE = np.random.random_integers(0, 255, size=(100, 200)).astype(np.uint8)
@@ -46,5 +46,41 @@ class TestDataLabelTool(unittest.TestCase, EnableTestAssistant):
         # should not fail
         self.press_move_release(
             test_2d_plot.plot,
+            [(0, 0), (200, 200), (300, 300)],
+        )
+
+    def test_use_with_xy_plot(self):
+        class TestXYPlot(HasTraits):
+            plot = Instance(Plot)
+
+            traits_view = View(
+                Item('plot', editor=ComponentEditor(), show_label=False),
+                width=500,
+                height=500,
+                resizable=True
+            )
+
+            def _plot_default(self):
+                values = np.arange(10)
+                plotdata = ArrayPlotData(x=values, y=values)
+
+                plot = Plot(plotdata)
+                self.renderer = plot.plot(
+                    ("x", "y"), type="line", color="blue"
+                )[0]
+
+                label = DataLabel(
+                    component=self.renderer,
+                    data_point=(5, 5)
+                )
+                plot.overlays.append(label)
+                tool = DataLabelTool(label)
+                label.tools.append(tool)
+                return plot
+
+        test_xy_plot = TestXYPlot()
+        # should not fail
+        self.press_move_release(
+            test_xy_plot.plot,
             [(0, 0), (200, 200), (300, 300)],
         )

--- a/chaco/tools/tests/test_data_label_tool.py
+++ b/chaco/tools/tests/test_data_label_tool.py
@@ -7,7 +7,7 @@ from enable.testing import EnableTestAssistant
 from traits.api import HasTraits, Instance
 from traitsui.api import Item, View
 
-from chaco.api import ArrayPlotData, create_line_plot, DataLabel, Plot
+from chaco.api import ArrayPlotData, DataLabel, Plot
 from chaco.tools.api import DataLabelTool
 
 IMAGE = np.random.random_integers(0, 255, size=(100, 200)).astype(np.uint8)


### PR DESCRIPTION
This PR adds a regression test and a fix for the specific error reported on #550.

550 is a bit broader in scope though and would also include #802 (and probably more) to be closed.
Note the changes here were pulled from #726 in an effort to make smaller more reviewable PRs.  However, there is some interconnectedness between these PRs.  This PR should not be merged first, as it will break things without the change in #802

As the issue mentions, currently the `DataLabelTool` is forced to assume the `BasaeXYPlot` way or the `Base2DPlot` way. 
"This difference forces objects that interact with `AbstractPlotRenderers` to make an assumption about the behavior of the `map_screen` method. For example, the `DataLabelTool` assumes the map_screen return shape matches that of `BaseXYPlot` for a single point ((2,)) ... And therefore this tool throws an exception when used with a `Base2DPlot`"

This PR makes `DataLabelTool` follow the `Base2DPlot` way (which we are pushing as the new standard), and #802 makes `BaseXYPlot` do the same.  On this branch, `DataLabelTool` will not work with a `BaseXYPlot`.

EDIT: I've added a failing test for use of `DataLabelTool`with a `BaseXYPlot`.  This test will pass once #802 is merged