### PR TITLE
MAINT: fix float input for number of samples

### DIFF
--- a/examples/demo/advanced/spec_waterfall.py
+++ b/examples/demo/advanced/spec_waterfall.py
@@ -100,7 +100,7 @@ class WaterfallRenderer(LinePlot):
 
 def _create_plot_component(obj):
     # Setup the spectrum plot
-    frequencies = linspace(0.0, float(SAMPLING_RATE) / 2, num=NUM_SAMPLES / 2)
+    frequencies = linspace(0.0, float(SAMPLING_RATE) / 2, num=NUM_SAMPLES // 2)
     obj.spectrum_data = ArrayPlotData(frequency=frequencies)
     empty_amplitude = zeros(NUM_SAMPLES // 2)
     obj.spectrum_data.set_data("amplitude", empty_amplitude)


### PR DESCRIPTION
A float is inputed to linspace as sample number which causes error, this pr fixes it

closes issue #869 

Though a new error happens:
(py311) cyliu@aus552cyliu chaco % python3.11 examples/demo/advanced/spec_waterfall.py         
traitsui.__version__ 8.0.0.dev0
pyface.__version__ 7.4.4
2023-03-31 10:35:54.804 Python[3049:51857] ApplePersistenceIgnoreState: Existing state will not be touched. New state will be written to /var/folders/2z/kylzj9s92y71cxscmljmpqrh0000gt/T/org.python.python.savedState
/Users/cyliu/Documents/3.11_test/chaco/examples/demo/advanced/spec_waterfall.py:178: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
  audio_data = fromstring(stream.read(NUM_SAMPLES), dtype=short)
Traceback (most recent call last):
  File "/Users/cyliu/.venvs/py311/lib/python3.11/site-packages/pyface/timer/i_timer.py", line 200, in perform
    self._perform()
  File "/Users/cyliu/.venvs/py311/lib/python3.11/site-packages/pyface/timer/i_timer.py", line 299, in _perform
    self.callback(*self.args, **self.kwargs)
  File "/Users/cyliu/Documents/3.11_test/chaco/examples/demo/advanced/spec_waterfall.py", line 187, in onTimer
    spectrum, time = get_audio_data()
                     ^^^^^^^^^^^^^^^^
  File "/Users/cyliu/Documents/3.11_test/chaco/examples/demo/advanced/spec_waterfall.py", line 181, in get_audio_data
    return (abs(fft(normalized_data))[: NUM_SAMPLES // 2], normalized_data)
                ^^^^^^^^^^^^^^^^^^^^
TypeError: 'module' object is not callable

Investigation...