### PR TITLE
Follow numpy's advice on how to use the resize function.

### DIFF
--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -18,6 +18,7 @@ from numpy import (
     array,
     cumsum,
     hstack,
+    resize,
     sum,
     zeros,
     zeros_like,
@@ -512,7 +513,7 @@ class GridPlotContainer(BasePlotContainer):
             numrows, numcols = divmod(len(self.components), self.shape[0])
             self.shape = (numrows, numcols)
         grid = array(self.components, dtype=object)
-        grid.resize(self.shape)
+        grid = resize(grid, self.shape)
         grid[grid == 0] = None
         self._grid = grid
         self._layout_needed = True


### PR DESCRIPTION
When working on an application that uses traitsui/chaco, I'm unable to use a visual debugger such as vscode or pycharm.  Instead, chaco raises the following exception.

```python
Exception occurred in traits notification handler for object: <chaco.plot_containers.GridPlotContainer object at 0x7ff52a9d04a0>, trait: shape, old value: (0, 0), new value: (2, 2)
Traceback (most recent call last):
  File "/usr/local/Caskroom/miniconda/base/envs/pybert/lib/python3.8/site-packages/traits/trait_notifiers.py", line 342, in __call__
    self.handler(*args)
  File "/usr/local/Caskroom/miniconda/base/envs/pybert/lib/python3.8/site-packages/chaco/plot_containers.py", line 539, in _shape_changed
    self._reflow_layout()
  File "/usr/local/Caskroom/miniconda/base/envs/pybert/lib/python3.8/site-packages/chaco/plot_containers.py", line 533, in _reflow_layout
    grid.resize(self.shape)
ValueError: cannot resize an array that references or is referenced
by another array in this way.
Use the np.resize function or refcheck=False
```

Following numpy's suggestion of changing to `np.resize(grid, self.shape)` was enough to start using a debugger with this application.  Looking at the codebase for `\.resize\(.+\)` this was the only instance of using resize from the numpy library.