### PR TITLE
Add Python 3.8 tests

### DIFF
--- a/.github/workflows/test-with-edm-3.8.yml
+++ b/.github/workflows/test-with-edm-3.8.yml
@@ -47,9 +47,9 @@ jobs:
       - name: Install click to the default EDM environment
         run: edm install -y wheel click coverage
       - name: Install test environment
-        run: edm run -- python ci/edmtool.py install --toolkit=${{ matrix.toolkit }}
+        run: edm run -- python ci/edmtool.py install --runtime=3.8 --toolkit=${{ matrix.toolkit }}
       - name: Flake8
-        run: edm run -- python ci/edmtool.py flake8 --toolkit=${{ matrix.toolkit }}
+        run: edm run -- python ci/edmtool.py flake8 --runtime=3.8 --toolkit=${{ matrix.toolkit }}
         if: matrix.toolkit == 'null'
       - name: Run tests
         run: xvfb-run --server-args="-screen 0 1024x768x24" edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }}
@@ -75,6 +75,6 @@ jobs:
       - name: Install click to the default EDM environment
         run: edm install -y wheel click coverage
       - name: Install test environment
-        run: edm run -- python ci/edmtool.py install --toolkit=${{ matrix.toolkit }}
+        run: edm run -- python ci/edmtool.py install --runtime=3.8 --toolkit=${{ matrix.toolkit }}
       - name: Run tests
-        run: edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }}
+        run: edm run -- python ci/edmtool.py test --runtime=3.8 --toolkit=${{ matrix.toolkit }}

--- a/.github/workflows/test-with-edm-3.8.yml
+++ b/.github/workflows/test-with-edm-3.8.yml
@@ -2,7 +2,7 @@
 # Note that some packages may not actually be installed from EDM but from
 # PyPI, see ci/edmtool.py implementations.
 
-name: Test with EDM
+name: Test with EDM on Python 3.8
 
 on: pull_request
 
@@ -12,7 +12,7 @@ env:
 jobs:
 
   # Test against EDM packages on Linux
-  test-edm-linux:
+  test-edm-linux-3.8:
     strategy:
       matrix:
         toolkit: ['null', 'pyside6']
@@ -52,10 +52,10 @@ jobs:
         run: edm run -- python ci/edmtool.py flake8 --runtime=3.8 --toolkit=${{ matrix.toolkit }}
         if: matrix.toolkit == 'null'
       - name: Run tests
-        run: xvfb-run --server-args="-screen 0 1024x768x24" edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }}
+        run: xvfb-run --server-args="-screen 0 1024x768x24" edm run -- python ci/edmtool.py test --runtime=3.8 --toolkit=${{ matrix.toolkit }}
 
   # Test against EDM packages on Windows and OSX
-  test-with-edm:
+  test-with-edm-3.8:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]

--- a/.github/workflows/test-with-edm-3.8.yml
+++ b/.github/workflows/test-with-edm-3.8.yml
@@ -1,0 +1,80 @@
+# This workflow targets stable released dependencies from EDM.
+# Note that some packages may not actually be installed from EDM but from
+# PyPI, see ci/edmtool.py implementations.
+
+name: Test with EDM
+
+on: pull_request
+
+env:
+  INSTALL_EDM_VERSION: 3.5.0
+
+jobs:
+
+  # Test against EDM packages on Linux
+  test-edm-linux:
+    strategy:
+      matrix:
+        toolkit: ['null', 'pyside6']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Qt dependencies for Linux
+        run: |
+          sudo apt-get update
+          sudo apt-get install libegl1
+          sudo apt-get install libxkbcommon-x11-0
+          sudo apt-get install libglu1-mesa-dev
+          sudo apt-get install libxcb-icccm4
+          sudo apt-get install libxcb-image0
+          sudo apt-get install libxcb-keysyms1
+          sudo apt-get install libxcb-randr0
+          sudo apt-get install libxcb-render-util0
+          sudo apt-get install libxcb-xinerama0
+          sudo apt-get install libxcb-shape0
+          # Needed to work around https://bugreports.qt.io/browse/PYSIDE-1547
+          sudo apt-get install libopengl0
+        if: matrix.toolkit != 'null'
+      - name: Cache EDM packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-3.8-${{ matrix.toolkit }}-${{ hashFiles('ci/edmtool.py') }}
+      - name: Setup EDM
+        uses: enthought/setup-edm-action@v1
+        with:
+          edm-version: ${{ env.INSTALL_EDM_VERSION }}
+      - name: Install click to the default EDM environment
+        run: edm install -y wheel click coverage
+      - name: Install test environment
+        run: edm run -- python ci/edmtool.py install --toolkit=${{ matrix.toolkit }}
+      - name: Flake8
+        run: edm run -- python ci/edmtool.py flake8 --toolkit=${{ matrix.toolkit }}
+        if: matrix.toolkit == 'null'
+      - name: Run tests
+        run: xvfb-run --server-args="-screen 0 1024x768x24" edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }}
+
+  # Test against EDM packages on Windows and OSX
+  test-with-edm:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+        toolkit: ['null', 'pyside6']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache EDM packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-3.8-${{ matrix.toolkit }}-${{ hashFiles('ci/edmtool.py') }}
+      - name: Setup EDM
+        uses: enthought/setup-edm-action@v1
+        with:
+          edm-version: ${{ env.INSTALL_EDM_VERSION }}
+      - name: Install click to the default EDM environment
+        run: edm install -y wheel click coverage
+      - name: Install test environment
+        run: edm run -- python ci/edmtool.py install --toolkit=${{ matrix.toolkit }}
+      - name: Run tests
+        run: edm run -- python ci/edmtool.py test --toolkit=${{ matrix.toolkit }}

--- a/.github/workflows/test-with-edm-3.8.yml
+++ b/.github/workflows/test-with-edm-3.8.yml
@@ -12,7 +12,7 @@ env:
 jobs:
 
   # Test against EDM packages on Linux
-  test-edm-linux-3.8:
+  test-edm-linux-38:
     strategy:
       matrix:
         toolkit: ['null', 'pyside6']
@@ -55,7 +55,7 @@ jobs:
         run: xvfb-run --server-args="-screen 0 1024x768x24" edm run -- python ci/edmtool.py test --runtime=3.8 --toolkit=${{ matrix.toolkit }}
 
   # Test against EDM packages on Windows and OSX
-  test-with-edm-3.8:
+  test-with-edm-38:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]

--- a/chaco/plot_containers.py
+++ b/chaco/plot_containers.py
@@ -18,6 +18,7 @@ from numpy import (
     array,
     cumsum,
     hstack,
+    resize,
     sum,
     zeros,
     zeros_like,
@@ -182,7 +183,7 @@ class GridPlotContainer(BasePlotContainer):
 
     # The internal component grid, in row-major order.  This gets updated
     # when any of the following traits change: shape, components, grid_components
-    _grid = Array
+    _grid = Array()
 
     _cached_total_size = Any
     _h_size_prefs = Any
@@ -510,7 +511,7 @@ class GridPlotContainer(BasePlotContainer):
             numrows, numcols = divmod(len(self.components), self.shape[0])
             self.shape = (numrows, numcols)
         grid = array(self.components, dtype=object)
-        grid.resize(self.shape)
+        grid = resize(grid, self.shape)
         grid[grid == 0] = None
         self._grid = grid
         self._layout_needed = True

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -77,7 +77,8 @@ from contextlib import contextmanager
 import click
 
 supported_combinations = {
-    '3.6': {'pyside2', 'pyqt', 'pyqt5', 'null'},
+    '3.6': {'pyside2', 'pyqt5', 'null'},
+    '3.8': {'pyside6', 'null'},
 }
 
 dependencies = {
@@ -111,6 +112,7 @@ github_url_fmt = "git+http://github.com/enthought/{0}.git#egg={0}"
 
 extra_dependencies = {
     'pyside2': {'pyside2'},
+    'pyside6': {'pyside6'},
     'pyqt': {'pyqt'},
     'pyqt5': {'pyqt5'},
     'null': set()
@@ -161,6 +163,7 @@ doc_ignore = {
 
 environment_vars = {
     'pyside2': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside2'},
+    'pyside6': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside6'},
     'pyqt': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt'},
     'pyqt5': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt5'},
     'null': {'ETS_TOOLKIT': 'null.image'},
@@ -204,7 +207,7 @@ def install(runtime, toolkit, environment, editable, source):
         | ci_dependencies
     )
 
-    if toolkit == "pyside2":
+    if toolkit.startswith("pyside"):
         addn_repositories = "--add-repository enthought/lgpl"
     else:
         addn_repositories = ""

--- a/ci/edmtool.py
+++ b/ci/edmtool.py
@@ -96,7 +96,7 @@ dependencies = {
     "swig",
 }
 
-pypi_dependencies = {"sphinx-copybutton"}
+pypi_dependencies = {}
 
 # Dependencies we install from source for cron tests
 # Order from packages with the most dependencies to one with the least
@@ -120,7 +120,8 @@ extra_dependencies = {
 
 doc_dependencies = {
     "sphinx",
-    "enthought_sphinx_theme"
+    "enthought_sphinx_theme",
+    "sphinx-copybutton",
 }
 
 doc_ignore = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["cython", "oldest-supported-numpy", "setuptools", "wheel"]
+requires = ["cython", "oldest-supported-numpy", "setuptools<65.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]


### PR DESCRIPTION
This adds a parallel set of tests for Python 3.8 rather than trying to adapt the current set of tests.  Also updates edmtool to allow Python 3.8 and PySide6, and pyproject.toml to allow for known issue with setuptools.

Needed to make one change to code due to newer version of NumPy being picked up.

No requirement that they pass for PRs to be mergeable yet, but will likely add that once this PR is approved.