### PR TITLE
remove old style trait

### DIFF
--- a/chaco/abstract_data_range.py
+++ b/chaco/abstract_data_range.py
@@ -13,7 +13,7 @@ Defines the base class for data ranges.
 """
 
 # Enthought library imports
-from traits.api import Event, Float, HasTraits, Instance, List, Trait
+from traits.api import Either, Event, Float, HasTraits, Instance, List
 
 # Local relative imports
 from .abstract_data_source import AbstractDataSource
@@ -43,9 +43,9 @@ class AbstractDataRange(HasTraits):
     high = Float(1.0)
 
     #: Setting for the lower bound of this range.
-    low_setting = Trait("auto", "auto", Float)
+    low_setting = Either("auto", Float, default="auto")
     #: Setting for the upper bound of this range.
-    high_setting = Trait("auto", "auto", Float)
+    high_setting = Either("auto", Float, default="auto")
 
     #: Event that is fired when the actual bounds values change; the value
     #: of the event is a tuple (low_bound, high_bound)

--- a/chaco/abstract_data_range.py
+++ b/chaco/abstract_data_range.py
@@ -13,7 +13,8 @@ Defines the base class for data ranges.
 """
 
 # Enthought library imports
-from traits.api import Either, Event, Float, HasTraits, Instance, List
+from traits.api import (
+    Constant, Event, Float, HasTraits, Instance, List, Union)
 
 # Local relative imports
 from .abstract_data_source import AbstractDataSource
@@ -43,9 +44,9 @@ class AbstractDataRange(HasTraits):
     high = Float(1.0)
 
     #: Setting for the lower bound of this range.
-    low_setting = Either("auto", Float, default="auto")
+    low_setting = Union(Constant("auto"), Float)
     #: Setting for the upper bound of this range.
-    high_setting = Either("auto", Float, default="auto")
+    high_setting = Union(Constant("auto"), Float)
 
     #: Event that is fired when the actual bounds values change; the value
     #: of the event is a tuple (low_bound, high_bound)

--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -34,7 +34,6 @@ from traits.api import (
     Float,
     Int,
     Str,
-    Trait,
     Unicode,
     Bool,
     Event,

--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -80,7 +80,7 @@ class PlotAxis(AbstractOverlay):
     origin = Enum("bottom left", "top left", "bottom right", "top right")
 
     #: The text of the axis title.
-    title = Str("")  # May want to add PlotLabel option
+    title = Str()  # May want to add PlotLabel option
 
     #: The font of the title.
     title_font = KivaFont("modern 12")

--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -30,7 +30,7 @@ from enable.api import ColorTrait, LineStyle
 from kiva.trait_defs.kiva_font_trait import KivaFont
 from traits.api import (
     Any,
-    Either,
+    Constant,
     Float,
     Int,
     Str,
@@ -44,7 +44,8 @@ from traits.api import (
     Enum,
     Callable,
     ArrayOrNone,
-    observe
+    observe,
+    Union,
 )
 
 # Local relative imports
@@ -86,7 +87,7 @@ class PlotAxis(AbstractOverlay):
     title_font = KivaFont("modern 12")
 
     #: The spacing between the axis line and the title
-    title_spacing = Either("auto", Float, default="auto")
+    title_spacing = Union(Constant("auto"), Float)
 
     #: The color of the title.
     title_color = ColorTrait("black")
@@ -135,7 +136,7 @@ class PlotAxis(AbstractOverlay):
     tick_visible = Bool(True)
 
     #: The dataspace interval between ticks.
-    tick_interval = Either("auto", Float, default="auto")
+    tick_interval = Union(Constant("auto"), Float)
 
     #: A callable that implements the AbstractTickGenerator interface.
     tick_generator = Instance(AbstractTickGenerator)

--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -30,6 +30,7 @@ from enable.api import ColorTrait, LineStyle
 from kiva.trait_defs.kiva_font_trait import KivaFont
 from traits.api import (
     Any,
+    Either,
     Float,
     Int,
     Str,
@@ -79,13 +80,13 @@ class PlotAxis(AbstractOverlay):
     origin = Enum("bottom left", "top left", "bottom right", "top right")
 
     #: The text of the axis title.
-    title = Trait("", Str, Unicode)  # May want to add PlotLabel option
+    title = Str("")  # May want to add PlotLabel option
 
     #: The font of the title.
     title_font = KivaFont("modern 12")
 
     #: The spacing between the axis line and the title
-    title_spacing = Trait("auto", "auto", Float)
+    title_spacing = Either("auto", Float, default="auto")
 
     #: The color of the title.
     title_color = ColorTrait("black")
@@ -134,7 +135,7 @@ class PlotAxis(AbstractOverlay):
     tick_visible = Bool(True)
 
     #: The dataspace interval between ticks.
-    tick_interval = Trait("auto", "auto", Float)
+    tick_interval = Either("auto", Float, default="auto")
 
     #: A callable that implements the AbstractTickGenerator interface.
     tick_generator = Instance(AbstractTickGenerator)
@@ -188,7 +189,8 @@ class PlotAxis(AbstractOverlay):
 
     # Cached position calculations
 
-    _tick_list = List(transient=True)  # These are caches of their respective positions
+    # These are caches of their respective positions
+    _tick_list = List(transient=True)
     _tick_positions = ArrayOrNone(transient=True)
     _tick_label_list = ArrayOrNone(transient=True)
     _tick_label_positions = ArrayOrNone(transient=True)

--- a/chaco/base_2d_plot.py
+++ b/chaco/base_2d_plot.py
@@ -68,7 +68,7 @@ class Base2DPlot(AbstractPlotRenderer):
 
     #: Overall alpha value of the image. Ranges from 0.0 for transparent to 1.0
     #: for full intensity.
-    alpha = Trait(1.0, Range(0.0, 1.0))
+    alpha = Range(0.0, 1.0, 1.0)
 
     #: Event fired when the index data changes. Subclasses can listen for this
     #: event and take appropriate steps (except for requesting a redraw, which
@@ -121,7 +121,7 @@ class Base2DPlot(AbstractPlotRenderer):
         """
         # data_pts is Nx2 array
         if len(data_pts) == 0:
-            return empty(shape=(0,2))
+            return empty(shape=(0, 2))
         return asarray(self.index_mapper.map_screen(data_pts))
 
     def map_data(self, screen_pts):

--- a/chaco/base_candle_plot.py
+++ b/chaco/base_candle_plot.py
@@ -13,7 +13,7 @@ from numpy import array, column_stack
 
 # Enthought library imports
 from enable.api import ColorTrait
-from traits.api import Bool, Float, Int, List, Property, Trait
+from traits.api import Bool, Float, Int, List, Property, Union
 
 # Chaco imports
 from .base_xy_plot import BaseXYPlot
@@ -54,11 +54,11 @@ class BaseCandlePlot(BaseXYPlot):
     #: The color of the stems reaching from the bar ends to the min and max
     #: values.  Also the color of the endcap line segments at min and max.  If
     #: None, this defaults to **bar_line_color**.
-    stem_color = Trait(None, None, ColorTrait("black"))
+    stem_color = Union(None, ColorTrait("black"))
 
     #: The color of the line drawn across the bar at the center values.
     #: If None, this defaults to **bar_line_color**.
-    center_color = Trait(None, None, ColorTrait("black"))
+    center_color = Union(None, ColorTrait("black"))
 
     #: The color of the outline to draw around the bar.
     outline_color = ColorTrait("black")
@@ -69,11 +69,11 @@ class BaseCandlePlot(BaseXYPlot):
 
     #: The thickness, in pixels, of the stem lines.  If None, this defaults
     #: to **line_width**.
-    stem_width = Trait(None, None, Int(1))
+    stem_width = Union(None, Int(1))
 
     #: The thickeness, in pixels, of the line drawn across the bar at the
     #: center values.  If None, this defaults to **line_width**.
-    center_width = Trait(None, None, Int(1))
+    center_width = Union(None, Int(1))
 
     #: Whether or not to draw bars at the min and max extents of the error bar
     end_cap = Bool(True)

--- a/chaco/base_contour_plot.py
+++ b/chaco/base_contour_plot.py
@@ -14,7 +14,7 @@ from numpy import array, isscalar, issubsctype, linspace, number
 from enable.api import ColorTrait
 from traits.api import (
     Bool,
-    Either,
+    Constant,
     Instance,
     Int,
     List,
@@ -45,7 +45,7 @@ class BaseContourPlot(Base2DPlot):
     #: the value of the function at the contours; a positive integer, in which
     #: case the range of the value is divided in the given number of equally
     #: spaced levels; or "auto" (default), which divides the range in 10 levels
-    levels = Either("auto", Int, List, default="auto")
+    levels = Union(Constant("auto"), Int, List)
 
     #: The color(s) of the lines.
     #: ``colors`` can be given as a color name, in which case all contours have

--- a/chaco/base_contour_plot.py
+++ b/chaco/base_contour_plot.py
@@ -21,7 +21,6 @@ from traits.api import (
     Property,
     Range,
     Str,
-    Trait,
     Tuple,
     Union,
 )

--- a/chaco/base_contour_plot.py
+++ b/chaco/base_contour_plot.py
@@ -14,6 +14,7 @@ from numpy import array, isscalar, issubsctype, linspace, number
 from enable.api import ColorTrait
 from traits.api import (
     Bool,
+    Either,
     Instance,
     Int,
     List,
@@ -22,6 +23,7 @@ from traits.api import (
     Str,
     Trait,
     Tuple,
+    Union,
 )
 
 # Local relative imports
@@ -43,7 +45,7 @@ class BaseContourPlot(Base2DPlot):
     #: the value of the function at the contours; a positive integer, in which
     #: case the range of the value is divided in the given number of equally
     #: spaced levels; or "auto" (default), which divides the range in 10 levels
-    levels = Trait("auto", Int, List)
+    levels = Either("auto", Int, List, default="auto")
 
     #: The color(s) of the lines.
     #: ``colors`` can be given as a color name, in which case all contours have
@@ -51,13 +53,13 @@ class BaseContourPlot(Base2DPlot):
     #: colors is shorter than the number of levels, the values are repeated
     #: from the beginning of the list. Default is black.
     #: Colors are associated with levels of increasing value.
-    colors = Trait(None, Str, Instance(ColorMapper), List, Tuple)
+    colors = Union(None, Str, Instance(ColorMapper), List, Tuple)
 
     #: If present, the color mapper for the colorbar to look at.
     color_mapper = Property(Instance(ColorMapper))
 
     #: A global alpha value to apply to all the contours
-    alpha = Trait(1.0, Range(0.0, 1.0))
+    alpha = Range(0.0, 1.0, 1.0)
 
     # ------------------------------------------------------------------------
     # Private traits

--- a/chaco/color_mapper.py
+++ b/chaco/color_mapper.py
@@ -40,6 +40,7 @@ from traits.api import (
     Array,
     Bool,
     Dict,
+    Either,
     Event,
     Float,
     HasTraits,
@@ -67,9 +68,9 @@ class ColorMapTemplate(HasTraits):
     #: The number of steps in the color map.
     steps = Int(256)
     #: Low end of the color map range.
-    range_low_setting = Trait("auto", "auto", Float)
+    range_low_setting = Either("auto", Float, default="auto")
     #: High end of the color map range.
-    range_high_setting = Trait("auto", "auto", Float)
+    range_high_setting = Either("auto", Float, default="auto")
 
     def __init__(self, colormap=None, **kwtraits):
         """

--- a/chaco/color_mapper.py
+++ b/chaco/color_mapper.py
@@ -47,7 +47,6 @@ from traits.api import (
     Int,
     Property,
     Str,
-    Trait,
     Union,
 )
 

--- a/chaco/color_mapper.py
+++ b/chaco/color_mapper.py
@@ -39,8 +39,8 @@ from traits.api import (
     Any,
     Array,
     Bool,
+    Constant,
     Dict,
-    Either,
     Event,
     Float,
     HasTraits,
@@ -48,6 +48,7 @@ from traits.api import (
     Property,
     Str,
     Trait,
+    Union,
 )
 
 # Relative imports
@@ -68,9 +69,9 @@ class ColorMapTemplate(HasTraits):
     #: The number of steps in the color map.
     steps = Int(256)
     #: Low end of the color map range.
-    range_low_setting = Either("auto", Float, default="auto")
+    range_low_setting = Union(Constant("auto"), Float)
     #: High end of the color map range.
-    range_high_setting = Either("auto", Float, default="auto")
+    range_high_setting = Union(Constant("auto"), Float)
 
     def __init__(self, colormap=None, **kwtraits):
         """

--- a/chaco/data_range_1d.py
+++ b/chaco/data_range_1d.py
@@ -19,7 +19,7 @@ from math import ceil, floor, log
 from numpy import compress, errstate, inf, isinf, isnan, ndarray
 
 # Enthought library imports
-from traits.api import Bool, CFloat, Enum, Float, Property, Trait, Callable
+from traits.api import Bool, CFloat, Either, Enum, Float, Property, Callable
 
 # Local relative imports
 from .base import arg_find_runs
@@ -43,14 +43,14 @@ class DataRange1D(BaseDataRange):
     #:   of the data.
     #: * 'track': The lower bound tracks the upper bound by **tracking_amount**.
     #: * CFloat: An explicit value for the lower bound
-    low_setting = Property(Trait("auto", "auto", "track", CFloat))
+    low_setting = Property(Either("auto", "track", CFloat, default="auto"))
     #: Property for the upper bound of this range (overrides AbstractDataRange).
     #:
     #: * 'auto': The upper bound is automatically set at or above the maximum
     #:   of the data.
     #: * 'track': The upper bound tracks the lower bound by **tracking_amount**.
     #: * CFloat: An explicit value for the upper bound
-    high_setting = Property(Trait("auto", "auto", "track", CFloat))
+    high_setting = Property(Either("auto", "track", CFloat, default="auto"))
 
     #: Do "auto" bounds imply an exact fit to the data? If False,
     #: they pad a little bit of margin on either side.
@@ -98,11 +98,11 @@ class DataRange1D(BaseDataRange):
     # setting.
 
     # The user-specified low setting.
-    _low_setting = Trait("auto", "auto", "track", CFloat)
+    _low_setting = Either("auto", "track", CFloat, default="auto")
     # The actual numerical value for the low setting.
     _low_value = CFloat(-inf)
     # The user-specified high setting.
-    _high_setting = Trait("auto", "auto", "track", CFloat)
+    _high_setting = Either("auto", "track", CFloat, default="auto")
     # The actual numerical value for the high setting.
     _high_value = CFloat(inf)
 
@@ -413,7 +413,7 @@ class DataRange1D(BaseDataRange):
         self._sources_changed(None, self.sources)
 
 
-###### method to calculate bounds for a given 1-dimensional set of data
+# method to calculate bounds for a given 1-dimensional set of data
 def calc_bounds(
     low_set,
     high_set,

--- a/chaco/data_range_1d.py
+++ b/chaco/data_range_1d.py
@@ -19,7 +19,8 @@ from math import ceil, floor, log
 from numpy import compress, errstate, inf, isinf, isnan, ndarray
 
 # Enthought library imports
-from traits.api import Bool, CFloat, Either, Enum, Float, Property, Callable
+from traits.api import (
+    Bool, CFloat, Constant, Enum, Float, Property, Callable, Union)
 
 # Local relative imports
 from .base import arg_find_runs
@@ -43,14 +44,14 @@ class DataRange1D(BaseDataRange):
     #:   of the data.
     #: * 'track': The lower bound tracks the upper bound by **tracking_amount**.
     #: * CFloat: An explicit value for the lower bound
-    low_setting = Property(Either("auto", "track", CFloat, default="auto"))
+    low_setting = Property(Union(Constant("auto"), Constant("track"), CFloat))
     #: Property for the upper bound of this range (overrides AbstractDataRange).
     #:
     #: * 'auto': The upper bound is automatically set at or above the maximum
     #:   of the data.
     #: * 'track': The upper bound tracks the lower bound by **tracking_amount**.
     #: * CFloat: An explicit value for the upper bound
-    high_setting = Property(Either("auto", "track", CFloat, default="auto"))
+    high_setting = Property(Union(Constant("auto"), Constant("track"), CFloat))
 
     #: Do "auto" bounds imply an exact fit to the data? If False,
     #: they pad a little bit of margin on either side.
@@ -98,11 +99,11 @@ class DataRange1D(BaseDataRange):
     # setting.
 
     # The user-specified low setting.
-    _low_setting = Either("auto", "track", CFloat, default="auto")
+    _low_setting = Union(Enum("auto", "track"), CFloat)
     # The actual numerical value for the low setting.
     _low_value = CFloat(-inf)
     # The user-specified high setting.
-    _high_setting = Either("auto", "track", CFloat, default="auto")
+    _high_setting = Union(Enum("auto", "track"), CFloat)
     # The actual numerical value for the high setting.
     _high_value = CFloat(inf)
 

--- a/chaco/data_view.py
+++ b/chaco/data_view.py
@@ -13,7 +13,7 @@ functions.
 """
 from numpy import array, empty, transpose
 
-from traits.api import Bool, Enum, Instance, Int, observe, Property, Union
+from traits.api import Bool, Enum, Instance, Int, Property, Union
 from enable.api import color_table
 
 from .abstract_overlay import AbstractOverlay
@@ -237,7 +237,7 @@ class DataView(OverlayPlotContainer):
     )
 
     _padding_top = Union(None, Int())
-    _padding_bottom= Union(None, Int())
+    _padding_bottom = Union(None, Int())
     _padding_left = Union(None, Int())
     _padding_right = Union(None, Int())
 
@@ -304,7 +304,7 @@ class DataView(OverlayPlotContainer):
         """
         # data_array is Nx2 array
         if len(data_array) == 0:
-            return empty(shape=(0,2))
+            return empty(shape=(0, 2))
         x_ary, y_ary = transpose(data_array)
         sx = self.index_mapper.map_screen(x_ary)
         sy = self.value_mapper.map_screen(y_ary)

--- a/chaco/examples/demo/advanced/data_cube.py
+++ b/chaco/examples/demo/advanced/data_cube.py
@@ -38,7 +38,6 @@ from traits.api import (
     Float,
     HasTraits,
     Int,
-    Trait,
     observe,
 )
 from traits.observation.api import match

--- a/chaco/examples/demo/advanced/data_cube.py
+++ b/chaco/examples/demo/advanced/data_cube.py
@@ -9,7 +9,9 @@ import warnings
 from numpy import amin, amax, zeros, fromfile, transpose, uint8
 
 # Standard library imports
-import os, sys, shutil
+import os
+import sys
+import shutil
 
 # Major library imports
 from numpy import arange, linspace, nanmin, nanmax, newaxis, pi, sin, cos
@@ -202,7 +204,7 @@ class Demo(DemoFrame):
     # Private Traits
     # ---------------------------------------------------------------------------
 
-    _cmap = Trait(viridis, Callable)
+    _cmap = Callable(viridis)
 
     def _index_callback(self, tool, x_index, y_index):
         plane = tool.token
@@ -399,7 +401,9 @@ def download_data():
         data_good = False
 
     if not data_good:
-        import urllib.request, urllib.parse, urllib.error
+        import urllib.request
+        import urllib.parse
+        import urllib.error
         import tarfile
 
         if len(dl_path) > 0 and not os.path.exists(dl_path):

--- a/chaco/examples/demo/advanced/data_stream.py
+++ b/chaco/examples/demo/advanced/data_stream.py
@@ -25,7 +25,6 @@ from traits.api import (
     Instance,
     Int,
     observe,
-    Trait,
 )
 from traitsui.api import Group, HGroup, Item, UItem, View, spring, Handler
 from pyface.timer.api import Timer
@@ -107,7 +106,7 @@ class Controller(HasTraits):
     # just means that self._generator should be initialized to
     # random.normal, which is a random number function, and in the future
     # it can be set to any callable object.
-    _generator = Trait(np.random.normal, Callable)
+    _generator = Callable(np.random.normal)
 
     view = View(
         Group(

--- a/chaco/examples/demo/advanced/scalar_image_function_inspector.py
+++ b/chaco/examples/demo/advanced/scalar_image_function_inspector.py
@@ -195,7 +195,7 @@ class PlotUI(HasTraits):
     _image_index = Instance(GridDataSource)
     _image_value = Instance(ImageData)
 
-    _cmap = Trait(default_colormaps.viridis, Callable)
+    _cmap = Callable(default_colormaps.viridis)
 
     # ---------------------------------------------------------------------------
     # Public View interface

--- a/chaco/examples/demo/advanced/scalar_image_function_inspector.py
+++ b/chaco/examples/demo/advanced/scalar_image_function_inspector.py
@@ -50,7 +50,6 @@ from traits.api import (
     Int,
     Instance,
     Str,
-    Trait,
     observe,
     Button,
     Bool,

--- a/chaco/grid.py
+++ b/chaco/grid.py
@@ -30,7 +30,7 @@ from traits.api import (
     Any,
     Bool,
     Callable,
-    Either,
+    Constant,
     Enum,
     Float,
     Instance,
@@ -106,7 +106,7 @@ class PlotGrid(AbstractOverlay):
     mapper = Instance(AbstractMapper)
 
     #: The dataspace interval between grid lines.
-    grid_interval = Either("auto", Float, default="auto")
+    grid_interval = Union(Constant("auto"), Float)
 
     #: The dataspace value at which to start this grid.  If None, then
     #: uses the mapper.range.low.

--- a/chaco/grid.py
+++ b/chaco/grid.py
@@ -30,15 +30,16 @@ from traits.api import (
     Any,
     Bool,
     Callable,
+    Either,
     Enum,
     Float,
     Instance,
     CInt,
-    Trait,
     Property,
     TraitError,
     Tuple,
     observe,
+    Union,
 )
 from traitsui.api import HGroup, Item, VGroup, View, TextEditor
 
@@ -105,15 +106,15 @@ class PlotGrid(AbstractOverlay):
     mapper = Instance(AbstractMapper)
 
     #: The dataspace interval between grid lines.
-    grid_interval = Trait("auto", "auto", Float)
+    grid_interval = Either("auto", Float, default="auto")
 
     #: The dataspace value at which to start this grid.  If None, then
     #: uses the mapper.range.low.
-    data_min = Trait(None, None, Float)
+    data_min = Union(None, Float)
 
     #: The dataspace value at which to end this grid.  If None, then uses
     #: the mapper.range.high.
-    data_max = Trait(None, None, Float)
+    data_max = Union(None, Float)
 
     #: A callable that implements the AbstractTickGenerator Interface.
     tick_generator = Instance(AbstractTickGenerator)
@@ -142,7 +143,7 @@ class PlotGrid(AbstractOverlay):
     #:   Callable : Function that takes an array of dataspace grid ticks
     #:              and returns either an array of shape (N,2) of (starts,ends)
     #:              for each grid point or a single tuple (low, high)
-    transverse_bounds = Trait(None, Tuple, Callable)
+    transverse_bounds = Union(None, Tuple, Callable)
 
     #: Mapper in the direction corresponding to self.orientation, i.e. transverse
     #: to the direction of self.mapper.  This is used to compute the screen
@@ -395,7 +396,7 @@ class PlotGrid(AbstractOverlay):
         if not self.visible:
             return
         self._compute_ticks(other_component)
-        
+
         if not self._cache_valid:
             self._compute_ticks()
 

--- a/chaco/overlays/data_label.py
+++ b/chaco/overlays/data_label.py
@@ -17,7 +17,7 @@ from numpy.linalg import norm
 
 # Enthought library imports
 from traits.api import Any, ArrayOrNone, Bool, Enum, Float, Int, List, \
-     Str, Tuple, Trait, observe, Property
+    Str, Tuple, observe, Property, Union
 from enable.api import ColorTrait, MarkerTrait
 
 # Local, relative imports
@@ -29,11 +29,10 @@ from chaco.plots.scatterplot import render_markers
 # be one of the text strings indicated, or a tuple or list of floats
 # representing the (x_offset, y_offset) in screen space of the label's
 # lower left corner.
-LabelPositionTrait = Trait("top right",
-                           Enum("bottom", "left", "right", "top",
-                                "top right", "top left",
-                                "bottom left", "bottom right"),
-                           Tuple, List)
+LabelPositionTrait = Union(
+    Enum("top right", "bottom", "left", "right", "top",
+         "top left", "bottom left", "bottom right"),
+    Tuple, List)
 
 
 def draw_arrow(gc, pt1, pt2, color, arrowhead_size=10.0, offset1=0,
@@ -251,9 +250,9 @@ class DataLabel(ToolTip):
     #: is 'auto', then the label uses **label_position**.  Otherwise, it
     #: treats the label as if it were at the label position indicated by
     #: this attribute.
-    arrow_root = Trait("auto", "auto", "top left", "top right", "bottom left",
-                       "bottom right", "top center", "bottom center",
-                       "left center", "right center")
+    arrow_root = Enum("auto", "top left", "top right", "bottom left",
+                      "bottom right", "top center", "bottom center",
+                      "left center", "right center")
 
     #: The minimum length of the arrow before it will be drawn.  By default,
     #: the arrow will be drawn regardless of how short it is.
@@ -291,7 +290,7 @@ class DataLabel(ToolTip):
         "bottom center": "top center",
         "left center": "right center",
         "right center": "left center"
-        }
+    }
 
     _root_positions = {
         "bottom right": ("x2", "y"),
@@ -302,7 +301,7 @@ class DataLabel(ToolTip):
         "bottom center": ("xmid", "y"),
         "left center": ("x", "ymid"),
         "right center": ("x2", "ymid"),
-        }
+    }
 
     def overlay(self, component, gc, view_bounds=None, mode="normal"):
         """ Draws the tooltip overlaid on another component.

--- a/chaco/overlays/databox.py
+++ b/chaco/overlays/databox.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.api import Bool, Enum, Float, Int, CList, Property, Trait, observe
+from traits.api import Bool, Enum, Float, Int, CList, Property, observe, Union
 from enable.api import ColorTrait
 from chaco.abstract_overlay import AbstractOverlay
 
@@ -45,7 +45,7 @@ class DataBox(AbstractOverlay):
     # named colors from Enable, this attribute allows the specification of a
     # separate alpha value that replaces the alpha value of **color** at draw
     # time.
-    alpha = Trait(0.3, None, Float)
+    alpha = Union(Float(0.3), None)
 
     # The color of the outside selection rectangle.
     border_color = ColorTrait("dodgerblue")

--- a/chaco/overlays/legend.py
+++ b/chaco/overlays/legend.py
@@ -164,7 +164,7 @@ class Legend(AbstractOverlay):
     resizable = "hv"
 
     #: An optional title string to show on the legend.
-    title = Str("")
+    title = Str()
 
     #: If True, title is at top, if False then at bottom.
     title_at_top = Bool(True)

--- a/chaco/overlays/plot_label.py
+++ b/chaco/overlays/plot_label.py
@@ -13,7 +13,7 @@
 
 
 from enable.font_metrics_provider import font_metrics_provider
-from traits.api import DelegatesTo, Enum, Instance, Str, Trait
+from traits.api import DelegatesTo, Enum, Instance, Str, Union
 
 from chaco.abstract_overlay import AbstractOverlay
 from chaco.label import Label
@@ -63,7 +63,7 @@ class PlotLabel(AbstractOverlay):
     #: Examples:
     #:     inside top
     #:     outside right
-    overlay_position = Trait("outside top", Str, None)
+    overlay_position = Union(Str("outside top"), None)
 
     # Should this PlotLabel modify the padding on its underlying component
     # if there is not enough room to lay out the text?

--- a/chaco/overlays/scatter_inspector_overlay.py
+++ b/chaco/overlays/scatter_inspector_overlay.py
@@ -13,7 +13,7 @@ from numpy import array, asarray
 
 # Enthought library imports
 from enable.api import ColorTrait, MarkerTrait
-from traits.api import Float, Int, Str, Trait
+from traits.api import Float, Int, Str, Union
 from traits.observation.events import TraitChangeEvent
 
 # Local, relative imports
@@ -32,19 +32,19 @@ class ScatterInspectorOverlay(AbstractOverlay):
 
     #: The style to use when a point is hovered over
     hover_metadata_name = Str("hover")
-    hover_marker = Trait(None, None, MarkerTrait)
-    hover_marker_size = Trait(None, None, Int)
-    hover_line_width = Trait(None, None, Float)
-    hover_color = Trait(None, None, ColorTrait)
-    hover_outline_color = Trait(None, None, ColorTrait)
+    hover_marker = Union(None, MarkerTrait)
+    hover_marker_size = Union(None, Int)
+    hover_line_width = Union(None, Float)
+    hover_color = Union(None, ColorTrait)
+    hover_outline_color = Union(None, ColorTrait)
 
     #: The style to use when a point has been selected by a click
     selection_metadata_name = Str("selections")
-    selection_marker = Trait(None, None, MarkerTrait)
-    selection_marker_size = Trait(None, None, Int)
-    selection_line_width = Trait(None, None, Float)
-    selection_color = Trait(None, None, ColorTrait)
-    selection_outline_color = Trait(None, None, ColorTrait)
+    selection_marker = Union(None, MarkerTrait)
+    selection_marker_size = Union(None, Int)
+    selection_line_width = Union(None, Float)
+    selection_color = Union(None, ColorTrait)
+    selection_outline_color = Union(None, ColorTrait)
 
     # For now, implement the equivalent of this Traits 3 feature manually
     # using a series of trait change handlers (defined at the end of the

--- a/chaco/overlays/text_box_overlay.py
+++ b/chaco/overlays/text_box_overlay.py
@@ -15,7 +15,7 @@
 # Enthought library imports
 from enable.api import ColorTrait
 from kiva.trait_defs.kiva_font_trait import KivaFont
-from traits.api import Any, Enum, Int, Str, Float, Trait, Bool
+from traits.api import Any, Enum, Int, Str, Float, Bool, Union
 
 # Local, relative imports
 from chaco.abstract_overlay import AbstractOverlay
@@ -37,7 +37,7 @@ class TextBoxOverlay(AbstractOverlay):
     bgcolor = ColorTrait("transparent")
 
     #: The alpha value to apply to **bgcolor**
-    alpha = Trait(1.0, None, Float)
+    alpha = Union(Float(1.0), None)
 
     #: The color of the outside box.
     border_color = ColorTrait("dodgerblue")

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -156,7 +156,7 @@ class GridPlotContainer(BasePlotContainer):
 
     #: The amount of space to put on either side of each component, expressed
     #: as a tuple (h_spacing, v_spacing).
-    spacing = Union(Tuple, List, Array)
+    spacing = Union(None, Tuple, List, Array)
 
     #: The vertical alignment of objects that don't span the full height.
     valign = Enum("bottom", "top", "center")

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -27,7 +27,6 @@ from numpy import (
 from traits.api import (
     Any,
     Array,
-    Either,
     Enum,
     Instance,
     List,
@@ -157,7 +156,7 @@ class GridPlotContainer(BasePlotContainer):
 
     #: The amount of space to put on either side of each component, expressed
     #: as a tuple (h_spacing, v_spacing).
-    spacing = Either(Tuple, List, Array)
+    spacing = Union(Tuple, List, Array)
 
     #: The vertical alignment of objects that don't span the full height.
     valign = Enum("bottom", "top", "center")

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -29,15 +29,14 @@ from traits.api import (
     Array,
     Either,
     Enum,
-    Float,
     Instance,
     List,
     Property,
     Str,
     String,
-    Trait,
     Tuple,
     Int,
+    Union,
 )
 from enable.api import OverlayContainer
 from enable.stacked_container import HStackedContainer, VStackedContainer
@@ -171,7 +170,7 @@ class GridPlotContainer(BasePlotContainer):
     #: specification.  If there are fewer components than cells, the remaining
     #: cells are filled in with spaces.  If there are more components than cells,
     #: the remainder wrap onto new rows as appropriate.
-    shape = Trait((0, 0), Either(Tuple, List, Array))
+    shape = Union(Tuple((0, 0)), List, Array)
 
     #: This property exposes the underlying grid structure of the container,
     #: and is the preferred way of setting and reading its contents.

--- a/chaco/plots/contour/contour_line_plot.py
+++ b/chaco/plots/contour/contour_line_plot.py
@@ -17,7 +17,7 @@ from numpy import array, isfinite, meshgrid, transpose
 # Enthought library imports
 from enable.api import LineStyle
 from kiva import constants
-from traits.api import Bool, Dict, Float, List, Str, Trait
+from traits.api import Bool, Dict, Float, List, Str, Union
 
 # Local relative imports
 from chaco.base_contour_plot import BaseContourPlot
@@ -40,10 +40,10 @@ class ContourLinePlot(BaseContourPlot):
     #: of widths. If the list is too short with respect to then number of
     #: contour lines, the values are repeated from the beginning of the list.
     #: Widths are associated with levels of increasing value.
-    widths = Trait(1.0, Float, List)
+    widths = Union(Float(1.0), List)
 
     #: The line dash style(s).
-    styles = Trait("signed", Str, List)
+    styles = Union(Str("signed"), List)
 
     #: Line style for positive levels.
     positive_style = LineStyle("solid")

--- a/chaco/plots/image_plot.py
+++ b/chaco/plots/image_plot.py
@@ -62,7 +62,7 @@ class ImagePlot(Base2DPlot):
 
     #: Overall alpha value of the image. Ranges from 0.0 for transparent to 1.0
     #: for full intensity.
-    alpha = Trait(1.0, Range(0.0, 1.0))
+    alpha = Range(0.0, 1.0, 1.0)
 
     #: The interpolation method to use when rendering an image onto the GC.
     interpolation = Enum("nearest", "bilinear", "bicubic")

--- a/chaco/plots/image_plot.py
+++ b/chaco/plots/image_plot.py
@@ -21,15 +21,14 @@ import numpy as np
 # Enthought library imports.
 from traits.api import (
     Bool,
-    Either,
     Enum,
     Instance,
     List,
     Range,
-    Trait,
     Tuple,
     Property,
     cached_property,
+    Union,
 )
 from kiva.agg import GraphicsContextArray
 
@@ -85,7 +84,7 @@ class ImagePlot(Base2DPlot):
 
     # Tuple-defined rectangle (x, y, dx, dy) in screen space in which the
     # **_cached_image** is to be drawn.
-    _cached_dest_rect = Either(Tuple, List, transient=True)
+    _cached_dest_rect = Union(Tuple, List, transient=True)
 
     # Bool indicating whether the origin is top-left or bottom-right.
     # The name "principal diagonal" is borrowed from linear algebra.

--- a/chaco/plots/multi_line_plot.py
+++ b/chaco/plots/multi_line_plot.py
@@ -26,13 +26,13 @@ from traits.api import (
     Float,
     List,
     Str,
-    Trait,
     Bool,
     Callable,
     Property,
     cached_property,
     Instance,
     Array,
+    Union,
 )
 from traitsui.api import Item, View, ScrubberEditor, HGroup
 
@@ -118,7 +118,7 @@ class MultiLinePlot(BaseXYPlot):
     color = black_color_trait(requires_redraw=True)
 
     #: A function that returns the color of lines.  Overrides `color` if not None.
-    color_func = Trait(None, None, Callable)
+    color_func = Union(None, Callable)
 
     #: The color to use to highlight the line when selected.
     selected_color = ColorTrait("lightyellow")
@@ -226,8 +226,8 @@ class MultiLinePlot(BaseXYPlot):
     # ------------------------------------------------------------------------
 
     # See base_xy_plot.py for these:
-    ## def hittest(self, screen_pt, threshold=7.0):
-    ## def interpolate(self, index_value):
+    # def hittest(self, screen_pt, threshold=7.0):
+    # def interpolate(self, index_value):
 
     def get_screen_points(self):
         self._gather_points()
@@ -427,8 +427,8 @@ class MultiLinePlot(BaseXYPlot):
                     z = transpose(
                         array(
                             (
-                                sorted_index[ndx : ndx + 2],
-                                sorted_value[ndx : ndx + 2],
+                                sorted_index[ndx: ndx + 2],
+                                sorted_value[ndx: ndx + 2],
                             )
                         )
                     )
@@ -460,8 +460,8 @@ class MultiLinePlot(BaseXYPlot):
         self._cache_valid = True
 
     # See base_xy_plot.py for:
-    ## def _downsample(self):
-    ## def _downsample_vectorized(self):
+    # def _downsample(self):
+    # def _downsample_vectorized(self):
 
     def _render(self, gc, line_points, selected_points=None):
 
@@ -484,7 +484,7 @@ class MultiLinePlot(BaseXYPlot):
                 # Existence of self.color_func overrides self.color.
                 color_func = self.color_func
             else:
-                color_func = lambda k: self.color_
+                def color_func(k): return self.color_
 
             tmp = list(enumerate(line_points))
             # Note: the list is reversed for testing with _render_filled.

--- a/chaco/plots/multi_line_plot.py
+++ b/chaco/plots/multi_line_plot.py
@@ -484,7 +484,8 @@ class MultiLinePlot(BaseXYPlot):
                 # Existence of self.color_func overrides self.color.
                 color_func = self.color_func
             else:
-                def color_func(k): return self.color_
+                def color_func(k):
+                    return self.color_
 
             tmp = list(enumerate(line_points))
             # Note: the list is reversed for testing with _render_filled.

--- a/chaco/plots/scatterplot.py
+++ b/chaco/plots/scatterplot.py
@@ -51,8 +51,8 @@ from traits.api import (
     Callable,
     Property,
     Tuple,
-    Either,
     cached_property,
+    Union,
 )
 from traitsui.api import View, VGroup, Item
 
@@ -228,7 +228,7 @@ class ScatterPlot(BaseXYPlot):
     # The pixel size of the markers, not including the thickness of the outline.
     # Default value is 4.0.
     # TODO: for consistency, there should be a size data source and a mapper
-    marker_size = Either(Float, Array, requires_redraw=True)
+    marker_size = Union(Float, Array, requires_redraw=True)
 
     # The function which actually renders the markers
     render_markers_func = Callable(render_markers)
@@ -300,7 +300,7 @@ class ScatterPlot(BaseXYPlot):
         """
         # data_array is Nx2 array
         if len(data_array) == 0:
-            return empty(shape=(0,2))
+            return empty(shape=(0, 2))
 
         data_array = asarray(data_array)
         if len(data_array.shape) == 1:

--- a/chaco/plotscrollbar.py
+++ b/chaco/plotscrollbar.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.api import Any, Enum, Int, Property, Trait, Union
+from traits.api import Any, Enum, Int, Property, Union
 
 from enable.api import NativeScrollBar
 

--- a/chaco/plotscrollbar.py
+++ b/chaco/plotscrollbar.py
@@ -36,11 +36,11 @@ class PlotScrollBar(NativeScrollBar):
 
     # The value of the override plot to use, if any.  If None, then uses
     # self.component.
-    _plot = Any(None)
+    _plot = Any()
 
     # The value of the override mapper to use, if any.  If None, then uses the
     # mapper on self.component.
-    _mapper = Any(None)
+    _mapper = Any()
 
     # Stores the index (0 or 1) corresponding to self.axis
     _axis_index = Union(None, Int)

--- a/chaco/plotscrollbar.py
+++ b/chaco/plotscrollbar.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.api import Any, Enum, Int, Property, Trait
+from traits.api import Any, Enum, Int, Property, Trait, Union
 
 from enable.api import NativeScrollBar
 
@@ -36,14 +36,14 @@ class PlotScrollBar(NativeScrollBar):
 
     # The value of the override plot to use, if any.  If None, then uses
     # self.component.
-    _plot = Trait(None, Any)
+    _plot = Any(None)
 
     # The value of the override mapper to use, if any.  If None, then uses the
     # mapper on self.component.
-    _mapper = Trait(None, Any)
+    _mapper = Any(None)
 
     # Stores the index (0 or 1) corresponding to self.axis
-    _axis_index = Trait(None, None, Int)
+    _axis_index = Union(None, Int)
 
     # ----------------------------------------------------------------------
     # Public methods

--- a/chaco/tools/better_selecting_zoom.py
+++ b/chaco/tools/better_selecting_zoom.py
@@ -15,7 +15,6 @@ from enable.api import ColorTrait, KeySpec
 from traits.api import (
     Bool,
     Enum,
-    Trait,
     Int,
     Float,
     Tuple,

--- a/chaco/tools/better_selecting_zoom.py
+++ b/chaco/tools/better_selecting_zoom.py
@@ -12,7 +12,16 @@ import numpy
 
 from chaco.abstract_overlay import AbstractOverlay
 from enable.api import ColorTrait, KeySpec
-from traits.api import Bool, Enum, Trait, Int, Float, Tuple, Instance, Property
+from traits.api import (
+    Bool,
+    Enum,
+    Trait,
+    Int,
+    Float,
+    Tuple,
+    Instance,
+    Union
+)
 
 from .better_zoom import BetterZoom
 from .tool_states import SelectedZoomState
@@ -71,7 +80,7 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
     #: named colors from Enable, this attribute allows the specification of a
     #: separate alpha value that replaces the alpha value of **color** at draw
     #: time.
-    alpha = Trait(0.4, None, Float)
+    alpha = Union(Float(0.4), None)
 
     #: The color of the outside selection rectangle.
     border_color = ColorTrait("dodgerblue")
@@ -83,10 +92,10 @@ class BetterSelectingZoom(AbstractOverlay, BetterZoom):
     event_state = Enum("normal", "selecting", "pre_selecting")
 
     # The (x,y) screen point where the mouse went down.
-    _screen_start = Trait(None, None, Tuple)
+    _screen_start = Union(None, Tuple)
 
     # The (x,,y) screen point of the last seen mouse move event.
-    _screen_end = Trait(None, None, Tuple)
+    _screen_end = Union(None, Tuple)
 
     # If **always_on** is False, this attribute indicates whether the tool
     # is currently enabled.

--- a/chaco/tools/image_inspector_tool.py
+++ b/chaco/tools/image_inspector_tool.py
@@ -13,7 +13,7 @@ ImageInspectorColorbarOverlay classes.
 """
 # Enthought library imports
 from enable.api import BaseTool, KeySpec
-from traits.api import Any, Bool, Enum, Event, Tuple
+from traits.api import Any, Bool, Enum, Event, Tuple, Union
 
 # Chaco imports
 from chaco.abstract_overlay import AbstractOverlay
@@ -42,7 +42,7 @@ class ImageInspectorTool(BaseTool):
 
     # Stores the value of self.visible when the mouse leaves the tool,
     # so that it can be restored when the mouse enters again.
-    _old_visible = Enum(None, True, False)
+    _old_visible = Union(None, Bool)
 
     def normal_key_pressed(self, event):
         if self.inspector_key.match(event):

--- a/chaco/tools/image_inspector_tool.py
+++ b/chaco/tools/image_inspector_tool.py
@@ -42,7 +42,7 @@ class ImageInspectorTool(BaseTool):
 
     # Stores the value of self.visible when the mouse leaves the tool,
     # so that it can be restored when the mouse enters again.
-    _old_visible = Enum(None, True, False)  # Trait(None, Bool(True))
+    _old_visible = Enum(None, True, False)
 
     def normal_key_pressed(self, event):
         if self.inspector_key.match(event):

--- a/chaco/tools/lasso_selection.py
+++ b/chaco/tools/lasso_selection.py
@@ -24,7 +24,6 @@ from traits.api import (
     Instance,
     Property,
     Str,
-    Trait,
     List,
 )
 from kiva.api import points_in_polygon

--- a/chaco/tools/lasso_selection.py
+++ b/chaco/tools/lasso_selection.py
@@ -102,7 +102,7 @@ class LassoSelection(AbstractController):
     # ----------------------------------------------------------------------
 
     # The PlotComponent associated with this tool.
-    _plot = Any(None)
+    _plot = Any()
 
     # To support multiple selections, a list of cached selections and the
     # active selection are maintained. A single list is not used because the

--- a/chaco/tools/lasso_selection.py
+++ b/chaco/tools/lasso_selection.py
@@ -103,7 +103,7 @@ class LassoSelection(AbstractController):
     # ----------------------------------------------------------------------
 
     # The PlotComponent associated with this tool.
-    _plot = Trait(None, Any)
+    _plot = Any(None)
 
     # To support multiple selections, a list of cached selections and the
     # active selection are maintained. A single list is not used because the

--- a/chaco/tools/line_inspector.py
+++ b/chaco/tools/line_inspector.py
@@ -72,7 +72,7 @@ class LineInspector(BaseTool):
     line_style = LineStyle("solid")
 
     # Last recorded position of the mouse
-    _last_position = Any(None)
+    _last_position = Any()
 
     def draw(self, gc, view_bounds=None):
         """Draws this tool on a graphics context.

--- a/chaco/tools/line_inspector.py
+++ b/chaco/tools/line_inspector.py
@@ -72,7 +72,7 @@ class LineInspector(BaseTool):
     line_style = LineStyle("solid")
 
     # Last recorded position of the mouse
-    _last_position = Trait(None, Any)
+    _last_position = Any(None)
 
     def draw(self, gc, view_bounds=None):
         """Draws this tool on a graphics context.

--- a/chaco/tools/line_segment_tool.py
+++ b/chaco/tools/line_segment_tool.py
@@ -17,7 +17,7 @@ from numpy import array
 
 # Enthought library imports
 from enable.api import Component, Pointer, Line
-from traits.api import Any, Bool, Enum, Instance, Int, List, Trait, Tuple
+from traits.api import Any, Bool, Enum, Instance, Int, List, Tuple, Union
 
 # Chaco imports
 from chaco.abstract_overlay import AbstractOverlay
@@ -55,10 +55,10 @@ class LineSegmentTool(AbstractOverlay):
 
     #: The data (index, value) position of the mouse cursor; this is used by various
     #: draw() routines.
-    mouse_position = Trait(None, None, Tuple)
+    mouse_position = Union(None, Tuple)
 
     # The index of the vertex being dragged, if any.
-    _dragged = Trait(None, None, Int)
+    _dragged = Union(None, Int)
 
     # Is the point being dragged is a newly placed point? This informs the
     # "dragging" state about what to do if the user presses Escape while

--- a/chaco/tools/range_selection.py
+++ b/chaco/tools/range_selection.py
@@ -29,6 +29,7 @@ from traits.api import (
     Property,
     Str,
     Trait,
+    Union
 )
 from enable.api import KeySpec
 
@@ -146,14 +147,14 @@ class RangeSelection(AbstractController):
 
     # The value of the override plot to use, if any.  If None, then uses
     # self.component.
-    _plot = Trait(None, Any)
+    _plot = Any(None)
 
     # The value of the override mapper to use, if any.  If None, then uses the
     # mapper on self.component.
-    _mapper = Trait(None, Any)
+    _mapper = Any(None)
 
     # Shadow trait for the **axis_index** property.
-    _axis_index = Trait(None, None, Int)
+    _axis_index = Union(None, Int)
 
     # The data space start and end coordinates of the selected region,
     # expressed as an array.

--- a/chaco/tools/range_selection.py
+++ b/chaco/tools/range_selection.py
@@ -146,11 +146,11 @@ class RangeSelection(AbstractController):
 
     # The value of the override plot to use, if any.  If None, then uses
     # self.component.
-    _plot = Any(None)
+    _plot = Any()
 
     # The value of the override mapper to use, if any.  If None, then uses the
     # mapper on self.component.
-    _mapper = Any(None)
+    _mapper = Any()
 
     # Shadow trait for the **axis_index** property.
     _axis_index = Union(None, Int)

--- a/chaco/tools/range_selection.py
+++ b/chaco/tools/range_selection.py
@@ -28,7 +28,6 @@ from traits.api import (
     observe,
     Property,
     Str,
-    Trait,
     Union
 )
 from enable.api import KeySpec

--- a/chaco/tools/simple_inspector.py
+++ b/chaco/tools/simple_inspector.py
@@ -62,7 +62,7 @@ class SimpleInspectorTool(BaseTool):
 
     # Stores the value of self.visible when the mouse leaves the tool,
     # so that it can be restored when the mouse enters again.
-    _old_visible = Enum(None, True, False)  # Trait(None, Bool(True))
+    _old_visible = Enum(None, True, False)
 
     #########################################################################
     # SimpleInspectorTool API

--- a/chaco/transform_color_mapper.py
+++ b/chaco/transform_color_mapper.py
@@ -11,7 +11,7 @@
 from numpy import clip, isinf, ones_like, empty
 
 from chaco.color_mapper import ColorMapper
-from traits.api import Trait, Callable, Tuple, Float, observe
+from traits.api import Callable, Tuple, Float, observe, Union
 
 from .speedups import map_colors, map_colors_uint8
 
@@ -35,12 +35,12 @@ class TransformColorMapper(ColorMapper):
     unit interval [0,1] to itself (e.g. x^2 or sin(pi*x/2)).
     """
 
-    data_func = Trait(None, None, Callable)
+    data_func = Union(None, Callable)
 
-    unit_func = Trait(None, None, Callable)
+    unit_func = Union(None, Callable)
 
     transformed_bounds = Tuple(
-        Trait(None, None, Float), Trait(None, None, Float)
+        Union(None, Float), Union(None, Float)
     )
 
     # -------------------------------------------------------------------

--- a/examples/demo/canvas/axis_tool.py
+++ b/examples/demo/canvas/axis_tool.py
@@ -3,11 +3,9 @@ from traits.api import (
     Any,
     Bool,
     Dict,
-    Enum,
     HasTraits,
     Int,
     List,
-    Trait,
     Tuple,
 )
 
@@ -66,7 +64,7 @@ class AxisTool(BaseTool):
     down_tick_label_color = ColorTrait("red")
     down_bgcolor = ColorTrait("lightgray")
     down_border_visible = Bool(True)
-    down_border_color = Trait(None, None, ColorTrait)
+    down_border_color = Union(None, ColorTrait)
 
     _cached_tick_color = ColorTrait
     _cached_axis_line_color = ColorTrait

--- a/examples/demo/canvas/mptools.py
+++ b/examples/demo/canvas/mptools.py
@@ -11,9 +11,9 @@ from traits.api import (
     Instance,
     Int,
     Property,
-    Trait,
     Tuple,
     CArray,
+    Union,
 )
 
 # Chaco imports
@@ -65,11 +65,11 @@ class MPDragZoom(DragZoom):
     speed = 1.0
 
     # The original dataspace points where blobs 1 and 2 went down
-    _orig_low = CArray  # Trait(None, None, Tuple)
-    _orig_high = CArray  # Trait(None, None, Tuple)
+    _orig_low = CArray  # Union(None, Tuple)
+    _orig_high = CArray  # Union(None, Tuple)
 
     # Dataspace center of the zoom action
-    _center_pt = Trait(None, None, Tuple)
+    _center_pt = Union(None, Tuple)
 
     # Maps blob ID numbers to the (x,y) coordinates that came in.
     _blobs = Dict()

--- a/examples/demo/canvas/plot_clone_tool.py
+++ b/examples/demo/canvas/plot_clone_tool.py
@@ -4,7 +4,7 @@ Makes a copy of the plot in the overlay and adds it to the canvas.
 
 
 # Enthought library imports
-from traits.api import Bool, Callable, Enum, Float, Instance, Int, Trait, Tuple
+from traits.api import Bool, Callable, Enum, Float, Instance, Int, Tuple, Union
 from enable.api import Container
 
 # Chaco imports
@@ -34,7 +34,7 @@ class PlotCloneTool(AbstractOverlay, DragTool):
     capture_mouse = True
 
     # The (x,y) position of the "last" mouse position we received
-    _offset = Trait(None, None, Tuple)
+    _offset = Union(None, Tuple)
 
     # The relative position of the mouse_down_position to the origin
     # of the plot's coordinate system

--- a/examples/demo/canvas/transient_plot_overlay.py
+++ b/examples/demo/canvas/transient_plot_overlay.py
@@ -1,5 +1,5 @@
 from enable.api import Component
-from traits.api import Enum, Float, Instance, Trait, Tuple
+from traits.api import Enum, Float, Instance, Tuple, Union
 
 from chaco.api import AbstractOverlay, BasePlotContainer
 
@@ -19,7 +19,7 @@ class TransientPlotOverlay(BasePlotContainer, AbstractOverlay):
     margin = Float(10)
 
     # An offset to apply in X and Y
-    offset = Trait(None, None, Tuple)
+    offset = Union(None, Tuple)
 
     # Override default values of some inherited traits
     unified_draw = True


### PR DESCRIPTION
Closes #829.  Closes #828.  Removes all instances of `Trait` and `Either` trait types.