### PR TITLE
Fix `LegendHiglighter` hit detection

### DIFF
--- a/chaco/overlays/legend.py
+++ b/chaco/overlays/legend.py
@@ -427,7 +427,7 @@ class Legend(AbstractOverlay):
         # We need a dummy GC in order to get font metrics
         dummy_gc = font_metrics_provider()
         label_sizes = array(
-            [label.get_width_height(dummy_gc) for label in labels]
+            [label.get_bounding_box(dummy_gc) for label in labels]
         )
 
         if len(label_sizes) > 0:
@@ -465,8 +465,12 @@ class Legend(AbstractOverlay):
 
     def get_label_at(self, x, y):
         """ Returns the label object at (x,y) """
+        icon_space = array([
+            self.icon_spacing + self.icon_bounds[0],
+            self.icon_bounds[1],
+        ])
         for i, pos in enumerate(self._cached_label_positions):
-            size = self._cached_label_sizes[i]
+            size = self._cached_label_sizes[i] + icon_space
             corner = pos + size
             if (pos[0] <= x <= corner[0]) and (pos[1] <= y <= corner[1]):
                 return self._cached_labels[i]

--- a/chaco/tools/legend_highlighter.py
+++ b/chaco/tools/legend_highlighter.py
@@ -30,10 +30,7 @@ def get_hit_plots(legend, event):
         return []
 
     try:
-        # FIXME: The size of the legend is not being computed correctly, so
-        # always look at the front of the label where we know we'll get a hit.
-        label = legend.get_label_at(legend.x + 20, event.y)
-
+        label = legend.get_label_at(event.x, event.y)
     except:
         raise
         label = None


### PR DESCRIPTION
This fixes `Legend.get_label_at()` to return the entire legend label region, including icon, which then allows `LegendHightlighter` to use the actual mouse position to perform it's hit detection.

Fixes #825 