### PR TITLE
Fix capitol image

### DIFF
--- a/chaco/__init__.py
+++ b/chaco/__init__.py
@@ -16,5 +16,5 @@ __requires__ = [
 
 __extras_require__ = {
     "docs": ["enthought-sphinx-theme", "sphinx", "sphinx-copybutton"],
-    'examples': ['encore', 'importlib_resources', 'scipy', 'pandas']
+    'examples': ["encore", "importlib_resources; python_version<'3.9'", "scipy", "pandas"]
 }

--- a/chaco/__init__.py
+++ b/chaco/__init__.py
@@ -16,5 +16,8 @@ __requires__ = [
 
 __extras_require__ = {
     "docs": ["enthought-sphinx-theme", "sphinx", "sphinx-copybutton"],
-    'examples': ["encore", "importlib_resources; python_version<'3.9'", "scipy", "pandas"]
+    'examples': ["encore",
+                 "importlib_resources; python_version<'3.9'",
+                 "scipy",
+                 "pandas"]
 }

--- a/chaco/__init__.py
+++ b/chaco/__init__.py
@@ -16,5 +16,5 @@ __requires__ = [
 
 __extras_require__ = {
     "docs": ["enthought-sphinx-theme", "sphinx", "sphinx-copybutton"],
-    'examples': ['encore', 'scipy', 'pandas']
+    'examples': ['encore', 'importlib_resources', 'scipy', 'pandas']
 }

--- a/examples/demo/zoomed_plot/zoom_plot.py
+++ b/examples/demo/zoomed_plot/zoom_plot.py
@@ -24,7 +24,7 @@ from chaco.api import VPlotContainer, ArrayPlotData, Plot, PlotGrid, PlotAxis
 from chaco.tools.api import RangeSelection
 
 # Relative imports
-from .zoom_overlay import ZoomOverlay
+from zoom_overlay import ZoomOverlay
 
 sample_path = os.path.join("examples", "data", "sample.wav")
 alt_path = os.path.join("..", "data", "sample.wav")

--- a/examples/demo/zoomed_plot/zoom_plot.py
+++ b/examples/demo/zoomed_plot/zoom_plot.py
@@ -24,7 +24,7 @@ from chaco.api import VPlotContainer, ArrayPlotData, Plot, PlotGrid, PlotAxis
 from chaco.tools.api import RangeSelection
 
 # Relative imports
-from zoom_overlay import ZoomOverlay
+from .zoom_overlay import ZoomOverlay
 
 sample_path = os.path.join("examples", "data", "sample.wav")
 alt_path = os.path.join("..", "data", "sample.wav")

--- a/examples/user_guide/plot_types/create_plot_snapshots.py
+++ b/examples/user_guide/plot_types/create_plot_snapshots.py
@@ -434,8 +434,9 @@ def get_image_plot():
 
 
 def get_image_from_file():
-    # importlib.resources is new in Python 3.7, and importlib.resources.files is
-    # new in Python 3.9, so for Python < 3.9 we must rely on the 3rd party
+    # importlib.resources is new in Python 3.7, and
+    # importlib.resources.files is new in Python 3.9,
+    # so for Python < 3.9 we must rely on the 3rd party
     # importlib_resources package.
     try:
         from importlib.resources import files

--- a/examples/user_guide/plot_types/create_plot_snapshots.py
+++ b/examples/user_guide/plot_types/create_plot_snapshots.py
@@ -436,7 +436,9 @@ def get_image_plot():
 def get_image_from_file():
     from importlib import resources
 
-    filename = resources.files('chaco.examples.demo.basic').joinpath('capitol.jpg')
+    filename = resources.files(
+        'chaco.examples.demo.basic'
+    ).joinpath('capitol.jpg')
     image_source = ImageData.fromfile(filename)
 
     w, h = image_source.get_width(), image_source.get_height()

--- a/examples/user_guide/plot_types/create_plot_snapshots.py
+++ b/examples/user_guide/plot_types/create_plot_snapshots.py
@@ -434,9 +434,15 @@ def get_image_plot():
 
 
 def get_image_from_file():
-    from importlib import resources
+    # importlib.resources is new in Python 3.7, and importlib.resources.files is
+    # new in Python 3.9, so for Python < 3.9 we must rely on the 3rd party
+    # importlib_resources package.
+    try:
+        from importlib.resources import files
+    except ImportError:
+        from importlib_resources import files
 
-    filename = resources.files(
+    filename = files(
         'chaco.examples.demo.basic'
     ).joinpath('capitol.jpg')
     image_source = ImageData.fromfile(filename)

--- a/examples/user_guide/plot_types/create_plot_snapshots.py
+++ b/examples/user_guide/plot_types/create_plot_snapshots.py
@@ -434,9 +434,9 @@ def get_image_plot():
 
 
 def get_image_from_file():
-    import os.path
+    from importlib import resources
 
-    filename = os.path.join("..", "..", "demo", "basic", "capitol.jpg")
+    filename = resources.files('chaco.examples.demo.basic').joinpath('capitol.jpg')
     image_source = ImageData.fromfile(filename)
 
     w, h = image_source.get_width(), image_source.get_height()

--- a/examples/user_guide/plot_types/create_plot_snapshots.py
+++ b/examples/user_guide/plot_types/create_plot_snapshots.py
@@ -439,32 +439,33 @@ def get_image_from_file():
     # so for Python < 3.9 we must rely on the 3rd party
     # importlib_resources package.
     try:
-        from importlib.resources import files
+        from importlib.resources import as_file, files
     except ImportError:
-        from importlib_resources import files
+        from importlib_resources import as_file, files
 
-    filename = files(
+    image_resource = files(
         'chaco.examples.demo.basic'
     ).joinpath('capitol.jpg')
-    image_source = ImageData.fromfile(filename)
 
-    w, h = image_source.get_width(), image_source.get_height()
-    index = GridDataSource(np.arange(w), np.arange(h))
-    index_mapper = GridMapper(
-        range=DataRange2D(low=(0, 0), high=(w - 1, h - 1))
-    )
+    with as_file(image_resource) as filename:
+        image_content = ImageData.fromfile(filename)
+        w, h = image_content.get_width(), image_content.get_height()
+        index = GridDataSource(np.arange(w), np.arange(h))
+        index_mapper = GridMapper(
+            range=DataRange2D(low=(0, 0), high=(w - 1, h - 1))
+        )
 
-    image_plot = ImagePlot(
-        index=index,
-        value=image_source,
-        index_mapper=index_mapper,
-        origin="top left",
-        **PLOT_DEFAULTS
-    )
+        image_plot = ImagePlot(
+            index=index,
+            value=image_content,
+            index_mapper=index_mapper,
+            origin="top left",
+            **PLOT_DEFAULTS
+        )
 
-    add_axes(image_plot, x_label="x", y_label="y")
+        add_axes(image_plot, x_label="x", y_label="y")
 
-    return image_plot
+        return image_plot
 
 
 def get_cmap_image_plot():


### PR DESCRIPTION
After the capitol.jpg moved, chaco/examples/user_guide/plot_types/create_plot_snapshots is broken, use importlib.resources to find the image for loading to fix this