### PR TITLE
Prevent axis related plot crash when plot is resized too small

### DIFF
--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -500,7 +500,7 @@ class PlotAxis(AbstractOverlay):
             screenlow, screenhigh = screenhigh, screenlow
 
         if (
-            (datalow == datahigh)
+            (datalow >= datahigh)
             or (screenlow == screenhigh)
             or (datalow in [inf, -inf])
             or (datahigh in [inf, -inf])
@@ -508,11 +508,6 @@ class PlotAxis(AbstractOverlay):
             self._reset_cache()
             self._cache_valid = True
             return
-
-        if datalow > datahigh:
-            raise RuntimeError(
-                "DataRange low is greater than high; unable to compute axis ticks."
-            )
 
         if not self.tick_generator:
             return

--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -512,7 +512,8 @@ class PlotAxis(AbstractOverlay):
             if datalow > datahigh:
                 logger.warning(
                     "{self.mapper} has an invalid data range with "
-                    "low={datalow} > high={datahigh}"
+                    "low={datalow} > high={datahigh}; unable to compute axis "
+                    "ticks."
                 )
             self._reset_cache()
             self._cache_valid = True

--- a/chaco/axis.py
+++ b/chaco/axis.py
@@ -10,6 +10,8 @@
 
 """ Defines the PlotAxis class, and associated validator and UI.
 """
+import logging
+
 # Major library import
 from numpy import (
     array,
@@ -57,6 +59,8 @@ from .abstract_mapper import AbstractMapper
 from .abstract_overlay import AbstractOverlay
 from .label import Label
 from .log_mapper import LogMapper
+
+logger = logging.getLogger(__name__)
 
 
 def DEFAULT_TICK_FORMATTER(val):
@@ -505,6 +509,11 @@ class PlotAxis(AbstractOverlay):
             or (datalow in [inf, -inf])
             or (datahigh in [inf, -inf])
         ):
+            if datalow > datahigh:
+                logger.warning(
+                    "{self.mapper} has an invalid data range with "
+                    "low={datalow} > high={datahigh}"
+                )
             self._reset_cache()
             self._cache_valid = True
             return

--- a/chaco/ticks.py
+++ b/chaco/ticks.py
@@ -305,6 +305,8 @@ def auto_ticks(
 
     if upper > end:
         end += tick_interval
+    if isnan([start, end]).any():
+        return []
     ticks = arange(start, end + (tick_interval / 2.0), tick_interval)
 
     if len(ticks) < 2:


### PR DESCRIPTION
This PR includes a defensive programming "fix" to #824 to prevent plot crashing.  The real fix would be to track down where the bad inputs are coming from.  However, regardless I think it makes sense for auto_ticks to be more robust to bad inputs as was discussed on the issue.

Also, in the same downstream project, when an application is resized to be very small and an inspector pane visibility is toggled, the plot some how ends up in a situation where `datalow > datahigh` in `chaco.axis.py` and we are hitting the `RunTimeError`.  I believe it makes sense to handle this case the same that we do for where `datalow == datahigh` (namely there is no plot we could show so we have no ticks).
I am unable to cause the downstream project's plots to crash when working off of this branch.