### PR TITLE
MAINT: fix DemoController in the image_from_file example

### DIFF
--- a/chaco/examples/demo/basic/image_from_file.py
+++ b/chaco/examples/demo/basic/image_from_file.py
@@ -183,6 +183,7 @@ class DemoController(Handler):
         Overridden here to assign the 'view' trait.
         """
         self.view = info.object
+        return True
 
     def save(self, ui_info):
         """


### PR DESCRIPTION
After the update of traitsui, the ui requires the init() method to return a boolean that indicates whether the initiation has been successful. However, some demos have not been able to adapt to this change such as #889 . This PR aims to fix #889 by adding the boolean return to the demo