### PR TITLE
Fix imports of `marker_trait`

### DIFF
--- a/chaco/api.py
+++ b/chaco/api.py
@@ -537,7 +537,10 @@ def __getattr__(name):
     if name in {'marker_trait'}:
         from warnings import warn
         import enable.api
-        warn(f"Please import {name} from enable.api instead of chaco.api.")
+        warn(
+            f"Please import {name} from enable.api instead of chaco.api.",
+            DeprecationWarning,
+        )
         return getattr(enable.api, name)
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/chaco/api.py
+++ b/chaco/api.py
@@ -498,7 +498,7 @@ from .default_colormaps import (
     YlGn,
     YlGnBu,
     YlOrBr,
-    YlOrRd,  
+    YlOrRd,
     gist_earth,
     gist_gray,
     gist_heat,
@@ -527,3 +527,17 @@ from .default_colormaps import (
     Set3,
 )
 from .default_colors import cbrewer, palette11, palette14, PALETTES
+
+
+def __getattr__(name):
+    """Backward compatibility lazy imports.
+
+    These imports warn about backwards incompatible changes.
+    """
+    if name in {'marker_trait'}:
+        from warnings import warn
+        import enable.api
+        warn(f"Please import {name} from enable.api instead of chaco.api.")
+        return getattr(enable.api, name)
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/chaco/tests/test_api.py
+++ b/chaco/tests/test_api.py
@@ -1,0 +1,24 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+
+import chaco.api
+
+
+class TestAPI(unittest.TestCase):
+
+    def test_enable_imports(self):
+        """Test for deprecated imports from enable.api"""
+        names = {'marker_trait'}
+        for name in names:
+            with self.subTest(name=name):
+                with self.assertWarns(DeprecationWarning):
+                    getattr(chaco.api, name)

--- a/docs/source/user_manual/chaco_tutorial.rst
+++ b/docs/source/user_manual/chaco_tutorial.rst
@@ -559,8 +559,8 @@ of these capabilities.  Here is the full listing of the modified code::
     from numpy import linspace, sin
     from traits.api import HasTraits, Instance, Int
     from traitsui.api import Item, Group, View
-    from chaco.api import ArrayPlotData, marker_trait, Plot
-    from enable.api import ColorTrait, ComponentEditor
+    from chaco.api import ArrayPlotData, Plot
+    from enable.api import ColorTrait, ComponentEditor, marker_trait
 
     class ScatterPlotTraits(HasTraits):
 


### PR DESCRIPTION
Add it back to chaco.api but with a deprecation warning.

Fixes #771  