### PR TITLE
FIX: suppress invalid data warnings for handling NaNs in DataRange classes

### DIFF
--- a/chaco/data_range_1d.py
+++ b/chaco/data_range_1d.py
@@ -124,10 +124,10 @@ class DataRange1D(BaseDataRange):
         Implements AbstractDataRange.
         """
         with errstate(invalid="ignore"):
-            # The data array may contain NaNs. These are strictly invalid for
-            # comparison and Numpy would emit a warning. Since we are happy
-            # with the defaul behavior (NaNs are "False" in the mask), we
-            # silence the warning.
+            # Running under context because the data array may contain NaNs.
+            # These are strictly invalid for comparison and Numpy would emit
+            # a warning. Since we are happy with the default behavior (NaNs
+            # become "False" in the mask), we silence the warning.
             mask = (data.view(ndarray) >= self._low_value) & (
                 data.view(ndarray) <= self._high_value
             )

--- a/chaco/data_range_1d.py
+++ b/chaco/data_range_1d.py
@@ -16,7 +16,7 @@ Defines the DataRange1D class.
 # Major library imports
 from math import ceil, floor, log
 
-from numpy import compress, inf, isinf, isnan, ndarray, errstate
+from numpy import compress, errstate, inf, isinf, isnan, ndarray
 
 # Enthought library imports
 from traits.api import Bool, CFloat, Enum, Float, Property, Trait, Callable

--- a/chaco/data_range_1d.py
+++ b/chaco/data_range_1d.py
@@ -16,7 +16,7 @@ Defines the DataRange1D class.
 # Major library imports
 from math import ceil, floor, log
 
-from numpy import compress, inf, isinf, isnan, ndarray
+from numpy import compress, inf, isinf, isnan, ndarray, errstate
 
 # Enthought library imports
 from traits.api import Bool, CFloat, Enum, Float, Property, Trait, Callable
@@ -123,9 +123,15 @@ class DataRange1D(BaseDataRange):
 
         Implements AbstractDataRange.
         """
-        return (data.view(ndarray) >= self._low_value) & (
-            data.view(ndarray) <= self._high_value
-        )
+        with errstate(invalid="ignore"):
+            # The data array may contain NaNs. These are strictly invalid for
+            # comparison and Numpy would emit a warning. Since we are happy
+            # with the defaul behavior (NaNs are "False" in the mask), we
+            # silence the warning.
+            mask = (data.view(ndarray) >= self._low_value) & (
+                data.view(ndarray) <= self._high_value
+            )
+        return mask
 
     def bound_data(self, data):
         """Returns a tuple of indices for the start and end of the first run

--- a/chaco/data_range_2d.py
+++ b/chaco/data_range_2d.py
@@ -12,16 +12,14 @@
 Defines the DataRange2D class.
 """
 
-from numpy import compress, inf, transpose
+from numpy import compress, transpose
 
 # Enthought library imports
 from traits.api import (
-    Any,
     Bool,
     CFloat,
     Instance,
     Property,
-    Trait,
     Tuple,
     observe,
 )

--- a/chaco/data_range_2d.py
+++ b/chaco/data_range_2d.py
@@ -12,7 +12,7 @@
 Defines the DataRange2D class.
 """
 
-from numpy import compress, transpose
+from numpy import compress, errstate, transpose
 
 # Enthought library imports
 from traits.api import (
@@ -94,8 +94,13 @@ class DataRange2D(BaseDataRange):
         Implements AbstractDataRange.
         """
         x_points, y_points = transpose(data)
-        x_mask = (x_points >= self.low[0]) & (x_points <= self.high[0])
-        y_mask = (y_points >= self.low[1]) & (y_points <= self.high[1])
+        with errstate(invalid="ignore"):
+            # Silence possible warnings that may result from NaNs being in the
+            # arrays. It is not strictly needed because apparently comparisons
+            # on arrays resulting from transpose() don't trigger the warning
+            # in the first place. 
+            x_mask = (x_points >= self.low[0]) & (x_points <= self.high[0])
+            y_mask = (y_points >= self.low[1]) & (y_points <= self.high[1])
         return x_mask & y_mask
 
     def bound_data(self, data):

--- a/chaco/data_range_2d.py
+++ b/chaco/data_range_2d.py
@@ -95,10 +95,10 @@ class DataRange2D(BaseDataRange):
         """
         x_points, y_points = transpose(data)
         with errstate(invalid="ignore"):
-            # Silence possible warnings that may result from NaNs being in the
-            # arrays. It is not strictly needed because apparently comparisons
-            # on arrays resulting from transpose() don't trigger the warning
-            # in the first place. 
+            # Running under context because the data array may contain NaNs.
+            # These are strictly invalid for comparison and Numpy would emit
+            # a warning. Since we are happy with the default behavior (NaNs
+            # become "False" in the mask), we silence the warning.
             x_mask = (x_points >= self.low[0]) & (x_points <= self.high[0])
             y_mask = (y_points >= self.low[1]) & (y_points <= self.high[1])
         return x_mask & y_mask

--- a/chaco/tests/test_datarange_1d.py
+++ b/chaco/tests/test_datarange_1d.py
@@ -275,6 +275,11 @@ class DataRangeTestCase(unittest.TestCase):
             assert_equal(r.mask_data(all_nans), array([0, 0, 0], "b"))
 
         # Then (treating nans should come with no warnings)
+        # NOTE: This assertion may pass because the warning has been correctly
+        # silenced by us (useful test), but it may also pass because the
+        # warning has been inactivated by the "only warn once" Python rule
+        # (test ineffective, false negative). Clearing the registry only for
+        # test purposes is not feasible: https://bugs.python.org/issue21724
         self.assertEqual(len(w), 0)
 
     def test_bound_data(self):

--- a/chaco/tests/test_datarange_1d.py
+++ b/chaco/tests/test_datarange_1d.py
@@ -258,7 +258,7 @@ class DataRangeTestCase(unittest.TestCase):
         r = DataRange1D(low=2.0, high=2.5)
         assert_equal(r.mask_data(ary), zeros(len(ary)))
 
-    def test_mask_data_contains_nans(self):
+    def test_mask_data_containing_nans(self):
         # Given
         r = DataRange1D(low=2.0, high=10.0)
         with warnings.catch_warnings(record=True) as w:

--- a/chaco/tests/test_datarange_1d.py
+++ b/chaco/tests/test_datarange_1d.py
@@ -9,6 +9,7 @@
 # Thanks for using Enthought open source!
 
 import unittest
+import warnings
 
 from numpy import arange, array, zeros, inf
 from numpy.testing import assert_equal
@@ -16,6 +17,8 @@ from numpy.testing import assert_equal
 from traits.api import HasTraits, Instance, Bool, observe
 
 from chaco.api import DataRange1D, ArrayDataSource
+
+NAN = float("nan")
 
 
 class Foo(HasTraits):
@@ -232,6 +235,15 @@ class DataRangeTestCase(unittest.TestCase):
         r = DataRange1D(low=2.0, high=2.5)
         assert_equal(len(r.clip_data(ary)), 0)
 
+        # Test the case with nans. Additionally require that no warnings are
+        # emitted.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            r = DataRange1D(low=2.0, high=10.0)
+            ary = array([1, 3, NAN, 9.8, 10.2, 12])
+            assert_equal(r.clip_data(ary), array([3.0, 9.8]))
+        self.assertEqual(len(w), 0)
+
     def test_mask_data(self):
         r = DataRange1D(low=2.0, high=10.0)
         ary = array([1, 3, 4, 9.8, 10.2, 12])
@@ -246,6 +258,25 @@ class DataRangeTestCase(unittest.TestCase):
         r = DataRange1D(low=2.0, high=2.5)
         assert_equal(r.mask_data(ary), zeros(len(ary)))
 
+    def test_mask_data_contains_nans(self):
+        # Given
+        r = DataRange1D(low=2.0, high=10.0)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            # When
+            has_nans = array([1, 3, 9.8, NAN, 12])
+            # Then
+            assert_equal(r.mask_data(has_nans), array([0, 1, 1, 0, 0], "b"))
+
+            # When
+            all_nans = array([NAN, NAN, NAN])
+            # Then
+            assert_equal(r.mask_data(all_nans), array([0, 0, 0], "b"))
+
+        # Then (treating nans should come with no warnings)
+        self.assertEqual(len(w), 0)
+
     def test_bound_data(self):
         r = DataRange1D(low=2.9, high=6.1)
         ary = arange(10)
@@ -255,6 +286,14 @@ class DataRangeTestCase(unittest.TestCase):
         ary = array([-5, -4, -7, -8, -2, 1, 2, 3, 4, 5, 4, 3, 8, 9, 10, 9, 8])
         bounds = r.bound_data(ary)
         assert_equal(bounds, (7, 11))
+
+        # test data with nan (expected: nan breaks a run)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            ary = array([1, 2, 3, 4, NAN, 6, 7])
+            bounds = r.bound_data(ary)
+            assert_equal(bounds, (2, 3))
+        self.assertEqual(len(w), 0)
 
     def test_custom_bounds_func(self):
         def custom_func(low, high, margin, tight_bounds):

--- a/chaco/tests/test_datarange_2d.py
+++ b/chaco/tests/test_datarange_2d.py
@@ -235,6 +235,12 @@ class DataRange2DTestCase(unittest.TestCase):
         # Then
         assert_equal(mask_1, expected_mask_1)
         assert_equal(mask_2, expected_mask_2)
+
+        # This assertion may pass because the warning has been correctly
+        # silenced by us (useful test), but it may also pass because the
+        # warning has been inactivated by the "only warn once" Python rule
+        # (test ineffective, false negative). Clearing the registry only for
+        # test purposes is not feasible: https://bugs.python.org/issue21724
         self.assertEqual(len(w), 0)
 
 

--- a/chaco/tests/test_datarange_2d.py
+++ b/chaco/tests/test_datarange_2d.py
@@ -9,11 +9,14 @@
 # Thanks for using Enthought open source!
 
 import unittest
+import warnings
 
 from numpy import alltrue, arange, array, ravel, transpose, zeros, inf, isinf
 from numpy.testing import assert_equal, assert_
 
 from chaco.api import DataRange2D, GridDataSource, PointDataSource
+
+NAN = float("nan")
 
 
 class DataRange2DTestCase(unittest.TestCase):
@@ -204,6 +207,35 @@ class DataRange2DTestCase(unittest.TestCase):
 
         r = DataRange2D(low=[2.0, 5.0], high=[2.5, 9.0])
         assert_equal(r.mask_data(ary), zeros(len(ary)))
+
+    def test_mask_data_containing_nans(self):
+        # Given
+        r = DataRange2D(low=[2.0, 3.0], high=[12.0, 13.0])
+        ary_1 = array(
+            [
+                [NAN, 1.0],
+                [NAN, 4.0],
+                [NAN, NAN],
+                [25.1, NAN],
+                [5.0, 6.0],
+                [12.5, 6.0]
+            ]
+        )
+        expected_mask_1 = array([0, 0, 0, 0, 1, 0], "b")
+        ary_2 = array([[NAN, NAN], [NAN, NAN]])
+        expected_mask_2 = array([0, 0], "b")
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            # When
+            mask_1 = r.mask_data(ary_1)
+            mask_2 = r.mask_data(ary_2)
+
+        # Then
+        assert_equal(mask_1, expected_mask_1)
+        assert_equal(mask_2, expected_mask_2)
+        self.assertEqual(len(w), 0)
 
 
 def assert_close_(desired, actual):


### PR DESCRIPTION
Fixes #834 

- suppresses "invalid value" warnings in numpy when computing range masks in the `BaseDataRange` API implementations
   - [x] in `DataRange1D`
   - [x] in `DataRange2D` ¹ 
- doesn't change behavior, apart from warning suppression

The default behavior of float comparison with `nan`s is consistent with the `mask_data` abstract specification (being "inside the range" implies being finite), so it should be fine to confidently use it without warnings.

By the way, all uses of `mask_data` in the Chaco codebase outside of the classes themselves are already paired with a `& nan_mask`. I'm not sure if that's redundant, but it makes me confident that exluding `nan`s from masks is expected everywhere.

---

¹ ~a curious finding: apparently transposing an array defuses the warning in the first place~

<details>

```python
>>> import numpy as np
>>> nan = float("nan")

>>> np.array([1.0, nan]) > 0.5
__main__:1: RuntimeWarning: invalid value encountered in greater
array([ True, False])

>>> np.array([[1.0], [nan]]).transpose()[0] > 0.5
array([ True, False]) 
```

Edit: I was wrong, there is an issue of state. Whichever of the above comparisons gets run first will emit the warning.

</details>


