### PR TITLE
Make map_screen return an empty array not empty list in empty input case

### DIFF
--- a/chaco/base_1d_plot.py
+++ b/chaco/base_1d_plot.py
@@ -12,7 +12,7 @@
 Abstract base class for 1-D plots which only use one axis
 """
 # Standard library imports
-from numpy import argsort, asarray
+from numpy import argsort, asarray, empty
 
 # Enthought library imports
 from traits.api import (
@@ -121,7 +121,7 @@ class Base1DPlot(AbstractPlotRenderer):
         """
         # data_array is 1D array of length N
         if len(data_array) == 0:
-            return []
+            return empty(shape=(0,))
         return asarray(self.index_mapper.map_screen(data_array))
 
     def map_data(self, screen_pts):

--- a/chaco/base_2d_plot.py
+++ b/chaco/base_2d_plot.py
@@ -11,7 +11,7 @@
 """ Defines the base class for 2-D plots.
 """
 # Standard library imports
-from numpy import asarray, isnan
+from numpy import asarray, empty, isnan
 
 # Enthought library imports.
 from traits.api import Enum, Event, Instance, Property, Range, Trait
@@ -121,7 +121,7 @@ class Base2DPlot(AbstractPlotRenderer):
         """
         # data_pts is Nx2 array
         if len(data_pts) == 0:
-            return []
+            return empty(shape=(0,2))
         return asarray(self.index_mapper.map_screen(data_pts))
 
     def map_data(self, screen_pts):

--- a/chaco/data_view.py
+++ b/chaco/data_view.py
@@ -11,7 +11,7 @@
 """ Defines the DataView class, and associated property traits and property
 functions.
 """
-from numpy import array, transpose
+from numpy import array, empty, transpose
 
 from traits.api import Bool, Enum, Instance, Property
 from enable.api import color_table
@@ -244,7 +244,7 @@ class DataView(OverlayPlotContainer):
         """
         # data_array is Nx2 array
         if len(data_array) == 0:
-            return []
+            return empty(shape=(0,2))
         x_ary, y_ary = transpose(data_array)
         sx = self.index_mapper.map_screen(x_ary)
         sy = self.value_mapper.map_screen(y_ary)

--- a/chaco/plots/jitterplot.py
+++ b/chaco/plots/jitterplot.py
@@ -46,7 +46,7 @@ class JitterPlot(ScatterPlot1D):
         Implements the AbstractPlotRenderer interface.
         """
         if len(data_array) == 0:
-            return np.zeros(0)
+            return np.empty(shape=(0,))
 
         if self._screen_cache_valid:
             sm = self._cached_screen_map

--- a/chaco/plots/polar_line_renderer.py
+++ b/chaco/plots/polar_line_renderer.py
@@ -13,7 +13,7 @@
 
 
 # Major library imports
-from numpy import array, cos, pi, sin, transpose
+from numpy import array, cos, empty, pi, sin, transpose
 
 # Enthought library imports
 from enable.api import black_color_trait, LineStyle
@@ -98,7 +98,7 @@ class PolarLineRenderer(AbstractPlotRenderer):
         """
 
         if len(data_array) == 0:
-            return []
+            return empty(shape=(0, 2))
         elif len(data_array) == 1:
             xtmp, ytmp = transpose(data_array)
             x_ary = xtmp

--- a/examples/demo/advanced/spec_waterfall.py
+++ b/examples/demo/advanced/spec_waterfall.py
@@ -5,7 +5,7 @@ Based on updating_plot.py
 """
 # Major library imports
 import pyaudio
-from numpy import zeros, linspace, short, fromstring, transpose, array
+from numpy import zeros, linspace, short, fromstring, transpose, array, empty
 from scipy import fft
 
 # Enthought library imports
@@ -78,7 +78,7 @@ class WaterfallRenderer(LinePlot):
         provided, then y2_mapper is used.
         """
         if len(data_array) == 0:
-            return []
+            return empty(shape=(0,2))
         x_ary, y_ary = transpose(data_array)
         sx = self.index_mapper.map_screen(x_ary)
         if data_offset is not None:


### PR DESCRIPTION
This pulls some additional changes out of #726.

This is to keep the return type for the method consistent 