### PR TITLE
MAINT: fix depreciated formt usage in nonlinear_color_mapping

### DIFF
--- a/chaco/examples/demo/nonlinear_color_mapping.py
+++ b/chaco/examples/demo/nonlinear_color_mapping.py
@@ -195,7 +195,7 @@ class DataGridView(HasTraits):
             Item("colormap_scale"),
             Item(
                 "power",
-                editor=RangeEditor(low=0.1, high=3.0, format="%4.2f"),
+                editor=RangeEditor(low=0.1, high=3.0, format_str="%4.2f"),
                 visible_when='colormap_scale.startswith("power")',
                 springy=True,
             ),


### PR DESCRIPTION
After the update of the traitsui package, RangeEditor has deprecated the usage of format_str. Some code that didn't adapt to the change has raised error during the test such as mentioned in #888 . 
The error is located in https://github.com/enthought/chaco/blob/main/chaco/examples/demo/nonlinear_color_mapping.py#L198, and the current PR fixes it by updating the deprecated "format" to "format_str".