### PR TITLE
Add a RtD config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+python:
+  version: 3.8
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/chaco/__init__.py
+++ b/chaco/__init__.py
@@ -15,5 +15,6 @@ __requires__ = [
 
 
 __extras_require__ = {
+    "docs": ["enthought-sphinx-theme", "sphinx"],
     'examples': ['encore', 'scipy', 'pandas']
 }


### PR DESCRIPTION
This PR adds a basic configuration file for Read the Docs. These changes are based on enthought/traits#1478. This is one more step towards enthought/ets#69.

This PR also add a docs extras_require when installing traitsui to make it easy to build the sphinx docs.