### PR TITLE
MAINT: replace deprecated boston dataset with diabetes

### DIFF
--- a/examples/user_guide/plot_types/create_plot_snapshots.py
+++ b/examples/user_guide/plot_types/create_plot_snapshots.py
@@ -149,9 +149,9 @@ get_line_plot_connectedhold = partial(get_line_plot, "connectedhold")
 
 
 def get_scatter_plot():
-    boston = datasets.load_boston()
-    prices = boston["target"]
-    lower_status = boston["data"][:, -1]
+    diabetes = datasets.load_diabetes()
+    prices = diabetes["target"]
+    lower_status = diabetes["data"][:, -1]
 
     x, y = get_data_sources(x=lower_status, y=prices)
     x_mapper, y_mapper = get_mappers(x, y)
@@ -176,10 +176,10 @@ def get_scatter_plot():
 
 
 def get_cmap_scatter_plot():
-    boston = datasets.load_boston()
-    prices = boston["target"]
-    lower_status = boston["data"][:, -1]
-    nox = boston["data"][:, 4]
+    diabetes = datasets.load_diabetes()
+    prices = diabetes["target"]
+    lower_status = diabetes["data"][:, -1]
+    nox = diabetes["data"][:, 4]
 
     x, y = get_data_sources(x=lower_status, y=prices)
     x_mapper, y_mapper = get_mappers(x, y)
@@ -212,11 +212,11 @@ def get_cmap_scatter_plot():
 
 
 def get_4d_scatter_plot():
-    boston = datasets.load_boston()
-    prices = boston["target"]
-    lower_status = boston["data"][:, -1]
-    tax = boston["data"][:, 9]
-    nox = boston["data"][:, 4]
+    diabetes = datasets.load_diabetes()
+    prices = diabetes["target"]
+    lower_status = diabetes["data"][:, -1]
+    tax = diabetes["data"][:, 9]
+    nox = diabetes["data"][:, 4]
 
     x, y = get_data_sources(x=lower_status, y=prices)
     x_mapper, y_mapper = get_mappers(x, y)
@@ -255,10 +255,10 @@ def get_4d_scatter_plot():
 
 
 def get_variable_size_scatter_plot():
-    boston = datasets.load_boston()
-    prices = boston["target"]
-    lower_status = boston["data"][:, -1]
-    tax = boston["data"][:, 9]
+    diabetes = datasets.load_diabetes()
+    prices = diabetes["target"]
+    lower_status = diabetes["data"][:, -1]
+    tax = diabetes["data"][:, 9]
 
     x, y = get_data_sources(x=lower_status, y=prices)
     x_mapper, y_mapper = get_mappers(x, y)
@@ -288,8 +288,8 @@ def get_variable_size_scatter_plot():
 
 
 def get_jitter_plot():
-    boston = datasets.load_boston()
-    prices = boston["target"]
+    diabetes = datasets.load_diabetes()
+    prices = diabetes["target"]
 
     x, y = get_data_sources(y=prices)
     x_mapper, y_mapper = get_mappers(x, y)
@@ -566,8 +566,8 @@ def get_polygon_plot():
 
 
 def get_bar_plot():
-    boston = datasets.load_boston()
-    prices = boston["target"]
+    diabetes = datasets.load_diabetes()
+    prices = diabetes["target"]
 
     ys, bin_edges = np.histogram(prices, bins=10)
     ys = ys.astype("d") / ys.sum()


### PR DESCRIPTION
The load_boston dataset is deprecated, replacing with the diabetes dataset (seems to the the only usable dataset in sklearn.dataset, iris and california housing dataset is not compatible with the code).

**However, there are two more errors arised after the fix that I found the fixes but want to discuss:**

**After correcting the dataset, an error will happen in get_image_from_file() since this function tries to read an image in the demo/basic/capitol.jpg, but the folder doesn't seem to exist anymore, removing this function can fix this problem.**

**Then, another error will happend in chaco.chaco.plots.polar_line_renderer, in function _draw_plot(). Function will try to call _render on gc (line 136), which is a parameter not exists. Removing this line can solve the problem** (this also causes exception in issue #875 )

**When both the above fixes are done, the plots can be generated without error. But are these fixes sounds good to you?**