### PR TITLE
Fix Test Warnings on Python 3.8

### DIFF
--- a/chaco/plots/image_plot.py
+++ b/chaco/plots/image_plot.py
@@ -22,13 +22,12 @@ import numpy as np
 from traits.api import (
     Bool,
     Enum,
+    Float,
     Instance,
-    List,
     Range,
     Tuple,
     Property,
     cached_property,
-    Union,
 )
 from kiva.agg import GraphicsContextArray
 
@@ -84,7 +83,7 @@ class ImagePlot(Base2DPlot):
 
     # Tuple-defined rectangle (x, y, dx, dy) in screen space in which the
     # **_cached_image** is to be drawn.
-    _cached_dest_rect = Union(Tuple, List, transient=True)
+    _cached_dest_rect = Tuple(Float, Float, Float, Float, transient=True)
 
     # Bool indicating whether the origin is top-left or bottom-right.
     # The name "principal diagonal" is borrowed from linear algebra.
@@ -285,7 +284,7 @@ class ImagePlot(Base2DPlot):
 
         # Update cached image and rectangle.
         self._cached_image = self._kiva_array_from_numpy_array(data)
-        self._cached_dest_rect = screen_rect
+        self._cached_dest_rect = tuple(screen_rect)
         self._image_cache_valid = True
 
     def _kiva_array_from_numpy_array(self, data):

--- a/chaco/plots/tests/test_image_plot.py
+++ b/chaco/plots/tests/test_image_plot.py
@@ -37,7 +37,7 @@ from chaco.api import (
 # The Quartz backend rescales pixel values, so use a higher threshold.
 MAX_RMS_ERROR = 16 if ETSConfig.kiva_backend == "quartz" else 1
 
-IMAGE = np.random.random_integers(0, 255, size=(100, 200)).astype(np.uint8)
+IMAGE = np.random.randint(0, 256, size=(100, 200)).astype(np.uint8)
 RGB = np.dstack([IMAGE] * 3)
 # Rendering adds rows and columns for some reason.
 TRIM_RENDERED = (slice(1, -1), slice(1, -1), 0)

--- a/chaco/tools/pan_tool.py
+++ b/chaco/tools/pan_tool.py
@@ -231,8 +231,10 @@ class PanTool(BaseTool):
                     newlow = mapper.map_data(screenlow + screen_delta)
 
                 # Use .set_bounds() so that we don't generate two range_changed
-                # events on the DataRange
-                mapper.range.set_bounds(newlow, newhigh)
+                # events on the DataRange.
+                # Do an explicit conversion to float because raw values may not
+                # be floating-point types, which makes NumPy unhappy (#854).
+                mapper.range.set_bounds(float(newlow), float(newhigh))
 
         event.handled = True
 

--- a/chaco/tools/tests/test_data_label_tool.py
+++ b/chaco/tools/tests/test_data_label_tool.py
@@ -10,7 +10,7 @@ from traitsui.api import Item, View
 from chaco.api import ArrayPlotData, DataLabel, Plot
 from chaco.tools.api import DataLabelTool
 
-IMAGE = np.random.random_integers(0, 255, size=(100, 200)).astype(np.uint8)
+IMAGE = np.random.randint(0, 256, size=(100, 200)).astype(np.uint8)
 RGB = np.dstack([IMAGE] * 3)
 
 


### PR DESCRIPTION
After this all Python 3.8 tests should pass with no warnings or errors.

This fixes #854 and fixes #855