### PR TITLE
Use the "sphinx-copybutton" extension in documentation

### DIFF
--- a/chaco/__init__.py
+++ b/chaco/__init__.py
@@ -15,6 +15,6 @@ __requires__ = [
 
 
 __extras_require__ = {
-    "docs": ["enthought-sphinx-theme", "sphinx"],
+    "docs": ["enthought-sphinx-theme", "sphinx", "sphinx-copybutton"],
     'examples': ['encore', 'scipy', 'pandas']
 }

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -95,6 +95,8 @@ dependencies = {
     "swig",
 }
 
+pypi_dependencies = {"sphinx-copybutton"}
+
 # Dependencies we install from source for cron tests
 # Order from packages with the most dependencies to one with the least
 # dependencies. Packages are forced re-installed in this order.
@@ -214,6 +216,12 @@ def install(runtime, toolkit, environment, editable, source):
         ("edm run -e {environment} -- pip install -r ci/requirements.txt"
          " --no-dependencies"),
     ]
+
+    if pypi_dependencies:
+        commands.extend([
+            "edm run -e {environment} -- python -m pip install " + dep
+            for dep in pypi_dependencies
+        ])
 
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,6 +34,7 @@ extensions = [
   'sphinx.ext.graphviz',
   'sphinx.ext.intersphinx',
   'sphinx.ext.todo',
+  'sphinx_copybutton',
   'traits.util.trait_documenter',
 ]
 
@@ -94,6 +95,12 @@ today_fmt = '%B %d, %Y'
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+# Options for Sphinx copybutton extension
+# ---------------------------------------
+
+# Matches prompts - "$ ", ">>>" and "..."
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True
 
 # Options for HTML output
 # -----------------------


### PR DESCRIPTION
This PR does the following: 
- Use the `sphinx_copybutton` extension when building the Sphinx documentation
- Make `sphinx-copybutton` a `docs` extra for the `chaco` package
- Add a `pypi_dependencies` section to the `ci/edmtool.py` utility and add `sphinx-copybutton` as a PyPI dependency for the moment.

Ref https://sphinx-copybutton.readthedocs.io/en/latest/