### PR TITLE
removed typo by replacing `obseve()` with `observe()`, fixing issue #914

### DIFF
--- a/chaco/base_2d_plot.py
+++ b/chaco/base_2d_plot.py
@@ -340,9 +340,9 @@ class Base2DPlot(AbstractPlotRenderer):
 
     def _index_changed(self, old, new):
         if old is not None:
-            old.obseve(self._update_index_data, "data_changed", remove=True)
+            old.observe(self._update_index_data, "data_changed", remove=True)
         if new is not None:
-            new.obseve(self._update_index_data, "data_changed")
+            new.observe(self._update_index_data, "data_changed")
         self._update_index_data()
 
     def _value_changed(self, old, new):


### PR DESCRIPTION
As this fixes a typo clearly visible in the source code, I have not added any code to reproduce the error nor a unit test. Hope this is still fine (I'm short on time currently, sorry!).

See [Issue 914](https://github.com/enthought/chaco/issues/914) and/or the original pull request #590 that introduced this bug.