### PR TITLE
fix hittest_tool.py example use of map_screen

### DIFF
--- a/chaco/examples/demo/basic/hittest_tool.py
+++ b/chaco/examples/demo/basic/hittest_tool.py
@@ -53,7 +53,7 @@ class HittestTool(BaseTool, AbstractOverlay):
     def overlay(self, plot, gc, view_bounds=None, mode="normal"):
         # If we have a point, draw it to the screen as a small square
         if self.pt is not None:
-            x, y = plot.map_screen(self.pt)
+            x, y = plot.map_screen(self.pt)[0]
             gc.draw_rect((int(x) - 2, int(y) - 2, 4, 4))
 
 


### PR DESCRIPTION
This example became broken by the recent changes to map_screen.
This change was pulled from #726 
Note there are some other examples which did not get pulled into `chaco/examples` that could be fixed as well.  I did not do that as I could not recall if they were planned to be deleted entirely.  See #726 changes to `examples/tutorials/...` 
I am happy to make those changes on this PR if need be.