### PR TITLE
Setup slack notification for cron jobs

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -55,6 +55,33 @@ jobs:
           # The --server-args assumes xvfb-run is called, hence Linux only.
           run: --server-args="-screen 0 1024x768x24" edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }}
 
+  notify-on-linux-failure:
+    needs: test-ets-source-linux
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on failure
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
+
+  notify-on-linux-success:
+    needs: test-ets-source-linux
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on success
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: SUCCESS
+          color: good
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
 
 # Test against EDM packages from source on Windows and OSX
   test-ets-source:
@@ -80,3 +107,31 @@ jobs:
         run: edm run -- python ci/edmtool.py install --toolkit=${{ matrix.toolkit }} --source
       - name: Run tests
         run: edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }}
+
+  notify-on-win-osx-failure:
+    needs: test-ets-source
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on failure
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
+
+  notify-on-win-osx-success:
+    needs: test-ets-source
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on success
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: SUCCESS
+          color: good
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -55,34 +55,6 @@ jobs:
           # The --server-args assumes xvfb-run is called, hence Linux only.
           run: --server-args="-screen 0 1024x768x24" edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }}
 
-  notify-on-linux-failure:
-    needs: test-ets-source-linux
-    if: failure()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Slack channel on failure
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
-          status: FAILED
-          color: danger
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
-
-  notify-on-linux-success:
-    needs: test-ets-source-linux
-    if: success()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Slack channel on success
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
-          status: SUCCESS
-          color: good
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
-
 # Test against EDM packages from source on Windows and OSX
   test-ets-source:
     strategy:
@@ -108,8 +80,8 @@ jobs:
       - name: Run tests
         run: edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }}
 
-  notify-on-win-osx-failure:
-    needs: test-ets-source
+  notify-on-failure:
+    needs: [test-ets-source-linux, test-ets-source]
     if: failure()
     runs-on: ubuntu-latest
     steps:
@@ -122,8 +94,8 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
 
-  notify-on-win-osx-success:
-    needs: test-ets-source
+  notify-on-success:
+    needs: [test-ets-source-linux, test-ets-source]
     if: success()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR sets up the slack notifications for the cron jobs. I manually triggered the cron jobs on this branch to ensure that the slack notifications are fired as expected. Ref https://github.com/enthought/chaco/actions/runs/1027318233

One more step towards https://github.com/enthought/ets/issues/65