### PR TITLE
MAINT: Replace some identity checks

### DIFF
--- a/chaco/color_mapper.py
+++ b/chaco/color_mapper.py
@@ -344,7 +344,7 @@ class ColorMapper(AbstractColormap):
             self._recalculate()
 
         luts = [self._red_lut, self._green_lut, self._blue_lut]
-        if self.color_depth is "rgba":
+        if self.color_depth == "rgba":
             luts.append(self._alpha_lut)
 
         result = list(zip(*luts))

--- a/chaco/tools/toolbars/plot_toolbar.py
+++ b/chaco/tools/toolbars/plot_toolbar.py
@@ -235,7 +235,7 @@ class PlotToolbar(Container, AbstractOverlay):
             # Overlay positions are not relative to the component's position,
             # so we have to add in the component's position
             cx, cy = component.outer_position
-            if self.location is "top":
+            if self.location == "top":
                 self.x = (
                     cx
                     + (component.width - self.width) / 2
@@ -248,14 +248,14 @@ class PlotToolbar(Container, AbstractOverlay):
                     - height
                     - 2
                 )
-            elif self.location is "bottom":
+            elif self.location == "bottom":
                 self.x = (
                     cx
                     + (component.width - self.width) / 2
                     + component.padding_left
                 )
                 self.y = cy + component.padding_bottom + 2
-            elif self.location is "left":
+            elif self.location == "left":
                 self.x = cx + component.padding_left + 2
                 self.y = (
                     cy


### PR DESCRIPTION
Under Python 3.8 a few `SyntaxWarning`s were raised for comparison with a string literal using "is" when running the tests.
