### PR TITLE
fix gc undeclare

### DIFF
--- a/chaco/plots/polar_line_renderer.py
+++ b/chaco/plots/polar_line_renderer.py
@@ -130,10 +130,9 @@ class PolarLineRenderer(AbstractPlotRenderer):
     def _downsample(self):
         return self.map_screen(self._cached_data_pts)
 
-    def _draw_plot(self, *args, **kw):
+    def _draw_plot(self, gc, *args, **kw):
         """Draws the 'plot' layer."""
         self._gather_points()
-        gc = args[0]
         self._render(gc, self._cached_data_pts)
 
     def _bounds_changed(self, old, new):

--- a/chaco/plots/polar_line_renderer.py
+++ b/chaco/plots/polar_line_renderer.py
@@ -133,6 +133,7 @@ class PolarLineRenderer(AbstractPlotRenderer):
     def _draw_plot(self, *args, **kw):
         """Draws the 'plot' layer."""
         self._gather_points()
+        gc = args[0]
         self._render(gc, self._cached_data_pts)
 
     def _bounds_changed(self, old, new):


### PR DESCRIPTION
Found that the gc (GraphicsContext) is referenced before construction in the line 136. This has caused the test chaco/chaco/examples/demo/simple_polar.py to fail.
The solution is to find the gc in the context. A gc context is actually conveniently included in the *args, thus retrieving that gc as GraphicContext to solve the problem. closes #875 