### PR TITLE
fix world_map demo with new link

### DIFF
--- a/examples/demo/world_map.py
+++ b/examples/demo/world_map.py
@@ -8,10 +8,6 @@ negative values.
    region to zoom.  If you use a sequence of zoom boxes, pressing alt-left-arrow
    and alt-right-arrow moves you forwards and backwards through the "zoom
    history".
-
-The image in this demo is an image from wikipedia
-https://commons.wikimedia.org/wiki/File:Winkel_triple_projection_SW.jpg
-Copyright Attribution: Strebe, Public domain, via Wikimedia Commons
 """
 
 # Standard library imports

--- a/examples/demo/world_map.py
+++ b/examples/demo/world_map.py
@@ -8,6 +8,10 @@ negative values.
    region to zoom.  If you use a sequence of zoom boxes, pressing alt-left-arrow
    and alt-right-arrow moves you forwards and backwards through the "zoom
    history".
+
+The image in this demo is an image from wikipedia
+https://commons.wikimedia.org/wiki/File:Winkel_triple_projection_SW.jpg
+Copyright Attribution: Strebe, Public domain, via Wikimedia Commons
 """
 
 # Standard library imports

--- a/examples/demo/world_map.py
+++ b/examples/demo/world_map.py
@@ -38,7 +38,7 @@ class WorldMapPlot(HasTraits):
 
     # The URL which points to the world map image to be downloaded
     image_url = Str(
-        "https://upload.wikimedia.org/wikipedia/commons/9/91/Winkel_triple_projection_SW.jpg"
+        "https://eoimages.gsfc.nasa.gov/images/imagerecords/57000/57752/land_shallow_topo_2048.jpg"
     )
 
     ### Private Traits #########################################################

--- a/examples/demo/world_map.py
+++ b/examples/demo/world_map.py
@@ -34,7 +34,7 @@ class WorldMapPlot(HasTraits):
 
     # The URL which points to the world map image to be downloaded
     image_url = Str(
-        "http://eoimages.gsfc.nasa.gov/ve//2433/land_shallow_topo_2048.jpg"
+        "https://upload.wikimedia.org/wikipedia/commons/9/91/Winkel_triple_projection_SW.jpg"
     )
 
     ### Private Traits #########################################################


### PR DESCRIPTION
The chaco/examples/demo/world_map demo example is broken due to the original image link in the example has expired. This PR replaces it with a new example.